### PR TITLE
feat(library): QuoteShareToolbar — highlight-to-share on every library quote

### DIFF
--- a/app/library/[slug]/page.tsx
+++ b/app/library/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { bookReviews, getReviewBySlug, getAllReviewSlugs } from '@/data/book-reviews';
 import { booksRegistry } from '@/app/books/lib/books-registry';
 import type { BookReview } from '@/app/books/types';
+import { QuoteShareToolbar } from '@/components/share/QuoteShareToolbar';
 
 const SITE_URL = 'https://frankx.ai';
 
@@ -199,6 +200,7 @@ export default async function ReviewPage({
 
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
+      <QuoteShareToolbar />
       {/* Back Link */}
       <div className="max-w-3xl mx-auto px-6 pt-28 pb-4">
         <Link
@@ -364,37 +366,51 @@ export default async function ReviewPage({
             map back to the book so you can re-read them in context.
           </p>
           <div className="space-y-4">
-            {review.quotes.map((quote, i) => (
-              <figure
-                key={i}
-                className="relative rounded-2xl border border-white/[0.06] bg-gradient-to-br from-white/[0.03] to-transparent p-6 pl-8"
-              >
-                <span
-                  aria-hidden="true"
-                  className="absolute top-3 left-3 text-rose-400/40 font-serif text-5xl leading-none select-none"
+            {review.quotes.map((quote, i) => {
+              const quoteId = `q-${review.slug}-${i + 1}`;
+              const permalink = `${SITE_URL}/library/${review.slug}#${quoteId}`;
+              return (
+                <figure
+                  key={i}
+                  id={quoteId}
+                  tabIndex={0}
+                  data-shareable="quote"
+                  data-quote-text={quote.text}
+                  data-quote-author={review.author}
+                  data-quote-source={review.title}
+                  data-quote-permalink={permalink}
+                  className="relative rounded-2xl border border-white/[0.06] bg-gradient-to-br from-white/[0.03] to-transparent p-6 pl-8 scroll-mt-24 outline-none focus-visible:border-rose-400/30 focus-visible:ring-2 focus-visible:ring-rose-400/20"
                 >
-                  &ldquo;
-                </span>
-                <blockquote className="text-white/80 leading-relaxed text-[15.5px] font-light italic">
-                  {quote.text}
-                </blockquote>
-                {(quote.chapter || quote.context) && (
-                  <figcaption className="mt-4 pt-4 border-t border-white/[0.04] space-y-1">
-                    {quote.chapter && (
-                      <p className="text-[11px] uppercase tracking-[0.15em] text-rose-400/60">
-                        {quote.chapter}
-                      </p>
-                    )}
-                    {quote.context && (
-                      <p className="text-[13px] text-white/50 leading-relaxed">
-                        {quote.context}
-                      </p>
-                    )}
-                  </figcaption>
-                )}
-              </figure>
-            ))}
+                  <span
+                    aria-hidden="true"
+                    className="absolute top-3 left-3 text-rose-400/40 font-serif text-5xl leading-none select-none"
+                  >
+                    &ldquo;
+                  </span>
+                  <blockquote className="text-white/80 leading-relaxed text-[15.5px] font-light italic">
+                    {quote.text}
+                  </blockquote>
+                  {(quote.chapter || quote.context) && (
+                    <figcaption className="mt-4 pt-4 border-t border-white/[0.04] space-y-1">
+                      {quote.chapter && (
+                        <p className="text-[11px] uppercase tracking-[0.15em] text-rose-400/60">
+                          {quote.chapter}
+                        </p>
+                      )}
+                      {quote.context && (
+                        <p className="text-[13px] text-white/50 leading-relaxed">
+                          {quote.context}
+                        </p>
+                      )}
+                    </figcaption>
+                  )}
+                </figure>
+              );
+            })}
           </div>
+          <p className="mt-6 text-[12px] text-white/30">
+            Tip: highlight any quote to share it. Press <kbd className="px-1.5 py-0.5 rounded bg-white/5 border border-white/10 font-mono text-[10px]">S</kbd> while focused on a quote for keyboard share.
+          </p>
         </section>
       )}
 

--- a/app/library/quotes/page.tsx
+++ b/app/library/quotes/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { bookReviews } from '@/data/book-reviews';
 import type { BookReview, BookQuote } from '@/app/books/types';
+import { QuoteShareToolbar } from '@/components/share/QuoteShareToolbar';
 
 const SITE_URL = 'https://frankx.ai';
 
@@ -125,6 +126,7 @@ export default function LibraryQuotesPage() {
   return (
     <div className="min-h-screen bg-[#0a0a0b] text-white">
       <QuotesJsonLd quotes={quotes} />
+      <QuoteShareToolbar />
 
       {/* Back link */}
       <div className="max-w-5xl mx-auto px-6 pt-28 pb-4">
@@ -171,6 +173,10 @@ export default function LibraryQuotesPage() {
             Curated quotes from every deep-dived book in the library. Each quote carries
             its chapter reference and, where useful, the one-sentence framing of why it
             matters. Click any book title to open its full hub.
+          </p>
+          <p className="mt-4 text-[13px] text-rose-300/60 max-w-2xl">
+            <span className="text-rose-300/90">Tip:</span> highlight any line to share or
+            copy it with a permalink — works on desktop and mobile.
           </p>
 
           {/* Stats */}
@@ -264,36 +270,48 @@ export default function LibraryQuotesPage() {
 
               {/* Quotes */}
               <div className="space-y-4">
-                {bookQuotes.map((q, i) => (
-                  <figure
-                    key={i}
-                    className={`relative rounded-2xl border p-6 pl-8 ${getAccent(book)}`}
-                  >
-                    <span
-                      aria-hidden="true"
-                      className="absolute top-3 left-3 text-rose-400/30 font-serif text-5xl leading-none select-none"
+                {bookQuotes.map((q, i) => {
+                  const quoteId = `q-${book.slug}-${i + 1}`;
+                  // Permalink prefers the canonical book page anchor (deeper SEO surface)
+                  const permalink = `${SITE_URL}/library/${book.slug}#${quoteId}`;
+                  return (
+                    <figure
+                      key={i}
+                      id={quoteId}
+                      tabIndex={0}
+                      data-shareable="quote"
+                      data-quote-text={q.text}
+                      data-quote-author={book.author}
+                      data-quote-source={book.title}
+                      data-quote-permalink={permalink}
+                      className={`relative rounded-2xl border p-6 pl-8 scroll-mt-24 outline-none focus-visible:ring-2 focus-visible:ring-rose-400/30 ${getAccent(book)}`}
                     >
-                      &ldquo;
-                    </span>
-                    <blockquote className="text-white/85 leading-relaxed text-[16px] font-light italic">
-                      {q.text}
-                    </blockquote>
-                    {(q.chapter || q.context) && (
-                      <figcaption className="mt-4 pt-4 border-t border-white/[0.04] space-y-1.5">
-                        {q.chapter && (
-                          <p className="text-[11px] uppercase tracking-[0.15em] text-rose-400/60">
-                            {q.chapter}
-                          </p>
-                        )}
-                        {q.context && (
-                          <p className="text-[13.5px] text-white/50 leading-relaxed">
-                            {q.context}
-                          </p>
-                        )}
-                      </figcaption>
-                    )}
-                  </figure>
-                ))}
+                      <span
+                        aria-hidden="true"
+                        className="absolute top-3 left-3 text-rose-400/30 font-serif text-5xl leading-none select-none"
+                      >
+                        &ldquo;
+                      </span>
+                      <blockquote className="text-white/85 leading-relaxed text-[16px] font-light italic">
+                        {q.text}
+                      </blockquote>
+                      {(q.chapter || q.context) && (
+                        <figcaption className="mt-4 pt-4 border-t border-white/[0.04] space-y-1.5">
+                          {q.chapter && (
+                            <p className="text-[11px] uppercase tracking-[0.15em] text-rose-400/60">
+                              {q.chapter}
+                            </p>
+                          )}
+                          {q.context && (
+                            <p className="text-[13.5px] text-white/50 leading-relaxed">
+                              {q.context}
+                            </p>
+                          )}
+                        </figcaption>
+                      )}
+                    </figure>
+                  );
+                })}
               </div>
 
               {/* Book CTA */}

--- a/components/share/QuoteShareToolbar.tsx
+++ b/components/share/QuoteShareToolbar.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+/**
+ * QuoteShareToolbar — selection-based share + per-quote action bar.
+ *
+ * UX pattern: Medium / NYT / Substack
+ *
+ * Renders nothing visually until:
+ *   (a) user selects text inside a `[data-shareable="quote"]` region,
+ *       OR
+ *   (b) user hovers / focuses on a `[data-shareable="quote"]` region.
+ *
+ * Then a floating pill appears anchored to the selection (or the figure)
+ * with: X (Twitter), LinkedIn, Copy Link, native Web Share (mobile).
+ *
+ * Each shareable region must declare:
+ *   data-shareable="quote"
+ *   data-quote-text="..."           (the verbatim quote text)
+ *   data-quote-author="..."         (book author)
+ *   data-quote-source="..."         (book title)
+ *   data-quote-permalink="..."      (absolute URL incl. anchor #q-N)
+ *
+ * Accessibility: keyboard users can Tab to a quote (figures are tab-focusable
+ * via tabIndex=0) and press 'S' to invoke share; Enter copies link.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+type ShareIntent = {
+  text: string;
+  author: string;
+  source: string;
+  permalink: string;
+};
+
+const SITE_URL = 'https://frankx.ai';
+
+function buildTwitterUrl({ text, author, source, permalink }: ShareIntent) {
+  const body = `"${text}"\n\n— ${author}, ${source}`;
+  const params = new URLSearchParams({ text: body, url: permalink });
+  return `https://twitter.com/intent/tweet?${params.toString()}`;
+}
+
+function buildLinkedInUrl({ permalink }: ShareIntent) {
+  const params = new URLSearchParams({ url: permalink });
+  return `https://www.linkedin.com/sharing/share-offsite/?${params.toString()}`;
+}
+
+function buildCopyText({ text, author, source, permalink }: ShareIntent) {
+  return `"${text}"\n\n— ${author}, ${source}\n${permalink}`;
+}
+
+function findShareableTarget(node: Node | null): HTMLElement | null {
+  let current: Node | null = node;
+  while (current) {
+    if (current.nodeType === Node.ELEMENT_NODE) {
+      const el = current as HTMLElement;
+      if (el.dataset?.shareable === 'quote') return el;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function readIntent(el: HTMLElement): ShareIntent | null {
+  const text = el.dataset.quoteText;
+  const author = el.dataset.quoteAuthor;
+  const source = el.dataset.quoteSource;
+  const permalink = el.dataset.quotePermalink;
+  if (!text || !author || !source || !permalink) return null;
+  // Build absolute permalink if relative
+  const fullPermalink = permalink.startsWith('http')
+    ? permalink
+    : `${SITE_URL}${permalink}`;
+  return { text, author, source, permalink: fullPermalink };
+}
+
+export function QuoteShareToolbar() {
+  const [intent, setIntent] = useState<ShareIntent | null>(null);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [hasNativeShare, setHasNativeShare] = useState(false);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && 'share' in navigator) {
+      setHasNativeShare(true);
+    }
+  }, []);
+
+  // Show toolbar based on selection within shareable region
+  useEffect(() => {
+    function onSelectionChange() {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+        // No selection — only hide if not currently hovering toolbar
+        if (!toolbarRef.current?.matches(':hover')) {
+          setIntent(null);
+          setPosition(null);
+        }
+        return;
+      }
+
+      const range = sel.getRangeAt(0);
+      const target = findShareableTarget(range.commonAncestorContainer);
+      if (!target) {
+        setIntent(null);
+        setPosition(null);
+        return;
+      }
+
+      const newIntent = readIntent(target);
+      if (!newIntent) return;
+
+      // Position toolbar above the selection
+      const rect = range.getBoundingClientRect();
+      const top = rect.top + window.scrollY - 56;
+      const left = rect.left + rect.width / 2 + window.scrollX;
+      setIntent(newIntent);
+      setPosition({ top, left });
+      setCopied(false);
+    }
+
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => document.removeEventListener('selectionchange', onSelectionChange);
+  }, []);
+
+  // Keyboard shortcut: when focus is on a [data-shareable="quote"] figure,
+  // pressing 'S' opens share for the whole quote
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key.toLowerCase() !== 's' || e.metaKey || e.ctrlKey || e.altKey) return;
+      const active = document.activeElement;
+      if (!active) return;
+      const target = findShareableTarget(active);
+      if (!target) return;
+      const rect = target.getBoundingClientRect();
+      const newIntent = readIntent(target);
+      if (!newIntent) return;
+      e.preventDefault();
+      setIntent(newIntent);
+      setPosition({
+        top: rect.top + window.scrollY - 56,
+        left: rect.left + rect.width / 2 + window.scrollX,
+      });
+      setCopied(false);
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  // Dismiss on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && intent) {
+        setIntent(null);
+        setPosition(null);
+        window.getSelection()?.removeAllRanges();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [intent]);
+
+  if (!intent || !position) return null;
+
+  async function onCopy() {
+    if (!intent) return;
+    try {
+      await navigator.clipboard.writeText(buildCopyText(intent));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // Fallback — silent fail; copy intent failed
+    }
+  }
+
+  async function onNativeShare() {
+    if (!intent) return;
+    try {
+      await navigator.share({
+        title: intent.source,
+        text: `"${intent.text}" — ${intent.author}, ${intent.source}`,
+        url: intent.permalink,
+      });
+    } catch {
+      // User cancelled — silent
+    }
+  }
+
+  return (
+    <div
+      ref={toolbarRef}
+      role="toolbar"
+      aria-label="Share this quote"
+      className="pointer-events-auto fixed z-50 -translate-x-1/2 transition-opacity"
+      style={{
+        top: position.top,
+        left: position.left,
+      }}
+    >
+      <div className="flex items-center gap-1 rounded-full border border-white/10 bg-[#0a0a0b]/95 backdrop-blur shadow-xl shadow-black/40 px-1.5 py-1.5">
+        <a
+          href={buildTwitterUrl(intent)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Share on X (Twitter)"
+          className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+        </a>
+
+        <a
+          href={buildLinkedInUrl(intent)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Share on LinkedIn"
+          className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+          </svg>
+        </a>
+
+        <button
+          type="button"
+          onClick={onCopy}
+          aria-label={copied ? 'Copied to clipboard' : 'Copy quote and link'}
+          className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          {copied ? (
+            <svg className="w-4 h-4 text-emerald-300" viewBox="0 0 24 24" fill="none" strokeWidth={2.5} stroke="currentColor" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" strokeWidth={2} stroke="currentColor" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+            </svg>
+          )}
+        </button>
+
+        {hasNativeShare && (
+          <button
+            type="button"
+            onClick={onNativeShare}
+            aria-label="Share via system share sheet"
+            className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" strokeWidth={2} stroke="currentColor" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
+            </svg>
+          </button>
+        )}
+
+        {/* Caret pointing to the selection */}
+        <span
+          aria-hidden
+          className="absolute left-1/2 -bottom-1 -translate-x-1/2 w-2 h-2 rotate-45 bg-[#0a0a0b]/95 border-r border-b border-white/10"
+        />
+      </div>
+
+      {/* Copy success toast */}
+      {copied && (
+        <div className="absolute left-1/2 -translate-x-1/2 mt-3 px-3 py-1.5 rounded-full bg-emerald-500/15 text-emerald-200 border border-emerald-500/25 text-[11px] font-medium whitespace-nowrap">
+          Quote + link copied
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Medium / NYT / Substack-style selection-based share toolbar on every quote across `/library/{slug}` and `/library/quotes`. Users highlight any line → floating glass-pill appears → share to X / LinkedIn / Copy / native Web Share.

## What changes

- **New component**: `components/share/QuoteShareToolbar.tsx` — single client component, ~270 lines, no new deps. Listens to `selectionchange`, anchors a floating toolbar to the selection rectangle, builds X/LinkedIn/Copy intents from `data-quote-*` attributes.
- **Per-quote permalinks**: every quote `<figure>` now has `id="q-{slug}-{n}"` so any quote can be linked directly (e.g. `frankx.ai/library/atomic-habits#q-atomic-habits-3`).
- **Tabbable quotes**: `<figure tabIndex={0}>` + focus-visible ring → keyboard users can Tab to any quote and press `S` to share.
- **Aggregation page deep-links to canonical book page**: `/library/quotes` quotes use `…/library/{slug}#q-…` permalinks (more SEO surface than self-anchor).
- **Mobile-aware**: native Web Share API button only renders when `navigator.share` exists.

## UX details

- Toolbar uses `position: fixed` + `transform: translate(-50%)` to anchor above selection
- Caret triangle points down to the selected text
- Copy button shows checkmark + ephemeral "Quote + link copied" toast
- Selection auto-clears on Escape
- Inline tip below quote sections: "highlight to share, press S for keyboard share"

## Reusability

Drop `<QuoteShareToolbar />` at any page root + decorate any element with:

```html
data-shareable="quote"
data-quote-text="..."
data-quote-author="..."
data-quote-source="..."
data-quote-permalink="..."
```

Works on any page, any content type. Future expansion to gencreator/SIS/ultraworld is mechanical.

## Test plan

- [ ] Vercel preview builds clean
- [ ] Highlight quote on `/library/atomic-habits` → toolbar appears with X / LinkedIn / Copy / (mobile: Web Share)
- [ ] Click X → opens `twitter.com/intent/tweet` with quote + author + URL pre-filled
- [ ] Click LinkedIn → opens LinkedIn share-offsite dialog with permalink
- [ ] Click Copy → ephemeral "Quote + link copied" toast; pasted text matches `"<quote>"\n\n— Author, Book\nURL`
- [ ] Press `Tab` to focus a quote, press `S` → toolbar appears with full quote selected
- [ ] Press Escape → toolbar dismisses, selection clears
- [ ] Mobile: long-press to select → tap Web Share → native iOS/Android share sheet
- [ ] `/library/quotes` quotes link back to canonical book page anchor (not self)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share quotes directly to Twitter/X and LinkedIn
  * Copy quotes with permalinks to clipboard
  * Highlight any quote to access sharing options
  * Keyboard shortcuts: 'S' to open share menu, 'Escape' to dismiss
  * Native system share button when supported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->