### PR TITLE
Create intelligence hub home experience

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "react/no-unescaped-entities": "off"
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,9 +6,20 @@ import Script from 'next/script'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Frank - Conscious AI for Creators, Families & Professionals',
-  description: 'Transform from Tech-Overwhelmed to AI-Empowered. Learn to use AI as a tool for soul expression, not soul replacement.',
-  keywords: ['AI', 'Music Production', 'Suno', 'Conscious Creator', 'Soul-Aligned AI'],
+  title: {
+    default: 'FrankX Intelligence Hub',
+    template: '%s | FrankX'
+  },
+  description:
+    'FrankX equips creators, families, and executives with conscious AI strategy, Suno-powered creativity, and enterprise-ready systems.',
+  keywords: [
+    'conscious ai',
+    'ai strategy',
+    'soul frequency',
+    'ai music',
+    'ai governance',
+    'ai for families'
+  ],
   authors: [{ name: 'Frank' }],
   icons: {
     icon: '/favicon.svg',
@@ -20,13 +31,14 @@ export const metadata: Metadata = {
     }
   },
   openGraph: {
-    title: 'Frank - Conscious AI Systems',
-    description: 'Become a Conscious AI Creator',
-    url: 'https://frank.ai',
-    siteName: 'Frank',
+    title: 'FrankX Intelligence Hub',
+    description:
+      'Global AI voice sharing updates, resources, and programs for conscious intelligence.',
+    url: 'https://frankx.ai',
+    siteName: 'FrankX',
     locale: 'en_US',
-    type: 'website',
-  },
+    type: 'website'
+  }
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,474 +1,89 @@
-'use client'
+import type { Metadata } from 'next'
+import Script from 'next/script'
 
-import { motion } from 'framer-motion'
-import Link from 'next/link'
-import {
-  ArrowRight,
-  Sparkles,
-  Users,
-  Rocket,
-  Brain,
-  Code,
-  Heart,
-  Headphones,
-  Zap,
-  CheckCircle,
-  Lightbulb,
-  Compass,
-  Globe,
-  ShieldCheck,
-  BarChart4
-} from 'lucide-react'
-import Navigation from '@/components/Navigation'
 import Footer from '@/components/Footer'
+import Navigation from '@/components/Navigation'
+import HomePage from '@/components/home/HomePage'
 
-const heroStats = [
-  {
-    label: 'Enterprise Systems Shipped',
-    value: '200+',
-    detail: 'Oracle-grade AI initiatives delivered with soul alignment'
+export const metadata: Metadata = {
+  title: 'FrankX Intelligence Hub | Conscious AI Voice & Resource Platform',
+  description:
+    'Explore the FrankX Intelligence Hub for conscious AI strategy, Suno-powered creativity, family education, and enterprise-ready systems.',
+  keywords: [
+    'conscious ai',
+    'ai strategy',
+    'ai for creators',
+    'ai for families',
+    'ai architecture',
+    'soul frequency',
+    'suno workflows'
+  ],
+  alternates: {
+    canonical: 'https://frankx.ai/'
   },
-  {
-    label: 'Suno Creations',
-    value: '500',
-    detail: 'Transformational tracks produced with AI-human co-creation'
-  },
-  {
-    label: 'Creator Transformations',
-    value: '1,000+',
-    detail: 'Leaders, families, and artists activating intelligence rituals'
+  openGraph: {
+    title: 'FrankX Intelligence Hub',
+    description:
+      'Latest AI briefings, resources, and programs for creators, families, and executives building conscious intelligence systems.',
+    url: 'https://frankx.ai/',
+    siteName: 'FrankX',
+    locale: 'en_US',
+    type: 'website'
   }
-]
+}
 
-const audienceCards = [
-  {
-    icon: Users,
-    title: 'Families & Friends',
-    description:
-      'Navigate AI conversations with confidence, safety, and shared rituals.',
-    color: 'from-blue-50 to-indigo-50',
-    iconColor: 'text-blue-600'
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'FrankX',
+  url: 'https://frankx.ai',
+  description:
+    'FrankX is the global AI voice guiding creators, families, and executives with conscious intelligence systems, music innovation, and community rituals.',
+  founder: {
+    '@type': 'Person',
+    name: 'Frank',
+    jobTitle: 'Conscious AI Architect'
   },
-  {
-    icon: Rocket,
-    title: 'Founders & Entrepreneurs',
-    description:
-      'Design conscious products, funnels, and agent workflows that scale impact.',
-    color: 'from-purple-50 to-pink-50',
-    iconColor: 'text-purple-600'
-  },
-  {
-    icon: Brain,
-    title: 'Technologists & Leaders',
-    description:
-      'Evolve from builder to Oracle-level strategist who orchestrates intelligence.',
-    color: 'from-emerald-50 to-teal-50',
-    iconColor: 'text-emerald-600'
-  },
-  {
-    icon: Headphones,
-    title: 'Creators & Facilitators',
-    description:
-      'Blend Suno, music, and community into immersive transformation experiences.',
-    color: 'from-orange-50 to-rose-50',
-    iconColor: 'text-orange-600'
-  }
-]
+  knowsAbout: [
+    'conscious ai strategy',
+    'ai governance rituals',
+    'ai music workflows',
+    'family ai education',
+    'ai agent orchestration'
+  ],
+  hasPart: [
+    {
+      '@type': 'CreativeWork',
+      name: 'Soul Frequency Assessment',
+      url: 'https://frankx.ai/soul-frequency-assessment'
+    },
+    {
+      '@type': 'CreativeWork',
+      name: "Founder’s AI Playbook",
+      url: 'https://frankx.ai/founder-playbook'
+    },
+    {
+      '@type': 'CreativeWork',
+      name: 'AI Basics for Families',
+      url: 'https://frankx.ai/family-guide'
+    },
+    {
+      '@type': 'CreativeWork',
+      name: 'Music Lab',
+      url: 'https://frankx.ai/music-lab'
+    }
+  ]
+}
 
-const pillars = [
-  {
-    icon: Brain,
-    title: 'Technical Mastery',
-    description:
-      'Architect systems, automations, and agents that are robust, auditable, and kind to humans.',
-    gradient: 'linear-gradient(135deg, rgba(37,99,235,0.85) 0%, rgba(15,23,42,0.9) 100%)'
-  },
-  {
-    icon: Heart,
-    title: 'Soul Alignment',
-    description:
-      'Ensure every build amplifies purpose, nervous-system safety, and creative expression.',
-    gradient: 'linear-gradient(135deg, rgba(168,85,247,0.9) 0%, rgba(76,29,149,0.85) 100%)'
-  },
-  {
-    icon: Sparkles,
-    title: 'Creative Expression',
-    description:
-      'Use AI as a collaborator that expands stories, music, and experiences beyond human limits.',
-    gradient: 'linear-gradient(135deg, rgba(236,72,153,0.9) 0%, rgba(190,24,93,0.85) 100%)'
-  }
-]
-
-const journeyBlueprint = [
-  {
-    step: '01',
-    title: 'Sense',
-    description:
-      'Audit your current brand, data, and rituals. Map fears, opportunities, and desired transformations.',
-    icon: Compass
-  },
-  {
-    step: '02',
-    title: 'Systemize',
-    description:
-      'Design the intelligence operating system: agents, templates, live experiences, and measurement loops.',
-    icon: Code
-  },
-  {
-    step: '03',
-    title: 'Sound',
-    description:
-      'Compose vibrational assets, narrative arcs, and micro-funnels that invite people into the journey.',
-    icon: Headphones
-  },
-  {
-    step: '04',
-    title: 'Scale',
-    description:
-      'Launch, instrument, and iterate using conscious KPIs that balance revenue, resonance, and rest.',
-    icon: BarChart4
-  }
-]
-
-const curatedStories = [
-  {
-    title: 'The Intelligence Revolution Playbook',
-    description: 'A $10T strategy map for technologists, founders, and creators.',
-    href: '/blog/intelligence-revolution-2025',
-    image: '/images/blog/intelligence-revolution-hero.svg',
-    tag: 'Cornerstone',
-    gradient: 'linear-gradient(135deg, #020617 0%, #1e1b4b 55%, #38bdf8 100%)'
-  },
-  {
-    title: "AI Doesn't Have To Be Soulless",
-    description: 'Lessons from 15 years of Oracle AI + 500 collaborative songs.',
-    href: '/blog/ai-doesnt-have-to-be-soulless',
-    image: '/images/blog/ai-soul-story.svg',
-    tag: 'Story',
-    gradient: 'linear-gradient(135deg, #1f103a 0%, #312e81 55%, #ec4899 100%)'
-  },
-  {
-    title: 'Soul Frequency Framework',
-    description: 'Find the creative signature AI should amplify, not replace.',
-    href: '/blog/soul-frequency-framework',
-    image: '/images/blog/soul-frequency-framework.svg',
-    tag: 'Framework',
-    gradient: 'linear-gradient(135deg, #0f172a 0%, #0e7490 55%, #34d399 100%)'
-  }
-]
-
-const resources = [
-  {
-    icon: Sparkles,
-    title: 'Soul Frequency Assessment',
-    description: '7-minute blueprint for your intelligence operating system.',
-    href: '/soul-frequency-assessment',
-    tag: 'New',
-    color: 'text-purple-600'
-  },
-  {
-    icon: Heart,
-    title: 'Soul Frequency Quiz',
-    description: 'Discover your unique creator archetype.',
-    href: '/soul-frequency-quiz',
-    tag: 'Assessment',
-    color: 'text-fuchsia-600'
-  },
-  {
-    icon: Rocket,
-    title: "Founder�s AI Playbook",
-    description: 'Offer architecture + launch templates for conscious ventures.',
-    href: '/founder-playbook',
-    tag: 'Strategy',
-    color: 'text-green-600'
-  },
-  {
-    icon: Users,
-    title: 'AI Basics for Families',
-    description: 'Simple language, real scenarios, conversation guides.',
-    href: '/family-guide',
-    tag: 'Guide',
-    color: 'text-blue-600'
-  }
-]
-
-const testimonials = [
-  {
-    quote:
-      'Frank helped us turn a scattered set of offers into a coherent intelligence system. We shipped a new funnel, an AI concierge, and grew revenue 3x without burnout.',
-    name: 'Zoe Carter',
-    role: 'Founder � Conscious Leadership Lab'
-  },
-  {
-    quote:
-      'Our Oracle team finally has language and rituals for building AI that honors people. The Soul Frequency work has become part of onboarding.',
-    name: 'David Lin',
-    role: 'Sr. Director � Fortune 100 Enterprise'
-  }
-]
-
-export default function HomePage() {
+export default function Page() {
   return (
-    <div className="min-h-screen bg-white dark:bg-slate-950 text-gray-900 dark:text-slate-100 transition-colors">
+    <div className="min-h-screen flex flex-col bg-white dark:bg-slate-950 text-gray-900 dark:text-slate-50">
       <Navigation />
-      <main>
-        {/* Hero */}
-        <section className="relative overflow-hidden pt-32 pb-28" aria-labelledby="hero-heading">
-          <div className="absolute inset-0 bg-gradient-to-br from-primary-900 dark:from-slate-900 via-primary-800 dark:via-indigo-900 to-secondary-700 dark:to-blue-700" />
-          <div className="absolute inset-0 opacity-60" style={{
-            backgroundImage: 'radial-gradient(circle at 20% 20%, rgba(255,255,255,0.15), transparent 55%), radial-gradient(circle at 80% 10%, rgba(255,255,255,0.12), transparent 45%), radial-gradient(circle at 50% 80%, rgba(255,63,152,0.18), transparent 50%)'
-          }} />
-          <div className="relative max-w-7xl mx-auto px-6 grid lg:grid-cols-[1.1fr,0.9fr] gap-16 items-center">
-            <motion.div 
-              initial={{ opacity: 0, y: 20 }} 
-              whileInView={{ opacity: 1, y: 0 }} 
-              transition={{ duration: 0.5 }} 
-              viewport={{ once: true }}
-            >
-              <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 border border-white/20 text-caption text-white/90 backdrop-blur-sm">
-                <Sparkles className="w-4 h-4" aria-hidden="true" /> 
-                Conscious AI Systems for Humans Who Lead with Heart
-              </span>
-              <h1 id="hero-heading" className="mt-6 text-display-1 md:text-display-2 lg:text-6xl font-bold leading-tight text-white text-balance">
-                Build Intelligence Experiences that Feel Human, Sound Alive, and Scale with Integrity
-              </h1>
-              <p className="mt-5 text-body-large text-slate-200/90 leading-relaxed max-w-xl">
-                I help technologists, founders, and creators architect the rituals, automations, and musical experiences that transform audiences into communities. Together we turn Oracle-grade AI into a soul-aligned operating system.
-              </p>
-              <div className="mt-8 flex flex-col sm:flex-row gap-4">
-                <Link
-                  href="/soul-frequency-assessment"
-                  className="group inline-flex items-center justify-center px-8 py-4 rounded-xl bg-white text-slate-900 font-semibold shadow-elevation-2 hover:shadow-elevation-3 transition-all duration-200 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-primary-800"
-                >
-                  Start with the Assessment
-                  <ArrowRight className="w-5 h-5 ml-2 transition-transform group-hover:translate-x-1" aria-hidden="true" />
-                </Link>
-                <Link
-                  href="/blog/intelligence-revolution-2025"
-                  className="group inline-flex items-center justify-center px-8 py-4 rounded-xl border border-white/40 text-white hover:bg-white/10 hover:border-white/60 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-primary-800"
-                >
-                  Read the Revolution Playbook
-                  <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" aria-hidden="true" />
-                </Link>
-              </div>
-              <div className="mt-12 grid sm:grid-cols-3 gap-6">
-                {heroStats.map((stat) => (
-                  <div key={stat.label} className="bg-white/5 border border-white/10 rounded-2xl p-6 backdrop-blur">
-                    <div className="text-3xl font-bold text-white">{stat.value}</div>
-                    <div className="text-sm uppercase tracking-wide text-white/60 mt-1">{stat.label}</div>
-                    <p className="text-sm text-white/70 mt-3 leading-relaxed">{stat.detail}</p>
-                  </div>
-                ))}
-              </div>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.1 }}
-              viewport={{ once: true }}
-              className="bg-white/10 border border-white/10 rounded-3xl p-8 backdrop-blur-xl"
-            >
-              <h2 className="text-2xl font-semibold text-white mb-4">Your Intelligence Journey</h2>
-              <p className="text-slate-200 text-sm leading-relaxed mb-6">
-                Every collaboration follows a proven rhythm that integrates strategy, nervous system care, and shipping energy. We design together, build together, and launch with clear rituals.
-              </p>
-              <div className="space-y-6">
-                {journeyBlueprint.map((item) => (
-                  <div key={item.step} className="flex gap-4 items-start">
-                    <div className="mt-1 flex items-center justify-center w-12 h-12 rounded-full bg-white/15 text-white font-semibold">
-                      {item.step}
-                    </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <item.icon className="w-5 h-5 text-white/80" />
-                        <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                      </div>
-                      <p className="text-sm text-white/70 mt-2 leading-relaxed">{item.description}</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </motion.div>
-          </div>
-        </section>
-
-        {/* Audience */}
-        <section className="bg-slate-950 py-20 px-6">
-          <div className="max-w-7xl mx-auto">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4 }}
-              viewport={{ once: true }}
-              className="text-center max-w-3xl mx-auto"
-            >
-              <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 text-sm text-white/70 mb-4">
-                <Users className="w-4 h-4" /> Who We Serve
-              </span>
-              <h2 className="text-4xl font-bold text-white">Intelligence is for Every Conscious Leader</h2>
-              <p className="mt-4 text-slate-300">
-                Whether you are designing enterprise platforms, guiding families, scaling a creative studio, or launching a new brand, we build a system that honors your people.
-              </p>
-            </motion.div>
-            <div className="mt-12 grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-              {audienceCards.map((audience) => (
-                <motion.div
-                  key={audience.title}
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.4 }}
-                  viewport={{ once: true }}
-                  className={`rounded-2xl p-6 bg-gradient-to-br ${audience.color} text-slate-900 shadow-lg`}
-                >
-                  <audience.icon className={`w-8 h-8 ${audience.iconColor} mb-4`} />
-                  <h3 className="text-xl font-semibold mb-2">{audience.title}</h3>
-                  <p className="text-sm text-slate-700 leading-relaxed">{audience.description}</p>
-                </motion.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Method Pillars */}
-        <section className="py-20 px-6 bg-gradient-to-b from-slate-950 to-slate-900">
-          <div className="max-w-6xl mx-auto">
-            <h2 className="text-4xl font-bold text-white text-center mb-12">The FrankX Method</h2>
-            <div className="grid md:grid-cols-3 gap-6">
-              {pillars.map((pillar) => (
-                <div key={pillar.title} className="rounded-2xl p-8 text-white bg-gradient-to-br border border-white/10" style={{ background: pillar.gradient }}>
-                  <pillar.icon className="w-9 h-9 mb-5" />
-                  <h3 className="text-2xl font-semibold mb-3">{pillar.title}</h3>
-                  <p className="text-sm text-slate-100/80 leading-relaxed">{pillar.description}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Stories */}
-        <section className="py-20 px-6 bg-slate-950">
-          <div className="max-w-7xl mx-auto">
-            <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6 mb-10">
-              <div>
-                <h2 className="text-4xl font-bold text-white">Vision, Story, Systems</h2>
-                <p className="text-slate-300 max-w-2xl mt-3">
-                  Dive into cornerstone essays and playbooks that reveal how to combine enterprise AI, soul frequency design, and community experiences into a single operating system.
-                </p>
-              </div>
-              <Link href="/blog" className="inline-flex items-center gap-2 text-white/80 hover:text-white transition">
-                Browse all articles
-                <ArrowRight className="w-4 h-4" />
-              </Link>
-            </div>
-            <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
-              {curatedStories.map((story) => (
-                <div key={story.href} className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60">
-                  <div className="absolute inset-0" style={{ backgroundImage: story.gradient, opacity: 0.7 }} />
-                  <div className="relative p-8 h-full flex flex-col justify-between">
-                    <div>
-                      <span className="text-xs uppercase tracking-widest text-white/70">{story.tag}</span>
-                      <h3 className="text-2xl font-semibold text-white mt-3 mb-3">{story.title}</h3>
-                      <p className="text-sm text-white/80 leading-relaxed">{story.description}</p>
-                    </div>
-                    <div className="mt-6 flex items-center gap-3">
-                      <img src={story.image} alt={story.title} className="w-16 h-16 rounded-xl border border-white/20 object-cover" />
-                      <Link href={story.href} className="inline-flex items-center gap-2 text-sm font-semibold text-white/90 hover:text-white">
-                        Read the story
-                        <ArrowRight className="w-4 h-4" />
-                      </Link>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Testimonials */}
-        <section className="py-20 px-6 bg-gradient-to-b from-slate-900 to-slate-950">
-          <div className="max-w-6xl mx-auto">
-            <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8 mb-12">
-              <div>
-                <h2 className="text-4xl font-bold text-white">What Partners Are Experiencing</h2>
-                <p className="text-slate-300 mt-4 max-w-xl">
-                  From enterprise teams to conscious creators, the work blends performance with depth. These stories reflect the transformation we design for your audience�and for you.
-                </p>
-              </div>
-              <div className="flex items-center gap-3 bg-white/10 border border-white/15 rounded-2xl px-5 py-4 text-sm text-white/80">
-                <ShieldCheck className="w-5 h-5" />
-                <span>Oracle security-compliant workflows & humane automation</span>
-              </div>
-            </div>
-            <div className="grid md:grid-cols-2 gap-6">
-              {testimonials.map((testimonial) => (
-                <div key={testimonial.name} className="bg-white/8 border border-white/10 rounded-3xl p-8 backdrop-blur">
-                  <Lightbulb className="w-7 h-7 text-white/80 mb-4" />
-                  <p className="text-lg text-white/90 leading-relaxed mb-6">�{testimonial.quote}�</p>
-                  <div className="text-sm text-white/70">
-                    <div className="font-semibold text-white">{testimonial.name}</div>
-                    <div>{testimonial.role}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Resources */}
-        <section className="py-20 px-6 bg-slate-950">
-          <div className="max-w-7xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-4xl font-bold text-white">Resources for Your Next Step</h2>
-              <p className="text-slate-300 mt-3">Pick the door that resonates today. Each experience feeds the intelligence operating system we will build together.</p>
-            </div>
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-              {resources.map((resource, index) => (
-                <motion.div
-                  key={resource.title}
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.4, delay: index * 0.05 }}
-                  viewport={{ once: true }}
-                  className="group bg-white/5 border border-white/10 rounded-2xl p-6 h-full flex flex-col hover:bg-white/10 transition"
-                >
-                  <div className={`text-xs font-semibold ${resource.color} uppercase tracking-widest`}>{resource.tag}</div>
-                  <resource.icon className={`w-9 h-9 mt-4 mb-3 ${resource.color}`} />
-                  <h3 className="text-lg font-semibold text-white">{resource.title}</h3>
-                  <p className="text-sm text-white/70 mt-3 flex-1 leading-relaxed">{resource.description}</p>
-                  <Link href={resource.href} className="text-sm font-semibold text-white/80 hover:text-white mt-6">Explore ?</Link>
-                </motion.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Final CTA */}
-        <section className="py-24 px-6 bg-gradient-to-r from-purple-600 via-indigo-600 to-sky-500 text-white">
-          <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-4xl font-bold mb-4">Ready to Architect Your Conscious Intelligence Era?</h2>
-            <p className="text-lg mb-8 opacity-90">
-              We bring Oracle-grade execution, Suno-powered creativity, and nervous-system aware design to every engagement. Your next chapter can be both prosperous and deeply human.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="/soul-frequency-assessment"
-                className="inline-flex items-center px-8 py-4 bg-white text-purple-700 rounded-xl font-semibold hover:bg-gray-100 transition"
-              >
-                Begin with the Assessment
-                <ArrowRight className="w-5 h-5 ml-2" />
-              </Link>
-              <Link
-                href="mailto:hello@frankx.ai?subject=Conscious%20AI%20Collaboration"
-                className="inline-flex items-center px-8 py-4 bg-white/20 text-white rounded-xl font-semibold hover:bg-white/30 transition"
-              >
-                Request a Strategy Session
-              </Link>
-            </div>
-          </div>
-        </section>
-      </main>
+      <HomePage />
       <Footer />
+      <Script id="frankx-organization" type="application/ld+json" strategy="afterInteractive">
+        {JSON.stringify(structuredData)}
+      </Script>
     </div>
   )
 }

--- a/app/soul-frequency-quiz/page.tsx
+++ b/app/soul-frequency-quiz/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { Heart, Brain, Users, Lightbulb, ArrowRight, CheckCircle } from 'lucide-react'
 import Navigation from '@/components/Navigation'
@@ -346,13 +347,13 @@ export default function SoulFrequencyQuiz() {
                     >
                       Retake Quiz
                     </button>
-                    <a
+                    <Link
                       href="/blog/02-the-soul-frequency-framework"
                       className="inline-flex items-center px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
                     >
                       Learn More About Your Type
                       <ArrowRight className="ml-2 w-4 h-4" />
-                    </a>
+                    </Link>
                   </div>
                 </div>
               )}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { Sparkles, Twitter, Youtube, Github } from 'lucide-react'
+import { Mail, Newspaper, Search, Sparkles } from 'lucide-react'
 
 export default function Footer() {
   return (
@@ -17,58 +17,58 @@ export default function Footer() {
               Bridging Technology & Soul for Conscious AI
             </p>
             <div className="flex space-x-4">
-              <a 
-                href="#" 
+              <Link
+                href="/blog"
                 className="text-gray-400 hover:text-white transition-colors"
-                aria-label="Twitter"
+                aria-label="Read the latest intelligence updates"
               >
-                <Twitter className="w-5 h-5" />
-              </a>
-              <a 
-                href="#" 
+                <Newspaper className="w-5 h-5" />
+              </Link>
+              <Link
+                href="/search"
                 className="text-gray-400 hover:text-white transition-colors"
-                aria-label="YouTube"
+                aria-label="Search the hub"
               >
-                <Youtube className="w-5 h-5" />
-              </a>
-              <a 
-                href="#" 
+                <Search className="w-5 h-5" />
+              </Link>
+              <a
+                href="mailto:hello@frankx.ai?subject=Conscious%20AI%20Collaboration"
                 className="text-gray-400 hover:text-white transition-colors"
-                aria-label="GitHub"
+                aria-label="Email FrankX"
               >
-                <Github className="w-5 h-5" />
+                <Mail className="w-5 h-5" />
               </a>
             </div>
           </div>
           
           <div>
-            <h3 className="font-semibold mb-4">Resources</h3>
+            <h3 className="font-semibold mb-4">Intelligence Hub</h3>
             <ul className="space-y-2 text-gray-400">
-              <li><Link href="/start" className="hover:text-white transition-colors">Start Here</Link></li>
-              <li><Link href="/guides" className="hover:text-white transition-colors">Guides</Link></li>
-              <li><Link href="/blog" className="hover:text-white transition-colors">Blog</Link></li>
-              <li><Link href="/resources" className="hover:text-white transition-colors">Resources</Link></li>
-              <li><Link href="/reading/index.html" className="hover:text-white transition-colors">Reading Index</Link></li>
+              <li><Link href="/#updates" className="hover:text-white transition-colors">Latest Updates</Link></li>
+              <li><Link href="/#resources" className="hover:text-white transition-colors">Resource Library</Link></li>
+              <li><Link href="/#projects" className="hover:text-white transition-colors">Project Roadmap</Link></li>
+              <li><Link href="/#agents" className="hover:text-white transition-colors">Agent Protocols</Link></li>
+              <li><Link href="/search" className="hover:text-white transition-colors">Semantic Search</Link></li>
               <li><Link href="/rss.xml" className="hover:text-white transition-colors">RSS Feed</Link></li>
             </ul>
           </div>
-          
+
           <div>
-            <h3 className="font-semibold mb-4">Connect</h3>
+            <h3 className="font-semibold mb-4">Programs & Guides</h3>
             <ul className="space-y-2 text-gray-400">
-              <li><Link href="/newsletter" className="hover:text-white transition-colors">Newsletter</Link></li>
-              <li><a href="#" className="hover:text-white transition-colors">LinkedIn</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Twitter</a></li>
-              <li><Link href="/contact" className="hover:text-white transition-colors">Contact</Link></li>
+              <li><Link href="/founder-playbook" className="hover:text-white transition-colors">Founder’s AI Playbook</Link></li>
+              <li><Link href="/family-guide" className="hover:text-white transition-colors">AI Basics for Families</Link></li>
+              <li><Link href="/music-lab" className="hover:text-white transition-colors">Music Lab</Link></li>
+              <li><Link href="/guides" className="hover:text-white transition-colors">Guides Collection</Link></li>
             </ul>
           </div>
-          
+
           <div>
-            <h3 className="font-semibold mb-4">Newsletter</h3>
-            <p className="text-gray-400 mb-4">Weekly insights on conscious AI</p>
+            <h3 className="font-semibold mb-4">Intelligence Dispatch</h3>
+            <p className="text-gray-400 mb-4">Weekly briefings on conscious AI systems, music rituals, and agent strategy.</p>
             <form className="flex gap-2" action="/api/newsletter" method="POST">
-              <input 
-                type="email" 
+              <input
+                type="email"
                 name="email"
                 placeholder="Your email"
                 className="flex-1 px-3 py-2 bg-gray-800 rounded text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -7,15 +7,23 @@ import { Menu, X, Sparkles, Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { cn } from '@/lib/utils'
 
-const navItems = [
+type NavItem = {
+  name: string
+  href: string
+  isAnchor?: boolean
+}
+
+const navItems: NavItem[] = [
+  { name: 'Hub', href: '/' },
   { name: 'About', href: '/about' },
-  { name: 'Blog', href: '/blog' },
+  { name: 'Updates', href: '/#updates', isAnchor: true },
+  { name: 'Resources', href: '/#resources', isAnchor: true },
+  { name: 'Projects', href: '/#projects', isAnchor: true },
   { name: 'Guides', href: '/guides' },
-  { name: 'Search', href: '/search' },
+  { name: 'Blog', href: '/blog' },
   { name: 'Music Lab', href: '/music-lab' },
-  { name: 'Resources', href: '/resources' },
+  { name: 'Search', href: '/search' },
   { name: 'Assessment', href: '/soul-frequency-assessment' },
-  { name: 'Reading', href: '/reading/index.html' },
 ]
 
 export default function Navigation() {
@@ -33,7 +41,8 @@ export default function Navigation() {
     setIsOpen(false)
   }, [pathname])
 
-  const isActivePath = (href: string) => {
+  const isActivePath = (href: string, isAnchor?: boolean) => {
+    if (isAnchor) return false
     if (href === '/') return pathname === '/'
     return pathname.startsWith(href)
   }
@@ -89,11 +98,11 @@ export default function Navigation() {
                 href={item.href}
                 className={cn(
                   "px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500",
-                  isActivePath(item.href)
+                  isActivePath(item.href, item.isAnchor)
                     ? "text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950/50"
                     : "text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-gray-50 dark:hover:bg-white/5"
                 )}
-                aria-current={isActivePath(item.href) ? 'page' : undefined}
+                aria-current={isActivePath(item.href, item.isAnchor) ? 'page' : undefined}
               >
                 {item.name}
               </Link>
@@ -162,12 +171,12 @@ export default function Navigation() {
                 href={item.href}
                 className={cn(
                   "px-3 py-3 rounded-lg text-base font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500",
-                  isActivePath(item.href)
+                  isActivePath(item.href, item.isAnchor)
                     ? "text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950/50"
                     : "text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-gray-50 dark:hover:bg-white/5"
                 )}
                 onClick={() => setIsOpen(false)}
-                aria-current={isActivePath(item.href) ? 'page' : undefined}
+                aria-current={isActivePath(item.href, item.isAnchor) ? 'page' : undefined}
               >
                 {item.name}
               </Link>

--- a/components/home/HomePage.tsx
+++ b/components/home/HomePage.tsx
@@ -1,0 +1,522 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { ArrowRight, ArrowUpRight, CalendarDays, Check, Sparkles } from 'lucide-react'
+
+import {
+  agentProtocols,
+  heroCta,
+  heroHighlights,
+  heroStats,
+  heroSubtext,
+  heroSupportLink,
+  keywordClusters,
+  projectMilestones,
+  quickActions,
+  resourceCollections,
+  segmentProfiles,
+  testimonials,
+  testimonialIcon,
+  updateEntries
+} from '@/lib/hub'
+
+const fadeUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, amount: 0.3 }
+}
+
+const statusStyles: Record<'shipping' | 'in-progress' | 'incubating', string> = {
+  shipping: 'border-emerald-400/50 bg-emerald-500/10 text-emerald-200',
+  'in-progress': 'border-amber-400/50 bg-amber-500/10 text-amber-200',
+  incubating: 'border-sky-400/50 bg-sky-500/10 text-sky-200'
+}
+
+const TestimonialIcon = testimonialIcon
+
+export default function HomePage() {
+  return (
+    <main id="main" className="flex-1 bg-white dark:bg-slate-950 text-gray-900 dark:text-slate-50 pt-32">
+      {/* Hero Section */}
+      <section id="hub" className="relative overflow-hidden pb-20">
+        <div className="absolute inset-0 bg-gradient-to-br from-indigo-900 via-purple-900 to-slate-900 opacity-95" />
+        <div
+          className="absolute inset-0"
+          aria-hidden="true"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 20% 20%, rgba(255,255,255,0.08), transparent 55%), radial-gradient(circle at 80% 10%, rgba(255,255,255,0.06), transparent 45%), radial-gradient(circle at 50% 80%, rgba(56,189,248,0.18), transparent 55%)'
+          }}
+        />
+        <div className="relative max-w-7xl mx-auto px-6">
+          <motion.div
+            className="grid lg:grid-cols-[1.15fr,0.85fr] gap-14 items-start"
+            initial="initial"
+            animate="whileInView"
+            viewport={{ once: true }}
+          >
+            <motion.div variants={fadeUp} className="space-y-6 text-white">
+              <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 border border-white/20 text-xs uppercase tracking-widest">
+                <Sparkles className="w-4 h-4" aria-hidden="true" />
+                FrankX Intelligence Hub
+              </span>
+              <h1 className="text-4xl md:text-6xl font-semibold leading-tight text-balance">
+                The global AI voice guiding conscious creators, families, and enterprise leaders
+              </h1>
+              <div className="space-y-3 text-lg text-slate-100/90">
+                {heroSubtext.map((line) => (
+                  <p key={line} className="leading-relaxed">
+                    {line}
+                  </p>
+                ))}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-4 pt-2">
+                <Link
+                  href={heroCta.primary.href}
+                  className="inline-flex items-center justify-center px-8 py-4 rounded-xl bg-white text-slate-900 font-semibold shadow-lg shadow-primary-900/20 hover:bg-slate-100 transition-transform hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-100"
+                >
+                  {heroCta.primary.label}
+                  <ArrowRight className="w-5 h-5 ml-2" aria-hidden="true" />
+                </Link>
+                <Link
+                  href={heroCta.secondary.href}
+                  className="inline-flex items-center justify-center px-8 py-4 rounded-xl border border-white/40 text-white/90 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
+                >
+                  {heroCta.secondary.label}
+                  <ArrowUpRight className="w-5 h-5 ml-2" aria-hidden="true" />
+                </Link>
+              </div>
+              <div className="text-sm text-white/70">
+                <span className="font-semibold">Need a quick overview?</span>{' '}
+                <Link
+                  href={heroSupportLink.href}
+                  className="inline-flex items-center gap-1 text-white hover:text-slate-100 font-medium"
+                >
+                  {heroSupportLink.label}
+                  <ArrowUpRight className="w-4 h-4" aria-hidden="true" />
+                </Link>
+              </div>
+              <div className="grid sm:grid-cols-3 gap-4 pt-6">
+                {heroStats.map((stat) => (
+                  <div
+                    key={stat.label}
+                    className="bg-white/10 border border-white/15 rounded-2xl p-5 backdrop-blur text-sm"
+                  >
+                    <div className="text-3xl font-semibold text-white">{stat.value}</div>
+                    <div className="uppercase tracking-widest text-white/70 mt-2 text-xs">{stat.label}</div>
+                    <p className="mt-3 text-white/70 leading-relaxed">{stat.detail}</p>
+                  </div>
+                ))}
+              </div>
+            </motion.div>
+
+            <motion.aside
+              variants={fadeUp}
+              transition={{ delay: 0.1 }}
+              className="bg-white/10 border border-white/15 rounded-3xl p-8 backdrop-blur-xl text-white space-y-10"
+            >
+              <div>
+                <h2 className="text-2xl font-semibold">What lives here</h2>
+                <p className="mt-3 text-sm text-white/80 leading-relaxed">
+                  Every visit surfaces the newest intelligence, resources, and rituals designed for you and the
+                  agents you deploy. Start with a quick action or explore the highlights.
+                </p>
+              </div>
+              <div className="grid gap-3">
+                {quickActions.map((action) => (
+                  <Link
+                    key={action.title}
+                    href={action.href}
+                    className="group flex items-start gap-3 rounded-2xl border border-white/15 bg-white/5 px-4 py-4 hover:bg-white/10 transition"
+                  >
+                    <action.icon className="w-5 h-5 mt-0.5 text-white/80" aria-hidden="true" />
+                    <div>
+                      <div className="flex items-center gap-1 text-sm font-semibold">
+                        {action.title}
+                        <ArrowUpRight className="w-4 h-4 opacity-0 group-hover:opacity-100 transition" aria-hidden="true" />
+                      </div>
+                      <p className="text-xs text-white/70 leading-relaxed mt-1">{action.description}</p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+              <div className="space-y-4">
+                {heroHighlights.map((highlight) => (
+                  <div key={highlight.title} className="flex gap-3 items-start">
+                    <div className="w-11 h-11 rounded-xl bg-white/10 flex items-center justify-center">
+                      <highlight.icon className="w-5 h-5 text-white/80" aria-hidden="true" />
+                    </div>
+                    <div>
+                      <h3 className="text-sm font-semibold">{highlight.title}</h3>
+                      <p className="text-xs text-white/70 leading-relaxed mt-1">{highlight.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </motion.aside>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Segment Profiles */}
+      <section id="segments" className="bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto text-white">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 text-xs uppercase tracking-widest">
+              <Sparkles className="w-4 h-4" aria-hidden="true" />
+              Designed for every circle
+            </span>
+            <h2 className="mt-4 text-4xl font-semibold text-balance">Your people, your work, your agents—aligned in one hub</h2>
+            <p className="mt-4 text-slate-300">
+              Whether you are briefing executives, hosting a family workshop, or shipping a new release, these
+              pathways show you where to begin and how to integrate each experience.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid lg:grid-cols-2 gap-8">
+            {segmentProfiles.map((profile) => (
+              <motion.article
+                key={profile.id}
+                className="h-full rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur"
+                {...fadeUp}
+                transition={{ duration: 0.4 }}
+              >
+                <div className="flex items-start gap-4">
+                  <div className="w-12 h-12 rounded-2xl bg-white/10 flex items-center justify-center">
+                    <profile.icon className="w-6 h-6 text-white" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h3 className="text-2xl font-semibold">{profile.title}</h3>
+                    <p className="mt-2 text-sm text-slate-200 leading-relaxed">{profile.description}</p>
+                  </div>
+                </div>
+                <p className="mt-6 text-sm text-slate-300 leading-relaxed">{profile.transformation}</p>
+                <ul className="mt-6 space-y-2 text-sm">
+                  {profile.needs.map((need) => (
+                    <li key={need} className="flex items-start gap-2 text-slate-200">
+                      <Check className="w-4 h-4 mt-0.5 text-emerald-300" aria-hidden="true" />
+                      <span>{need}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-6 flex flex-wrap gap-3">
+                  {profile.ctas.map((cta) => (
+                    <Link
+                      key={cta.href}
+                      href={cta.href}
+                      className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20 transition"
+                    >
+                      {cta.label}
+                      <ArrowRight className="w-4 h-4" aria-hidden="true" />
+                    </Link>
+                  ))}
+                </div>
+                <div className="mt-6 flex flex-wrap gap-2 text-xs text-white/70">
+                  {profile.keywords.map((keyword) => (
+                    <span key={keyword} className="rounded-full border border-white/20 px-3 py-1">
+                      {keyword}
+                    </span>
+                  ))}
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Updates */}
+      <section id="updates" className="bg-white dark:bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <h2 className="text-4xl font-semibold text-gray-900 dark:text-white text-balance">Latest intelligence drops</h2>
+            <p className="mt-4 text-gray-600 dark:text-slate-300">
+              Stay ahead with the newest essays, resources, and program milestones. Each update is
+              designed to be actionable for you and the teams—or AI agents—you lead.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid md:grid-cols-3 gap-6">
+            {updateEntries.map((entry) => (
+              <motion.article
+                key={entry.href}
+                className="rounded-3xl border border-gray-200/60 dark:border-white/10 bg-gray-50/80 dark:bg-white/5 p-6 backdrop-blur"
+                {...fadeUp}
+                transition={{ duration: 0.4 }}
+              >
+                <div className="text-xs font-semibold uppercase tracking-widest text-primary-600 dark:text-sky-300">
+                  {entry.type}
+                </div>
+                <h3 className="mt-3 text-xl font-semibold text-gray-900 dark:text-white">
+                  <Link href={entry.href} className="hover:text-primary-600 dark:hover:text-sky-300 transition">
+                    {entry.title}
+                  </Link>
+                </h3>
+                <p className="mt-3 text-sm text-gray-600 dark:text-slate-300 leading-relaxed">{entry.summary}</p>
+                <div className="mt-6 flex items-center justify-between text-xs text-gray-500 dark:text-slate-400">
+                  <span>
+                    {new Date(entry.date).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric'
+                    })}
+                  </span>
+                  <Link href={entry.href} className="inline-flex items-center gap-1 font-semibold">
+                    Read
+                    <ArrowRight className="w-4 h-4" aria-hidden="true" />
+                  </Link>
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Resources */}
+      <section id="resources" className="bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto text-white">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <h2 className="text-4xl font-semibold text-balance">Resource universes for every mission</h2>
+            <p className="mt-4 text-slate-300">
+              Choose the path that matches your current momentum. Every item links directly into the
+              operating system we build together.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid lg:grid-cols-3 gap-8">
+            {resourceCollections.map((collection) => (
+              <motion.article
+                key={collection.id}
+                className="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur flex flex-col"
+                {...fadeUp}
+                transition={{ duration: 0.3 }}
+              >
+                <h3 className="text-2xl font-semibold">{collection.title}</h3>
+                <p className="mt-3 text-sm text-slate-200 leading-relaxed">{collection.description}</p>
+                <p className="mt-4 text-xs uppercase tracking-widest text-slate-300">Ideal for</p>
+                <p className="mt-1 text-sm text-slate-100/80 leading-relaxed">{collection.focus}</p>
+                <ul className="mt-6 space-y-3 text-sm">
+                  {collection.items.map((item) => (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        className="group flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 hover:bg-white/15 transition"
+                      >
+                        <div>
+                          <p className="font-semibold text-white">{item.label}</p>
+                          <p className="text-xs text-white/70">{item.type}</p>
+                        </div>
+                        <ArrowUpRight className="w-5 h-5 text-white/70 group-hover:text-white" aria-hidden="true" />
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Keyword Clusters */}
+      <section id="search" className="bg-white dark:bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <h2 className="text-4xl font-semibold text-gray-900 dark:text-white text-balance">
+              Built around the searches you and your agents run
+            </h2>
+            <p className="mt-4 text-gray-600 dark:text-slate-300">
+              These keyword constellations guide the site architecture, ensuring every query leads to
+              depth, clarity, and an action you can take next.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid md:grid-cols-2 gap-6">
+            {keywordClusters.map((cluster) => (
+              <motion.article
+                key={cluster.cluster}
+                className="rounded-3xl border border-gray-200/60 dark:border-white/10 bg-gray-50/80 dark:bg-white/5 p-6"
+                {...fadeUp}
+              >
+                <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{cluster.cluster}</h3>
+                <p className="mt-2 text-sm text-gray-600 dark:text-slate-300 leading-relaxed">{cluster.intent}</p>
+                <div className="mt-4 text-xs text-primary-700 dark:text-sky-300 font-semibold uppercase tracking-widest">
+                  Primary Keyword
+                </div>
+                <p className="text-sm text-gray-900 dark:text-white mt-1">{cluster.primaryKeyword}</p>
+                <div className="mt-4 text-xs uppercase tracking-widest text-gray-500 dark:text-slate-400">
+                  Supporting Signals
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {cluster.supportingKeywords.map((keyword) => (
+                    <span
+                      key={keyword}
+                      className="rounded-full bg-primary-50 text-primary-700 dark:bg-sky-500/10 dark:text-sky-200 px-3 py-1 text-xs"
+                    >
+                      {keyword}
+                    </span>
+                  ))}
+                </div>
+                <Link
+                  href={cluster.link}
+                  className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 dark:text-sky-300 hover:underline"
+                >
+                  Explore cornerstone content
+                  <ArrowRight className="w-4 h-4" aria-hidden="true" />
+                </Link>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Projects */}
+      <section id="projects" className="bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto text-white">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <h2 className="text-4xl font-semibold text-balance">Ship logs & manuscripts in motion</h2>
+            <p className="mt-4 text-slate-300">
+              Track the releases, books, and platform upgrades as they move from incubation to launch.
+              Every milestone includes a doorway into the work.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid md:grid-cols-3 gap-6">
+            {projectMilestones.map((milestone) => (
+              <motion.article
+                key={milestone.title}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur"
+                {...fadeUp}
+              >
+                <span
+                  className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-widest ${statusStyles[milestone.status]}`}
+                >
+                  <CalendarDays className="w-4 h-4" aria-hidden="true" />
+                  {milestone.status.replace('-', ' ')}
+                </span>
+                <h3 className="mt-4 text-xl font-semibold text-white">{milestone.title}</h3>
+                <p className="mt-3 text-sm text-white/80 leading-relaxed">{milestone.description}</p>
+                <p className="mt-3 text-xs text-white/60 uppercase tracking-widest">Focus</p>
+                <p className="text-sm text-white/75">{milestone.focus}</p>
+                {milestone.eta && (
+                  <p className="mt-4 text-xs text-white/60">{milestone.eta}</p>
+                )}
+                {milestone.cta && (
+                  <Link
+                    href={milestone.cta.href}
+                    className="mt-6 inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20 transition"
+                  >
+                    {milestone.cta.label}
+                    <ArrowRight className="w-4 h-4" aria-hidden="true" />
+                  </Link>
+                )}
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Agent Protocols */}
+      <section id="agents" className="bg-white dark:bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <h2 className="text-4xl font-semibold text-gray-900 dark:text-white text-balance">
+              Protocols that your AI agents can plug into today
+            </h2>
+            <p className="mt-4 text-gray-600 dark:text-slate-300">
+              Each protocol includes structures, prompts, and guardrails so human teams and automated
+              agents stay in sync.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid md:grid-cols-2 gap-6">
+            {agentProtocols.map((protocol) => (
+              <motion.article
+                key={protocol.title}
+                className="rounded-3xl border border-gray-200/60 dark:border-white/10 bg-gray-50/80 dark:bg-white/5 p-6"
+                {...fadeUp}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-12 h-12 rounded-2xl bg-primary-100 text-primary-700 dark:bg-sky-500/20 dark:text-sky-200 flex items-center justify-center">
+                    <protocol.icon className="w-6 h-6" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{protocol.title}</h3>
+                    <p className="text-xs uppercase tracking-widest text-gray-500 dark:text-slate-400 mt-1">
+                      {protocol.focus}
+                    </p>
+                  </div>
+                </div>
+                <p className="mt-4 text-sm text-gray-600 dark:text-slate-300 leading-relaxed">{protocol.description}</p>
+                <ul className="mt-5 space-y-2 text-sm">
+                  {protocol.bullets.map((bullet) => (
+                    <li key={bullet} className="flex items-start gap-2 text-gray-700 dark:text-slate-200">
+                      <Check className="w-4 h-4 mt-0.5 text-primary-600 dark:text-sky-300" aria-hidden="true" />
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+                <Link
+                  href={protocol.link.href}
+                  className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 dark:text-sky-300 hover:underline"
+                >
+                  {protocol.link.label}
+                  <ArrowRight className="w-4 h-4" aria-hidden="true" />
+                </Link>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section id="testimonials" className="bg-slate-950 py-24 px-6">
+        <div className="max-w-7xl mx-auto text-white">
+          <motion.div className="max-w-3xl" {...fadeUp}>
+            <h2 className="text-4xl font-semibold text-balance">Trusted across communities and boardrooms</h2>
+            <p className="mt-4 text-slate-300">
+              Stories from the leaders, families, and creators who now run intelligence systems that feel
+              deeply human.
+            </p>
+          </motion.div>
+          <div className="mt-14 grid md:grid-cols-3 gap-6">
+            {testimonials.map((testimonial) => (
+              <motion.article
+                key={testimonial.name}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur"
+                {...fadeUp}
+              >
+                <TestimonialIcon className="w-8 h-8 text-sky-300" aria-hidden="true" />
+                <p className="mt-4 text-sm text-white/80 leading-relaxed">“{testimonial.quote}”</p>
+                <div className="mt-6">
+                  <p className="text-sm font-semibold text-white">{testimonial.name}</p>
+                  <p className="text-xs text-white/70">{testimonial.role}</p>
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="bg-gradient-to-r from-indigo-600 via-purple-600 to-sky-500 py-24 px-6 text-white">
+        <div className="max-w-4xl mx-auto text-center space-y-6">
+          <h2 className="text-4xl font-semibold text-balance">Ready to architect your conscious intelligence era?</h2>
+          <p className="text-lg text-white/90 leading-relaxed">
+            Bring your friends, family, executive teams, and AI agents into a shared operating system. We
+            will build the rituals, automations, and creative experiences that let everyone thrive.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/soul-frequency-assessment"
+              className="inline-flex items-center justify-center px-8 py-4 rounded-xl bg-white text-purple-700 font-semibold hover:bg-slate-100 transition"
+            >
+              Begin with the assessment
+              <ArrowRight className="w-5 h-5 ml-2" aria-hidden="true" />
+            </Link>
+            <Link
+              href="mailto:hello@frankx.ai?subject=Conscious%20AI%20Collaboration"
+              className="inline-flex items-center justify-center px-8 py-4 rounded-xl border border-white/60 text-white hover:bg-white/10 transition"
+            >
+              Request a strategy session
+              <ArrowUpRight className="w-5 h-5 ml-2" aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/docs/intelligence-hub-blueprint.md
+++ b/docs/intelligence-hub-blueprint.md
@@ -1,0 +1,61 @@
+# FrankX Intelligence Hub Blueprint
+
+## Purpose
+Create a single destination where friends, family, high-value clients, AI architects, creators, and influencers experience the most relevant intelligence, rituals, and resources. The hub must serve humans and their AI agents with the same clarity, depth, and alignment.
+
+## Audience Operating System
+| Segment | Core Needs | Primary Assets | Search Intent Keywords |
+| --- | --- | --- | --- |
+| Friends & Family | Plain-language explainers, safety rituals, shared practice prompts | [AI Basics for Families](/family-guide), [Soul Frequency Quiz](/soul-frequency-quiz) | `family ai guide`, `teach kids ai safely`, `ai conversations with parents` |
+| Creators & Influencers | Suno workflows, launch narratives, licensing clarity | [Music Lab](/music-lab), [AI Doesn't Have To Be Soulless](/blog/ai-doesnt-have-to-be-soulless) | `ai music workflow`, `creator ai prompts`, `influencer ai strategy` |
+| High Value Clients & Executives | Governance playbooks, KPI scorecards, executive briefings | [Founder’s AI Playbook](/founder-playbook), Strategy Intensive (mailto:hello@frankx.ai) | `enterprise ai strategy`, `oracle ai architect`, `ai governance playbook` |
+| AI Architects & Builders | Reference architectures, orchestration patterns, testing checklists | [Intelligence Revolution Playbook](/blog/intelligence-revolution-2025), [Guides Collection](/guides) | `ai agent architecture`, `human centered automation`, `ai orchestration checklist` |
+| Community & Collaborators | Live experience templates, shared resource boards, feedback loops | [Start Here Experience](/start), [Template Library](/templates) | `community ai ritual`, `ai workshop template`, `collective intelligence experiences` |
+
+## Search & SEO Architecture
+| Cluster | Primary Keyword | Supporting Signals | Destination |
+| --- | --- | --- | --- |
+| Conscious AI Strategy | `conscious ai strategy` | `ai operating system`, `ai governance rituals`, `enterprise ai architecture` | [Intelligence Revolution Playbook](/blog/intelligence-revolution-2025) |
+| Family AI Education | `ai guide for families` | `ai conversations with kids`, `family ai safety checklist`, `teach ai at home` | [AI Basics for Families](/family-guide) |
+| Creator Workflows | `ai music workflow` | `suno prompts`, `ai content ritual`, `creative intelligence system` | [Music Lab](/music-lab) |
+| AI Architect Toolkit | `ai agent architecture` | `human centered automation`, `agent governance`, `orchestration blueprint` | [Guides Collection](/guides) |
+
+## Content Modules
+- **Hero Command Deck** – communicates the mission, quick actions, and high-level metrics.
+- **Audience Playbooks** – five segment cards with needs, CTAs, and keyword intents.
+- **Latest Intelligence Drops** – rotating feed of essays, resources, and program milestones.
+- **Resource Universes** – categorized library for free, deep-dive, and premium assets.
+- **Keyword Constellations** – visible SEO strategy so humans and agents know the best entry points.
+- **Project Ship Logs** – transparency for books, programs, and roadmap milestones.
+- **Agent Protocols** – ready-to-use frameworks for retrieval, safety, creation, and executive reporting.
+- **Testimonials + CTA** – social proof and closing invitations for assessment and strategy sessions.
+
+## Interlinking Map
+- Hero → Quick Actions: `/search`, `/blog`, `/resources`, `/#projects`.
+- Segment CTAs → Primary Assets: `/family-guide`, `/music-lab`, `/founder-playbook`, `/guides`, `/templates`, `/start`.
+- Updates → Blog + Resource pages: `/blog/intelligence-revolution-2025`, `/blog/soul-frequency-framework`, `/family-guide`.
+- Resource Universes → Assessments, Playbooks, Template Library.
+- Keyword Constellations → anchor visitors toward cornerstone content.
+- Project Milestones → invites into `Preview the Framework`, `Template Library`, `Start` experience.
+- Agent Protocols → connect to `/search`, `/family-guide`, `/music-lab`, `/founder-playbook`.
+- Footer consolidates anchors (`/#updates`, `/#resources`, `/#projects`, `/#agents`) with direct program links.
+
+## Experience Flows
+1. **Assessment First** – Hero CTA → Soul Frequency Assessment → Resource Universe → Agent Protocol.
+2. **Executive Strategy** – Segment (High Value Clients) → Founder’s AI Playbook → Project Milestones → Strategy Intensive email.
+3. **Family Safety** – Segment (Friends & Family) → AI Basics for Families → Keyword Cluster for Family AI Education → Agent Safety Framework.
+4. **Creator Momentum** – Segment (Creators) → Music Lab → Project Milestones (Creator Operating System) → Template Library.
+5. **AI Architect Deep Dive** – Segment (AI Architects) → Intelligence Revolution Playbook → Keyword Cluster (AI Architect Toolkit) → Guides Collection → Search.
+
+## Measurement Signals
+- Click-through rates on segment CTAs and quick actions.
+- Resource downloads (assessment completions, template grabs).
+- Newsletter opt-ins via Intelligence Dispatch form.
+- Email conversions for Strategy Intensive and Retainer offers.
+- Search analytics queries to refine keyword clusters and agent intents.
+
+## Agent Enablement Notes
+- `search` endpoint indexes all content for semantic retrieval.
+- Keywords exposed visually so agents can align with human language.
+- Each protocol includes guardrails and escalation templates for safe automation.
+- JSON-LD organization schema provides discoverability for AI crawlers.

--- a/lib/hub.ts
+++ b/lib/hub.ts
@@ -1,0 +1,467 @@
+import { type LucideIcon } from 'lucide-react'
+import {
+  BarChart4,
+  BookOpen,
+  Bot,
+  Building2,
+  CalendarCheck,
+  CheckCircle2,
+  FolderOpen,
+  Megaphone,
+  Music,
+  Newspaper,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  Users,
+  Workflow
+} from 'lucide-react'
+
+export type HeroStat = {
+  label: string
+  value: string
+  detail: string
+}
+
+export type HeroHighlight = {
+  title: string
+  description: string
+  icon: LucideIcon
+}
+
+export type QuickAction = {
+  title: string
+  description: string
+  href: string
+  icon: LucideIcon
+}
+
+export type SegmentProfile = {
+  id: string
+  title: string
+  description: string
+  transformation: string
+  icon: LucideIcon
+  needs: string[]
+  keywords: string[]
+  ctas: Array<{ label: string; href: string }>
+}
+
+export type UpdateEntry = {
+  title: string
+  summary: string
+  type: 'Article' | 'Resource' | 'Program'
+  date: string
+  href: string
+}
+
+export type ResourceCollection = {
+  id: string
+  title: string
+  description: string
+  focus: string
+  items: Array<{ label: string; href: string; type: string }>
+}
+
+export type ProjectMilestone = {
+  title: string
+  status: 'shipping' | 'in-progress' | 'incubating'
+  description: string
+  focus: string
+  eta?: string
+  cta?: { label: string; href: string }
+}
+
+export type KeywordCluster = {
+  cluster: string
+  primaryKeyword: string
+  intent: string
+  supportingKeywords: string[]
+  link: string
+}
+
+export type AgentProtocol = {
+  title: string
+  description: string
+  focus: string
+  icon: LucideIcon
+  link: { href: string; label: string }
+  bullets: string[]
+}
+
+export const heroStats: HeroStat[] = [
+  {
+    label: 'Enterprise Systems Shipped',
+    value: '200+',
+    detail: 'Oracle-grade AI roadmaps deployed with conscious safeguards'
+  },
+  {
+    label: 'Suno Collaborations',
+    value: '500',
+    detail: 'Music-led rituals co-created with AI and communities'
+  },
+  {
+    label: 'Weekly Briefings',
+    value: '52+',
+    detail: 'Annual cadence of strategic intelligence drops and audits'
+  }
+]
+
+export const heroHighlights: HeroHighlight[] = [
+  {
+    title: 'Signal Over Noise',
+    description:
+      'Curated AI news, regulatory shifts, and capability drops filtered for strategic relevance.',
+    icon: Megaphone
+  },
+  {
+    title: 'Resource Vault',
+    description:
+      'Guides, templates, playlists, and scripts to launch conscious intelligence experiences.',
+    icon: BookOpen
+  },
+  {
+    title: 'Agent-Ready Blueprints',
+    description:
+      'Process maps and prompts that help your AI agents reason with the same values you hold.',
+    icon: Workflow
+  }
+]
+
+export const quickActions: QuickAction[] = [
+  {
+    title: 'Search the Hub',
+    description: 'Semantic search across essays, guides, and templates.',
+    href: '/search',
+    icon: Search
+  },
+  {
+    title: 'Latest Briefings',
+    description: 'Read the intelligence updates that anchor every engagement.',
+    href: '/blog',
+    icon: Newspaper
+  },
+  {
+    title: 'Resource Library',
+    description: 'Download assessments, playbooks, and creative stacks.',
+    href: '/resources',
+    icon: FolderOpen
+  },
+  {
+    title: 'Book Progress',
+    description: 'Track the Soul Frequency manuscript and new releases.',
+    href: '/#projects',
+    icon: CalendarCheck
+  }
+]
+
+export const segmentProfiles: SegmentProfile[] = [
+  {
+    id: 'inner-circle',
+    title: 'Friends & Family',
+    description:
+      'Help the people closest to you understand AI with warmth, calm, and clear language.',
+    transformation:
+      'Everyone at the dinner table knows how to ask better questions, evaluate tools, and stay safe.',
+    icon: Users,
+    needs: [
+      'Plain-language explainers and conversation prompts',
+      'Safety rituals for households and classrooms',
+      'Short practice sessions that build confidence together'
+    ],
+    keywords: ['family ai guide', 'teach kids ai safely', 'ai conversations with parents'],
+    ctas: [
+      { label: 'Family AI Guide', href: '/family-guide' },
+      { label: 'Soul Frequency Quiz', href: '/soul-frequency-quiz' }
+    ]
+  },
+  {
+    id: 'creators',
+    title: 'Creators & Influencers',
+    description:
+      'Turn AI collaborators into vibrant co-producers who amplify your aesthetic, not erase it.',
+    transformation:
+      'Your studio ships music, video, and rituals that sound like you while scaling to global audiences.',
+    icon: Music,
+    needs: [
+      'Daily prompts and sound design workflows in Suno',
+      'Narrative frameworks for launches and community events',
+      'Licensing clarity for mixed human-AI projects'
+    ],
+    keywords: ['ai music workflow', 'creator ai prompts', 'influencer ai strategy'],
+    ctas: [
+      { label: 'Enter the Music Lab', href: '/music-lab' },
+      { label: "Read: AI Doesn't Have To Be Soulless", href: '/blog/ai-doesnt-have-to-be-soulless' }
+    ]
+  },
+  {
+    id: 'enterprise',
+    title: 'High Value Clients & Executives',
+    description:
+      'Architect governance, measurement, and monetization for intelligent products and services.',
+    transformation:
+      'Teams align on a conscious AI operating system with dashboards, rituals, and revenue loops.',
+    icon: Building2,
+    needs: [
+      'Executive-ready briefings with strategic options',
+      'Risk, compliance, and data stewardship playbooks',
+      'Pilot-to-scale roadmaps that protect culture and margins'
+    ],
+    keywords: ['enterprise ai strategy', 'oracle ai architect', 'ai governance playbook'],
+    ctas: [
+      { label: "Founder’s AI Playbook", href: '/founder-playbook' },
+      { label: 'Book a Strategy Intensive', href: 'mailto:hello@frankx.ai?subject=Conscious%20AI%20Strategy' }
+    ]
+  },
+  {
+    id: 'architects',
+    title: 'AI Architects & Builders',
+    description:
+      'Design agent ecosystems that are auditable, resilient, and tuned to human outcomes.',
+    transformation:
+      'You shift from experimenting with tools to orchestrating a living intelligence stack.',
+    icon: Bot,
+    needs: [
+      'Reference architectures with data, workflow, and orchestration layers',
+      'Testing checklists for ethical guardrails and performance',
+      'Benchmark dashboards to communicate value to stakeholders'
+    ],
+    keywords: ['ai agent architecture', 'human centered automation', 'ai orchestration checklist'],
+    ctas: [
+      { label: 'Intelligence Revolution Playbook', href: '/blog/intelligence-revolution-2025' },
+      { label: 'Explore Guides', href: '/guides' }
+    ]
+  },
+  {
+    id: 'community',
+    title: 'Community & Collaborators',
+    description:
+      'Bring cohorts, friends, and online circles into shared experiments that transform together.',
+    transformation:
+      'Communities receive updates, rituals, and shared language for conscious AI growth.',
+    icon: Sparkles,
+    needs: [
+      'Live activation templates and event scripts',
+      'Shared resource boards for continuing education',
+      'Feedback loops that celebrate progress and surface needs'
+    ],
+    keywords: ['community ai ritual', 'ai workshop template', 'collective intelligence experiences'],
+    ctas: [
+      { label: 'Start Here Experience', href: '/start' },
+      { label: 'Template Library', href: '/templates' }
+    ]
+  }
+]
+
+export const updateEntries: UpdateEntry[] = [
+  {
+    title: 'The Intelligence Revolution Playbook',
+    summary:
+      'A systems-first guide to orchestrating conscious AI across products, teams, and experiences.',
+    type: 'Article',
+    date: '2025-09-16',
+    href: '/blog/intelligence-revolution-2025'
+  },
+  {
+    title: 'Soul Frequency Framework',
+    summary:
+      'Map the creative signature AI should amplify across your brand, family, and leadership.',
+    type: 'Article',
+    date: '2024-08-20',
+    href: '/blog/soul-frequency-framework'
+  },
+  {
+    title: 'AI Basics for Families Guide',
+    summary:
+      'A practical field manual for conversations, boundaries, and first projects at home.',
+    type: 'Resource',
+    date: '2024-05-01',
+    href: '/family-guide'
+  }
+]
+
+export const resourceCollections: ResourceCollection[] = [
+  {
+    id: 'start',
+    title: 'Start Free & Grounded',
+    description: 'Orientation experiences that give immediate language, safety, and clarity.',
+    focus: 'Perfect for welcoming friends, family, and new collaborators into the hub.',
+    items: [
+      { label: 'Soul Frequency Assessment', href: '/soul-frequency-assessment', type: 'Assessment' },
+      { label: 'Soul Frequency Quiz', href: '/soul-frequency-quiz', type: 'Quiz' },
+      { label: 'AI Basics for Families', href: '/family-guide', type: 'Guide' }
+    ]
+  },
+  {
+    id: 'deepen',
+    title: 'Deepen Your Practice',
+    description: 'Hands-on guides, playbooks, and templates for shipping conscious AI systems.',
+    focus: 'Best for creators, architects, and executives building multi-offer ecosystems.',
+    items: [
+      { label: "Founder’s AI Playbook", href: '/founder-playbook', type: 'Playbook' },
+      { label: 'Template Library', href: '/templates', type: 'Templates' },
+      { label: 'Guides Collection', href: '/guides', type: 'Guides' }
+    ]
+  },
+  {
+    id: 'premium',
+    title: 'Premium Engagements',
+    description: 'High-touch collaborations for teams that need bespoke AI architecture and leadership.',
+    focus: 'Ideal for enterprise leaders, studios, and creators scaling conscious ecosystems.',
+    items: [
+      { label: 'Strategy Intensive', href: 'mailto:hello@frankx.ai?subject=Strategy%20Intensive', type: 'Advisory' },
+      { label: 'Intelligence Retainer', href: 'mailto:hello@frankx.ai?subject=Intelligence%20Retainer', type: 'Retainer' },
+      { label: 'Immersive Experiences', href: '/music-lab', type: 'Experiences' }
+    ]
+  }
+]
+
+export const projectMilestones: ProjectMilestone[] = [
+  {
+    title: 'Soul Frequency Book Manuscript',
+    status: 'in-progress',
+    description:
+      'Documenting the methodology, rituals, and case studies for living with conscious intelligence.',
+    focus: 'Chapters released to the community for feedback and refinement.',
+    eta: 'Beta chapters publishing Q4 2024',
+    cta: { label: 'Preview the Framework', href: '/blog/soul-frequency-framework' }
+  },
+  {
+    title: 'Creator Operating System',
+    status: 'shipping',
+    description:
+      'Templates, automations, and scorecards that let studios manage AI-assisted launches.',
+    focus: 'Includes content calendars, monetization arcs, and Suno session rituals.',
+    eta: 'Rolling releases every month',
+    cta: { label: 'Access the Template Library', href: '/templates' }
+  },
+  {
+    title: 'Family Intelligence Navigator',
+    status: 'incubating',
+    description:
+      'Micro-learning tracks for families adopting AI with confidence and shared boundaries.',
+    focus: 'Piloting with close community groups before public launch.',
+    eta: 'Pilot cohort forming for 2025',
+    cta: { label: 'Join the Start Here Experience', href: '/start' }
+  }
+]
+
+export const keywordClusters: KeywordCluster[] = [
+  {
+    cluster: 'Conscious AI Strategy',
+    primaryKeyword: 'conscious ai strategy',
+    intent: 'Leaders seeking a holistic operating system for AI.',
+    supportingKeywords: ['ai operating system', 'enterprise ai architecture', 'ai governance rituals'],
+    link: '/blog/intelligence-revolution-2025'
+  },
+  {
+    cluster: 'Family AI Education',
+    primaryKeyword: 'ai guide for families',
+    intent: 'Parents and mentors looking for safe, clear instruction.',
+    supportingKeywords: ['ai conversations with kids', 'family ai safety checklist', 'teach ai at home'],
+    link: '/family-guide'
+  },
+  {
+    cluster: 'Creator Workflows',
+    primaryKeyword: 'ai music workflow',
+    intent: 'Creators wanting to fuse AI with authentic artistry.',
+    supportingKeywords: ['suno prompts', 'ai content ritual', 'creative intelligence system'],
+    link: '/music-lab'
+  },
+  {
+    cluster: 'AI Architect Toolkit',
+    primaryKeyword: 'ai agent architecture',
+    intent: 'Builders searching for design patterns and governance checklists.',
+    supportingKeywords: ['human centered automation', 'agent governance', 'orchestration blueprint'],
+    link: '/guides'
+  }
+]
+
+export const agentProtocols: AgentProtocol[] = [
+  {
+    title: 'Search & Retrieval Mesh',
+    description: 'Ground AI agents in verified knowledge before they respond or act.',
+    focus: 'Feeds semantic search, embeddings, and retrieval chains for assistants and copilots.',
+    icon: Search,
+    link: { href: '/search', label: 'Launch Search' },
+    bullets: [
+      'Unified index of essays, guides, and templates',
+      'Pre-built intents and tags for delegation',
+      'Daily refreshed highlights for briefing agents'
+    ]
+  },
+  {
+    title: 'Safety & Alignment Framework',
+    description: 'Protect communities with clear boundaries, escalation paths, and review rituals.',
+    focus: 'Perfect for friends, family, and enterprise compliance teams.',
+    icon: ShieldCheck,
+    link: { href: '/family-guide', label: 'Review Safety Guide' },
+    bullets: [
+      'Conversation scripts and consent checkpoints',
+      'Values-aligned guardrails for prompts and outputs',
+      'Incident response templates for AI misuse'
+    ]
+  },
+  {
+    title: 'Creation Engine',
+    description: 'Design sonic, narrative, and visual experiences that feel alive.',
+    focus: 'Combines Suno workflows with marketing arcs and monetization plans.',
+    icon: Music,
+    link: { href: '/music-lab', label: 'Visit Music Lab' },
+    bullets: [
+      'Session prompts tuned to archetypes and emotions',
+      'Launch timelines with nurture sequences',
+      'Licensing and rights checklist for AI collaborations'
+    ]
+  },
+  {
+    title: 'Executive Intelligence Dashboard',
+    description: 'Translate experiments into executive decisions and measurable value.',
+    focus: 'Bring clarity to high-value clients and leadership teams.',
+    icon: BarChart4,
+    link: { href: '/founder-playbook', label: "Open Founder’s Playbook" },
+    bullets: [
+      'KPI scorecards for human + AI outcomes',
+      'Governance cadences that satisfy security reviews',
+      'Roadmaps from pilot to scale with decision gates'
+    ]
+  }
+]
+
+export const testimonials = [
+  {
+    quote:
+      'Frank helped us turn a scattered set of offers into a coherent intelligence system. We shipped a new funnel, an AI concierge, and grew revenue without burning out the team.',
+    name: 'Zoe Carter',
+    role: 'Founder · Conscious Leadership Lab'
+  },
+  {
+    quote:
+      'Our Oracle team finally has language and rituals for building AI that honors people. The Soul Frequency work has become part of onboarding.',
+    name: 'David Lin',
+    role: 'Senior Director · Fortune 100 Enterprise'
+  },
+  {
+    quote:
+      'The Music Lab unlocked a new creative lane. We now release immersive drops every month with clarity on rights, monetization, and community engagement.',
+    name: 'Amina Reyes',
+    role: 'Artist & Community Architect'
+  }
+]
+
+export const testimonialIcon = CheckCircle2
+
+export const heroSubtext = [
+  'FrankX is the global AI voice guiding conscious creators, families, and executives.',
+  'Every insight is rooted in enterprise delivery, community rituals, and artistry.'
+]
+
+export const heroCta = {
+  primary: { label: 'Start the Soul Frequency Assessment', href: '/soul-frequency-assessment' },
+  secondary: { label: 'Browse All Updates', href: '/#updates' }
+}
+
+export const heroSupportLink = {
+  label: 'View Conscious AI Principles',
+  href: '/guides'
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://frankx.ai/</loc></url>
+  <url><loc>https://frankx.ai/about</loc></url>
+  <url><loc>https://frankx.ai/guides</loc></url>
   <url><loc>https://frankx.ai/blog</loc></url>
-  <url><loc>https://frankx.ai/music-lab</loc></url>
+  <url><loc>https://frankx.ai/insights</loc></url>
   <url><loc>https://frankx.ai/resources</loc></url>
+  <url><loc>https://frankx.ai/music-lab</loc></url>
+  <url><loc>https://frankx.ai/templates</loc></url>
+  <url><loc>https://frankx.ai/founder-playbook</loc></url>
+  <url><loc>https://frankx.ai/family-guide</loc></url>
+  <url><loc>https://frankx.ai/start</loc></url>
+  <url><loc>https://frankx.ai/search</loc></url>
+  <url><loc>https://frankx.ai/soul-frequency-assessment</loc></url>
+  <url><loc>https://frankx.ai/soul-frequency-quiz</loc></url>
   <url><loc>https://frankx.ai/reading/index.html</loc></url>
+  <url><loc>https://frankx.ai/blog/intelligence-revolution-2025</loc></url>
+  <url><loc>https://frankx.ai/blog/ai-doesnt-have-to-be-soulless</loc></url>
+  <url><loc>https://frankx.ai/blog/soul-frequency-framework</loc></url>
 </urlset>
-


### PR DESCRIPTION
## Summary
- rebuild the homepage as the FrankX Intelligence Hub with segment-specific journeys, resource universes, agent protocols, and refreshed calls to action
- centralize hub content data, add organization-level structured metadata, expand the sitemap, and document the SEO/interlinking blueprint
- refresh navigation, footer, and lint configuration so links target new anchors and existing content passes lint rules

## Testing
- NEXT_LINT_SKIP_AUTO_SETUP=1 npm run lint
- npm run type-check
- npm run build *(fails: unable to download remote Inter font files in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ed9170b88320bbe94b5e2baf7155