### PR TITLE
feat(library): per-quote pages + dynamic OG images + /api/quote endpoints

### DIFF
--- a/app/api/quote/random/route.ts
+++ b/app/api/quote/random/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { bookReviews } from '@/data/book-reviews';
+
+const SITE_URL = 'https://frankx.ai';
+
+export const runtime = 'edge';
+// 5-minute Vercel edge cache — random doesn't need to be perfectly random per call,
+// and caching dramatically reduces cold-start cost
+export const revalidate = 300;
+
+type ApiQuote = {
+  text: string;
+  chapter: string | null;
+  context: string | null;
+  author: string;
+  source: string;
+  sourceSlug: string;
+  permalink: string;
+  shareImage: string;
+};
+
+function flatten(): ApiQuote[] {
+  const all: ApiQuote[] = [];
+  for (const book of bookReviews) {
+    if (!book.quotes) continue;
+    book.quotes.forEach((q, i) => {
+      const n = i + 1;
+      all.push({
+        text: q.text,
+        chapter: q.chapter ?? null,
+        context: q.context ?? null,
+        author: book.author,
+        source: book.title,
+        sourceSlug: book.slug,
+        permalink: `${SITE_URL}/library/${book.slug}/q/${n}`,
+        shareImage: `${SITE_URL}/library/${book.slug}/q/${n}/opengraph-image`,
+      });
+    });
+  }
+  return all;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const author = url.searchParams.get('author');
+  const slug = url.searchParams.get('book');
+  const count = Math.min(Math.max(parseInt(url.searchParams.get('count') ?? '1', 10), 1), 20);
+
+  let pool = flatten();
+  if (author) {
+    pool = pool.filter((q) => q.author.toLowerCase().includes(author.toLowerCase()));
+  }
+  if (slug) {
+    pool = pool.filter((q) => q.sourceSlug === slug);
+  }
+
+  if (pool.length === 0) {
+    return NextResponse.json(
+      { error: 'No quotes match the given filters', total: 0 },
+      { status: 404 }
+    );
+  }
+
+  const picks: ApiQuote[] = [];
+  const taken = new Set<number>();
+  while (picks.length < count && taken.size < pool.length) {
+    const idx = Math.floor(Math.random() * pool.length);
+    if (taken.has(idx)) continue;
+    taken.add(idx);
+    picks.push(pool[idx]);
+  }
+
+  return NextResponse.json(
+    {
+      count: picks.length,
+      total: pool.length,
+      quotes: picks,
+      meta: {
+        source: 'frankx.ai/library',
+        license: 'Quotes excerpted under fair use for review and commentary purposes.',
+        attribution_required: true,
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': 's-maxage=60, stale-while-revalidate=300',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }
+  );
+}

--- a/app/api/quote/today/route.ts
+++ b/app/api/quote/today/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { bookReviews } from '@/data/book-reviews';
+
+const SITE_URL = 'https://frankx.ai';
+
+export const runtime = 'edge';
+
+type ApiQuote = {
+  text: string;
+  chapter: string | null;
+  context: string | null;
+  author: string;
+  source: string;
+  sourceSlug: string;
+  permalink: string;
+  shareImage: string;
+};
+
+function flatten(): ApiQuote[] {
+  const all: ApiQuote[] = [];
+  for (const book of bookReviews) {
+    if (!book.quotes) continue;
+    book.quotes.forEach((q, i) => {
+      const n = i + 1;
+      all.push({
+        text: q.text,
+        chapter: q.chapter ?? null,
+        context: q.context ?? null,
+        author: book.author,
+        source: book.title,
+        sourceSlug: book.slug,
+        permalink: `${SITE_URL}/library/${book.slug}/q/${n}`,
+        shareImage: `${SITE_URL}/library/${book.slug}/q/${n}/opengraph-image`,
+      });
+    });
+  }
+  return all;
+}
+
+// Fast, deterministic 32-bit hash — turns YYYY-MM-DD into a stable index
+function hashString(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function todayKey(timezone = 'UTC') {
+  const now = new Date();
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return fmt.format(now); // YYYY-MM-DD
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const tz = url.searchParams.get('tz') ?? 'UTC';
+
+  const pool = flatten();
+  if (pool.length === 0) {
+    return NextResponse.json({ error: 'No quotes available', total: 0 }, { status: 503 });
+  }
+
+  const day = todayKey(tz);
+  const idx = hashString(day) % pool.length;
+  const quote = pool[idx];
+
+  return NextResponse.json(
+    {
+      date: day,
+      timezone: tz,
+      total: pool.length,
+      quote,
+      meta: {
+        source: 'frankx.ai/library',
+        license: 'Quotes excerpted under fair use for review and commentary purposes.',
+        attribution_required: true,
+        rotation: 'deterministic by UTC date — same quote for every caller within a 24h window',
+      },
+    },
+    {
+      headers: {
+        // Cache for 5 minutes; the value only changes once per day so this is safe and cheap
+        'Cache-Control': 's-maxage=300, stale-while-revalidate=3600',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }
+  );
+}

--- a/app/library/[slug]/page.tsx
+++ b/app/library/[slug]/page.tsx
@@ -368,7 +368,10 @@ export default async function ReviewPage({
           <div className="space-y-4">
             {review.quotes.map((quote, i) => {
               const quoteId = `q-${review.slug}-${i + 1}`;
-              const permalink = `${SITE_URL}/library/${review.slug}#${quoteId}`;
+              // Permalink points at the dedicated /q/{n} page so social shares
+              // get the per-quote OpenGraph image. Anchor still works for
+              // in-page navigation; the share URL is what amplifies.
+              const permalink = `${SITE_URL}/library/${review.slug}/q/${i + 1}`;
               return (
                 <figure
                   key={i}

--- a/app/library/[slug]/q/[n]/opengraph-image.tsx
+++ b/app/library/[slug]/q/[n]/opengraph-image.tsx
@@ -1,0 +1,182 @@
+import { ImageResponse } from 'next/og';
+import { getReviewBySlug } from '@/data/book-reviews';
+
+export const runtime = 'edge';
+export const alt = 'Quote from the FrankX Library';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+/**
+ * Renders a 1200x630 PNG card per quote.
+ * Picked up automatically by Next.js for the route's OpenGraph image.
+ *
+ * Design: dark background matching site, rose accent, Inter-ish system font.
+ * Text scales based on quote length so long quotes don't overflow.
+ */
+export default async function Image({
+  params,
+}: {
+  params: { slug: string; n: string };
+}) {
+  const review = getReviewBySlug(params.slug);
+  const idx = parseInt(params.n, 10) - 1;
+  const quote = review?.quotes?.[idx];
+
+  // Fallback for unknown slug/index — minimal card so social previews don't 500
+  if (!review || !quote) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#0a0a0b',
+            color: 'white',
+            fontSize: 48,
+            fontFamily: 'system-ui, -apple-system, sans-serif',
+          }}
+        >
+          The FrankX Library
+        </div>
+      ),
+      { ...size }
+    );
+  }
+
+  const text = quote.text;
+  // Scale the type to fit. Aim for ~12-18 visual lines of body text.
+  const len = text.length;
+  let fontSize = 56;
+  if (len > 90) fontSize = 48;
+  if (len > 160) fontSize = 40;
+  if (len > 240) fontSize = 34;
+  if (len > 340) fontSize = 28;
+
+  const accent = '#fb7185'; // rose-400 (matches site)
+  const subtle = 'rgba(255,255,255,0.55)';
+  const muted = 'rgba(255,255,255,0.30)';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          background: '#0a0a0b',
+          backgroundImage:
+            'radial-gradient(circle at 20% 20%, rgba(251,113,133,0.10), transparent 50%), radial-gradient(circle at 80% 80%, rgba(217,119,6,0.08), transparent 50%)',
+          color: 'white',
+          padding: '72px 88px',
+          fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+          position: 'relative',
+        }}
+      >
+        {/* Top eyebrow */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            fontSize: 18,
+            letterSpacing: 6,
+            textTransform: 'uppercase',
+            color: accent,
+            opacity: 0.85,
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>FrankX Library</span>
+          <span style={{ color: muted }}>·</span>
+          <span style={{ color: subtle, letterSpacing: 4 }}>The Quote Vault</span>
+        </div>
+
+        {/* Big opening quote mark */}
+        <div
+          style={{
+            display: 'flex',
+            color: accent,
+            opacity: 0.45,
+            fontSize: 200,
+            lineHeight: 0.6,
+            fontFamily: 'Georgia, serif',
+            marginTop: 28,
+            marginBottom: -40,
+          }}
+        >
+          “
+        </div>
+
+        {/* Quote */}
+        <div
+          style={{
+            display: 'flex',
+            flex: 1,
+            alignItems: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontSize,
+              lineHeight: 1.25,
+              fontWeight: 300,
+              fontStyle: 'italic',
+              color: 'rgba(255,255,255,0.95)',
+              maxWidth: '100%',
+              letterSpacing: -0.2,
+            }}
+          >
+            {text}
+          </div>
+        </div>
+
+        {/* Attribution */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            marginTop: 32,
+            paddingTop: 24,
+            borderTop: '1px solid rgba(255,255,255,0.08)',
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ fontSize: 24, color: 'rgba(255,255,255,0.85)', fontWeight: 500 }}>
+              {review.author}
+            </div>
+            <div style={{ fontSize: 18, color: subtle }}>{review.title}</div>
+            {quote.chapter && (
+              <div
+                style={{
+                  fontSize: 14,
+                  color: muted,
+                  letterSpacing: 2,
+                  textTransform: 'uppercase',
+                  marginTop: 4,
+                }}
+              >
+                {quote.chapter}
+              </div>
+            )}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 16,
+              color: muted,
+              letterSpacing: 4,
+              textTransform: 'uppercase',
+            }}
+          >
+            frankx.ai/library
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/library/[slug]/q/[n]/page.tsx
+++ b/app/library/[slug]/q/[n]/page.tsx
@@ -1,0 +1,321 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import { bookReviews, getReviewBySlug, getAllReviewSlugs } from '@/data/book-reviews';
+import { booksRegistry } from '@/app/books/lib/books-registry';
+import { QuoteShareToolbar } from '@/components/share/QuoteShareToolbar';
+
+const SITE_URL = 'https://frankx.ai';
+
+export function generateStaticParams() {
+  const params: Array<{ slug: string; n: string }> = [];
+  for (const slug of getAllReviewSlugs()) {
+    const review = getReviewBySlug(slug);
+    if (!review?.quotes) continue;
+    for (let i = 0; i < review.quotes.length; i++) {
+      params.push({ slug, n: String(i + 1) });
+    }
+  }
+  return params;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; n: string }>;
+}): Promise<Metadata> {
+  const { slug, n } = await params;
+  const review = getReviewBySlug(slug);
+  const idx = parseInt(n, 10) - 1;
+  const quote = review?.quotes?.[idx];
+  if (!review || !quote) return {};
+
+  const url = `${SITE_URL}/library/${slug}/q/${n}`;
+  // Use the quote text itself as the description — works for OG, Twitter, search
+  const description = `"${quote.text}" — ${review.author}, ${review.title}`;
+
+  return {
+    title: `"${quote.text.slice(0, 60)}${quote.text.length > 60 ? '…' : ''}" — ${review.author}`,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: `${review.author} — ${review.title}`,
+      description: quote.text,
+      type: 'article',
+      url,
+      siteName: 'FrankX Library',
+      authors: [review.author],
+      // The opengraph-image.tsx in this folder is auto-picked up by Next.js
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${review.author} — ${review.title}`,
+      description: quote.text,
+    },
+  };
+}
+
+function QuoteJsonLd({
+  quote,
+  review,
+  url,
+}: {
+  quote: { text: string; chapter?: string };
+  review: { title: string; author: string; slug: string };
+  url: string;
+}) {
+  const data = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+          { '@type': 'ListItem', position: 2, name: 'Library', item: `${SITE_URL}/library` },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: review.title,
+            item: `${SITE_URL}/library/${review.slug}`,
+          },
+          { '@type': 'ListItem', position: 4, name: 'Quote', item: url },
+        ],
+      },
+      {
+        '@type': 'Quotation',
+        text: quote.text,
+        spokenByCharacter: { '@type': 'Person', name: review.author },
+        isPartOf: {
+          '@type': 'Book',
+          name: review.title,
+          author: { '@type': 'Person', name: review.author },
+          url: `${SITE_URL}/library/${review.slug}`,
+        },
+        url,
+      },
+    ],
+  };
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}
+
+export default async function QuotePage({
+  params,
+}: {
+  params: Promise<{ slug: string; n: string }>;
+}) {
+  const { slug, n } = await params;
+  const review = getReviewBySlug(slug);
+  const idx = parseInt(n, 10) - 1;
+  const quote = review?.quotes?.[idx];
+  if (!review || !quote) notFound();
+
+  const url = `${SITE_URL}/library/${slug}/q/${n}`;
+  const quoteId = `q-${slug}-${n}`;
+  const totalQuotes = review.quotes!.length;
+  const prevN = idx > 0 ? idx : null;
+  const nextN = idx < totalQuotes - 1 ? idx + 2 : null;
+
+  const relatedBook = review.relatedBook
+    ? booksRegistry.find((b) => b.slug === review.relatedBook)
+    : null;
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0b] text-white flex flex-col">
+      <QuoteJsonLd quote={quote} review={review} url={url} />
+      <QuoteShareToolbar />
+
+      {/* Top breadcrumb */}
+      <header className="max-w-4xl w-full mx-auto px-6 pt-12 pb-4">
+        <nav aria-label="Breadcrumb" className="text-[12px] text-white/40">
+          <Link href="/library" className="hover:text-white/70 transition-colors">
+            Library
+          </Link>
+          <span className="mx-2 text-white/20">/</span>
+          <Link
+            href={`/library/${slug}`}
+            className="hover:text-white/70 transition-colors"
+          >
+            {review.title}
+          </Link>
+          <span className="mx-2 text-white/20">/</span>
+          <span className="text-white/60">Quote {n} of {totalQuotes}</span>
+        </nav>
+      </header>
+
+      {/* The quote */}
+      <main className="flex-1 flex items-center px-6">
+        <div className="max-w-3xl mx-auto py-16">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-rose-400/70 mb-8 text-center">
+            From the FrankX Library
+          </p>
+
+          <figure
+            id={quoteId}
+            tabIndex={0}
+            data-shareable="quote"
+            data-quote-text={quote.text}
+            data-quote-author={review.author}
+            data-quote-source={review.title}
+            data-quote-permalink={url}
+            className="relative outline-none focus-visible:ring-2 focus-visible:ring-rose-400/30 rounded-2xl"
+          >
+            <span
+              aria-hidden
+              className="block text-rose-400/30 font-serif text-7xl md:text-9xl leading-none text-center mb-2 select-none"
+            >
+              &ldquo;
+            </span>
+            <blockquote className="text-2xl md:text-4xl leading-snug font-light italic text-white/90 text-center max-w-2xl mx-auto">
+              {quote.text}
+            </blockquote>
+            <figcaption className="mt-12 text-center space-y-3">
+              <p className="text-[15px] md:text-base text-white/60">
+                — <span className="font-medium text-white/85">{review.author}</span>
+              </p>
+              <Link
+                href={`/library/${slug}`}
+                className="inline-block text-[14px] text-amber-300/80 hover:text-amber-200 transition-colors"
+              >
+                {review.title}
+              </Link>
+              {quote.chapter && (
+                <p className="text-[11px] uppercase tracking-[0.18em] text-rose-400/55">
+                  {quote.chapter}
+                </p>
+              )}
+              {quote.context && (
+                <p className="text-[14px] text-white/50 italic max-w-xl mx-auto pt-2">
+                  {quote.context}
+                </p>
+              )}
+            </figcaption>
+          </figure>
+
+          <p className="mt-10 text-center text-[12px] text-white/30">
+            Highlight any line above to share, or press{' '}
+            <kbd className="px-1.5 py-0.5 rounded bg-white/5 border border-white/10 font-mono text-[10px]">
+              S
+            </kbd>{' '}
+            with the quote focused.
+          </p>
+        </div>
+      </main>
+
+      {/* Navigation between quotes */}
+      <nav
+        aria-label="Quote navigation"
+        className="border-t border-white/[0.06] bg-white/[0.01]"
+      >
+        <div className="max-w-4xl mx-auto px-6 py-6 flex items-center justify-between gap-4">
+          {prevN ? (
+            <Link
+              href={`/library/${slug}/q/${prevN}`}
+              className="group flex items-center gap-2 text-[13px] text-white/60 hover:text-white transition-colors"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                aria-hidden
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                />
+              </svg>
+              <span>Previous quote</span>
+            </Link>
+          ) : (
+            <span aria-hidden className="opacity-0 pointer-events-none">.</span>
+          )}
+
+          <Link
+            href={`/library/${slug}#${quoteId}`}
+            className="text-[12px] uppercase tracking-[0.18em] text-white/40 hover:text-white/70 transition-colors"
+          >
+            Read in full deep-dive
+          </Link>
+
+          {nextN ? (
+            <Link
+              href={`/library/${slug}/q/${nextN}`}
+              className="group flex items-center gap-2 text-[13px] text-white/60 hover:text-white transition-colors"
+            >
+              <span>Next quote</span>
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                aria-hidden
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+                />
+              </svg>
+            </Link>
+          ) : (
+            <span aria-hidden className="opacity-0 pointer-events-none">.</span>
+          )}
+        </div>
+      </nav>
+
+      {/* Footer CTAs */}
+      <section className="border-t border-white/[0.06] py-10">
+        <div className="max-w-4xl mx-auto px-6 grid grid-cols-1 sm:grid-cols-3 gap-3 text-center text-[13px]">
+          <Link
+            href={`/library/${slug}`}
+            className="rounded-xl border border-white/[0.06] bg-white/[0.02] hover:bg-white/[0.04] hover:border-white/[0.12] py-4 px-3 transition-all"
+          >
+            <p className="text-white/40 text-[10px] uppercase tracking-[0.18em] mb-1">
+              Full deep-dive
+            </p>
+            <p className="text-white/85">{review.title}</p>
+          </Link>
+          <Link
+            href="/library/quotes"
+            className="rounded-xl border border-rose-500/15 bg-rose-500/[0.04] hover:bg-rose-500/[0.07] py-4 px-3 transition-all"
+          >
+            <p className="text-rose-300/60 text-[10px] uppercase tracking-[0.18em] mb-1">
+              Browse all quotes
+            </p>
+            <p className="text-white/85">The Quote Vault</p>
+          </Link>
+          {relatedBook ? (
+            <Link
+              href={`/books/${relatedBook.slug}`}
+              className="rounded-xl border border-violet-500/15 bg-violet-500/[0.04] hover:bg-violet-500/[0.07] py-4 px-3 transition-all"
+            >
+              <p className="text-violet-300/60 text-[10px] uppercase tracking-[0.18em] mb-1">
+                Our companion book
+              </p>
+              <p className="text-white/85">{relatedBook.title}</p>
+            </Link>
+          ) : (
+            <Link
+              href="/library/approach"
+              className="rounded-xl border border-amber-500/15 bg-amber-500/[0.04] hover:bg-amber-500/[0.07] py-4 px-3 transition-all"
+            >
+              <p className="text-amber-300/60 text-[10px] uppercase tracking-[0.18em] mb-1">
+                The system
+              </p>
+              <p className="text-white/85">How this library is built</p>
+            </Link>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/library/quotes/page.tsx
+++ b/app/library/quotes/page.tsx
@@ -272,8 +272,9 @@ export default function LibraryQuotesPage() {
               <div className="space-y-4">
                 {bookQuotes.map((q, i) => {
                   const quoteId = `q-${book.slug}-${i + 1}`;
-                  // Permalink prefers the canonical book page anchor (deeper SEO surface)
-                  const permalink = `${SITE_URL}/library/${book.slug}#${quoteId}`;
+                  // Permalink points at the dedicated /q/{n} page so social
+                  // shares get the per-quote OpenGraph image card.
+                  const permalink = `${SITE_URL}/library/${book.slug}/q/${i + 1}`;
                   return (
                     <figure
                       key={i}


### PR DESCRIPTION
## Summary

Three v2 deliverables for the Library OS quote-share system:

### 1. Per-quote landing pages — `/library/{slug}/q/{n}`

- ~280 dedicated focused-quote routes generated via `generateStaticParams`
- Quote rendered hero-size, italic, centered, with cover-author-book-chapter attribution
- Inherits existing QuoteShareToolbar (highlight-to-share works here too)
- Prev/next quote navigation + breadcrumb + "Read in deep-dive" CTA
- JSON-LD: BreadcrumbList + Quotation schema with `isPartOf` Book

### 2. Dynamic OpenGraph image generation

- `app/library/[slug]/q/[n]/opengraph-image.tsx` — Next.js Edge runtime, `ImageResponse` API
- 1200×630 PNG: dark gradient background, rose accent, italic quote
- Auto-scales font 28-56pt by length (28pt for 340+ chars; 56pt for short)
- Author + book + chapter attribution + frankx.ai branding
- Auto-picked up by Next.js as the OG image for each `/q/{n}` URL
- **Every shared quote URL now generates a unique branded preview card** for Twitter, LinkedIn, Slack, Discord, Telegram, etc.

### 3. JSON API endpoints

- `GET /api/quote/random` — random quote, supports `?author=`, `?book=`, `?count=N` (1-20). 5-min edge cache. CORS-enabled.
- `GET /api/quote/today` — deterministic daily quote (FNV-1a hash of UTC date), `?tz=` timezone. Same value for every caller in a 24h window — perfect for newsletter integration and stable embeds.
- Both edge runtime, return `permalink` + `shareImage` URL alongside quote.

## Permalink format updated

QuoteShareToolbar permalinks now point at `/library/{slug}/q/{n}` so every social share carries the per-quote OG image. Anchor permalinks (`#q-{slug}-{n}`) preserved for in-page navigation.

## Files

- `app/library/[slug]/q/[n]/page.tsx` (NEW)
- `app/library/[slug]/q/[n]/opengraph-image.tsx` (NEW)
- `app/api/quote/random/route.ts` (NEW)
- `app/api/quote/today/route.ts` (NEW)
- `app/library/[slug]/page.tsx` (permalink format)
- `app/library/quotes/page.tsx` (permalink format)

Pushed via gh-api Contents endpoint (disk-full workaround using documented memory pattern).

## Test plan

- [ ] Vercel preview builds clean
- [ ] `/library/atomic-habits/q/1` returns HTTP 200 with quote rendered hero-size
- [ ] `/library/atomic-habits/q/1/opengraph-image` returns 1200×630 PNG
- [ ] `/api/quote/random` returns JSON with random quote
- [ ] `/api/quote/today` returns same quote on repeated calls within UTC day
- [ ] Sharing a quote on Twitter from `/library/atomic-habits` previews with the per-quote OG card

🤖 Generated with [Claude Code](https://claude.com/claude-code)