### PR TITLE
fix(library/share): mobile-aware QuoteShareToolbar v2

### DIFF
--- a/app/library/rss.xml/route.ts
+++ b/app/library/rss.xml/route.ts
@@ -1,0 +1,61 @@
+import { bookReviews } from '@/data/book-reviews'
+
+const SITE_URL = 'https://frankx.ai'
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export async function GET() {
+  const sorted = [...bookReviews].sort((a, b) => {
+    const dateA = a.reviewDate ? new Date(a.reviewDate).getTime() : 0
+    const dateB = b.reviewDate ? new Date(b.reviewDate).getTime() : 0
+    return dateB - dateA
+  })
+
+  const items = sorted
+    .map((book) => {
+      const link = `${SITE_URL}/library/${book.slug}`
+      const pubDate = book.reviewDate
+        ? new Date(book.reviewDate).toUTCString()
+        : new Date().toUTCString()
+      const description = book.tldr || book.keyInsights?.[0] || `${book.title} by ${book.author}`
+      const categoryLine = (book.categories || [])
+        .map((c) => `      <category>${escapeXml(c)}</category>`)
+        .join('\n')
+      return `    <item>
+      <title>${escapeXml(book.title)} — ${escapeXml(book.author)}</title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <description>${escapeXml(description)}</description>
+      <pubDate>${pubDate}</pubDate>
+${categoryLine}
+    </item>`
+    })
+    .join('\n')
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>FrankX Library — book deep-dives</title>
+    <link>${SITE_URL}/library</link>
+    <description>Permanent deep-dives on every book Frank reads — quotes, chapters, related reading, and videos.</description>
+    <language>en-us</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${SITE_URL}/library/rss.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { researchDomains } from '@/lib/research/domains'
+import { bookReviews } from '@/data/book-reviews'
 
 const BASE_URL = 'https://frankx.ai'
 
@@ -523,6 +524,34 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.7,
     })
+  })
+
+  // Library OS — index, manifesto, quotes aggregation
+  entries.push(
+    { url: `${BASE_URL}/library`, lastModified: currentDate, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${BASE_URL}/library/approach`, lastModified: currentDate, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE_URL}/library/quotes`, lastModified: currentDate, changeFrequency: 'weekly', priority: 0.8 },
+  )
+
+  // Per-book deep-dive pages + per-quote landing pages
+  bookReviews.forEach(book => {
+    const lastMod = book.reviewDate ? new Date(book.reviewDate).toISOString() : currentDate
+    entries.push({
+      url: `${BASE_URL}/library/${book.slug}`,
+      lastModified: lastMod,
+      changeFrequency: 'monthly',
+      priority: 0.85,
+    })
+    if (book.quotes && book.quotes.length > 0) {
+      book.quotes.forEach((_, idx) => {
+        entries.push({
+          url: `${BASE_URL}/library/${book.slug}/q/${idx + 1}`,
+          lastModified: lastMod,
+          changeFrequency: 'monthly',
+          priority: 0.6,
+        })
+      })
+    }
   })
 
   return entries

--- a/components/share/QuoteShareToolbar.tsx
+++ b/components/share/QuoteShareToolbar.tsx
@@ -1,27 +1,20 @@
 'use client';
 
 /**
- * QuoteShareToolbar — selection-based share + per-quote action bar.
+ * QuoteShareToolbar — selection-based (desktop) + tap-to-share (mobile).
  *
- * UX pattern: Medium / NYT / Substack
- *
- * Renders nothing visually until:
- *   (a) user selects text inside a `[data-shareable="quote"]` region,
- *       OR
- *   (b) user hovers / focuses on a `[data-shareable="quote"]` region.
- *
- * Then a floating pill appears anchored to the selection (or the figure)
- * with: X (Twitter), LinkedIn, Copy Link, native Web Share (mobile).
- *
- * Each shareable region must declare:
+ * Each shareable region declares:
  *   data-shareable="quote"
- *   data-quote-text="..."           (the verbatim quote text)
- *   data-quote-author="..."         (book author)
- *   data-quote-source="..."         (book title)
- *   data-quote-permalink="..."      (absolute URL incl. anchor #q-N)
+ *   data-quote-text="..."
+ *   data-quote-author="..."
+ *   data-quote-source="..."
+ *   data-quote-permalink="..."
  *
- * Accessibility: keyboard users can Tab to a quote (figures are tab-focusable
- * via tabIndex=0) and press 'S' to invoke share; Enter copies link.
+ * Desktop: floating toolbar appears above text selection inside a quote figure.
+ * Mobile (touch + coarse pointer): a "Tap to share" badge is injected into
+ * each figure on mount; tapping the figure opens the toolbar centered above it.
+ * Every share action raises a toast so the user gets confirmation that an
+ * intent fired even when it opens in a new tab.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -33,7 +26,11 @@ type ShareIntent = {
   permalink: string;
 };
 
+type Toast = { msg: string; tone: 'info' | 'success' | 'error' };
+
 const SITE_URL = 'https://frankx.ai';
+const TOAST_MS = 2400;
+const VIEWPORT_PADDING = 12;
 
 function buildTwitterUrl({ text, author, source, permalink }: ShareIntent) {
   const body = `"${text}"\n\n— ${author}, ${source}`;
@@ -68,19 +65,45 @@ function readIntent(el: HTMLElement): ShareIntent | null {
   const source = el.dataset.quoteSource;
   const permalink = el.dataset.quotePermalink;
   if (!text || !author || !source || !permalink) return null;
-  // Build absolute permalink if relative
   const fullPermalink = permalink.startsWith('http')
     ? permalink
     : `${SITE_URL}${permalink}`;
   return { text, author, source, permalink: fullPermalink };
 }
 
+function clampLeft(rawLeft: number, viewportWidth: number, toolbarWidth: number) {
+  const half = toolbarWidth / 2;
+  const minLeft = half + VIEWPORT_PADDING;
+  const maxLeft = viewportWidth - half - VIEWPORT_PADDING;
+  if (maxLeft < minLeft) return viewportWidth / 2;
+  return Math.max(minLeft, Math.min(rawLeft, maxLeft));
+}
+
+function useIsTouch() {
+  const [isTouch, setIsTouch] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(hover: none) and (pointer: coarse)');
+    setIsTouch(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsTouch(e.matches);
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else mq.addListener(onChange);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener('change', onChange);
+      else mq.removeListener(onChange);
+    };
+  }, []);
+  return isTouch;
+}
+
 export function QuoteShareToolbar() {
+  const isTouch = useIsTouch();
   const [intent, setIntent] = useState<ShareIntent | null>(null);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
-  const [copied, setCopied] = useState(false);
   const [hasNativeShare, setHasNativeShare] = useState(false);
+  const [toast, setToast] = useState<Toast | null>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (typeof navigator !== 'undefined' && 'share' in navigator) {
@@ -88,19 +111,41 @@ export function QuoteShareToolbar() {
     }
   }, []);
 
-  // Show toolbar based on selection within shareable region
+  function showToast(msg: string, tone: Toast['tone'] = 'info') {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setToast({ msg, tone });
+    toastTimerRef.current = setTimeout(() => setToast(null), TOAST_MS);
+  }
+
+  function toolbarWidthEstimate() {
+    return hasNativeShare ? 240 : 200;
+  }
+
+  function showToolbarForElement(el: HTMLElement) {
+    const newIntent = readIntent(el);
+    if (!newIntent) return;
+    const rect = el.getBoundingClientRect();
+    const rawLeft = rect.left + rect.width / 2 + window.scrollX;
+    const left = clampLeft(rawLeft, window.innerWidth, toolbarWidthEstimate());
+    const aboveTop = rect.top + window.scrollY - 56;
+    const belowTop = rect.bottom + window.scrollY + 12;
+    const top = aboveTop > window.scrollY + 8 ? aboveTop : belowTop;
+    setIntent(newIntent);
+    setPosition({ top, left });
+  }
+
+  // Selection-based behavior (desktop / non-touch)
   useEffect(() => {
+    if (isTouch) return;
     function onSelectionChange() {
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
-        // No selection — only hide if not currently hovering toolbar
         if (!toolbarRef.current?.matches(':hover')) {
           setIntent(null);
           setPosition(null);
         }
         return;
       }
-
       const range = sel.getRangeAt(0);
       const target = findShareableTarget(range.commonAncestorContainer);
       if (!target) {
@@ -108,25 +153,69 @@ export function QuoteShareToolbar() {
         setPosition(null);
         return;
       }
-
       const newIntent = readIntent(target);
       if (!newIntent) return;
-
-      // Position toolbar above the selection
       const rect = range.getBoundingClientRect();
-      const top = rect.top + window.scrollY - 56;
-      const left = rect.left + rect.width / 2 + window.scrollX;
+      const rawLeft = rect.left + rect.width / 2 + window.scrollX;
+      const left = clampLeft(rawLeft, window.innerWidth, toolbarWidthEstimate());
       setIntent(newIntent);
-      setPosition({ top, left });
-      setCopied(false);
+      setPosition({ top: rect.top + window.scrollY - 56, left });
     }
-
     document.addEventListener('selectionchange', onSelectionChange);
     return () => document.removeEventListener('selectionchange', onSelectionChange);
-  }, []);
+  }, [isTouch, hasNativeShare]);
 
-  // Keyboard shortcut: when focus is on a [data-shareable="quote"] figure,
-  // pressing 'S' opens share for the whole quote
+  // Tap-to-share (touch devices)
+  useEffect(() => {
+    if (!isTouch) return;
+    function onClick(e: MouseEvent) {
+      const root = e.target as Node;
+      if (toolbarRef.current?.contains(root)) return;
+      const target = findShareableTarget(root);
+      if (target) {
+        showToolbarForElement(target);
+      } else {
+        setIntent(null);
+        setPosition(null);
+      }
+    }
+    document.addEventListener('click', onClick);
+    return () => document.removeEventListener('click', onClick);
+  }, [isTouch, hasNativeShare]);
+
+  // Inject "Tap to share" affordance into each figure on touch devices
+  useEffect(() => {
+    if (!isTouch || typeof document === 'undefined') return;
+    const figures = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-shareable="quote"]'),
+    );
+    const cleanups: Array<() => void> = [];
+    figures.forEach((fig) => {
+      if (fig.dataset.shareBadgeInjected === 'true') return;
+      fig.dataset.shareBadgeInjected = 'true';
+      const computed = window.getComputedStyle(fig);
+      let restorePosition: string | null = null;
+      if (computed.position === 'static') {
+        restorePosition = fig.style.position;
+        fig.style.position = 'relative';
+      }
+      const badge = document.createElement('div');
+      badge.setAttribute('aria-hidden', 'true');
+      badge.dataset.shareFab = 'true';
+      badge.className =
+        'pointer-events-none absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-white/8 backdrop-blur px-2 py-0.5 text-[10px] uppercase tracking-wider text-white/60 border border-white/10';
+      badge.textContent = '↗ Tap to share';
+      fig.appendChild(badge);
+      cleanups.push(() => {
+        badge.remove();
+        delete fig.dataset.shareBadgeInjected;
+        if (restorePosition !== null) fig.style.position = restorePosition;
+      });
+    });
+    return () => cleanups.forEach((fn) => fn());
+  }, [isTouch]);
+
+  // 'S' shortcut on focused figure (keyboard / accessibility)
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (e.key.toLowerCase() !== 's' || e.metaKey || e.ctrlKey || e.altKey) return;
@@ -134,22 +223,14 @@ export function QuoteShareToolbar() {
       if (!active) return;
       const target = findShareableTarget(active);
       if (!target) return;
-      const rect = target.getBoundingClientRect();
-      const newIntent = readIntent(target);
-      if (!newIntent) return;
       e.preventDefault();
-      setIntent(newIntent);
-      setPosition({
-        top: rect.top + window.scrollY - 56,
-        left: rect.left + rect.width / 2 + window.scrollX,
-      });
-      setCopied(false);
+      showToolbarForElement(target as HTMLElement);
     }
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [hasNativeShare]);
 
-  // Dismiss on Escape
+  // Escape dismisses
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape' && intent) {
@@ -162,16 +243,24 @@ export function QuoteShareToolbar() {
     return () => document.removeEventListener('keydown', onKey);
   }, [intent]);
 
-  if (!intent || !position) return null;
+  // Re-clamp toolbar on viewport resize
+  useEffect(() => {
+    function onResize() {
+      if (!intent || !position) return;
+      const left = clampLeft(position.left, window.innerWidth, toolbarWidthEstimate());
+      if (left !== position.left) setPosition({ ...position, left });
+    }
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [intent, position, hasNativeShare]);
 
   async function onCopy() {
     if (!intent) return;
     try {
       await navigator.clipboard.writeText(buildCopyText(intent));
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
+      showToast('Quote + link copied', 'success');
     } catch {
-      // Fallback — silent fail; copy intent failed
+      showToast('Could not copy — try again', 'error');
     }
   }
 
@@ -183,90 +272,111 @@ export function QuoteShareToolbar() {
         text: `"${intent.text}" — ${intent.author}, ${intent.source}`,
         url: intent.permalink,
       });
-    } catch {
-      // User cancelled — silent
+      showToast('Shared', 'success');
+    } catch (err) {
+      const name = (err as Error)?.name;
+      if (name && name !== 'AbortError') {
+        showToast('Share dialog unavailable', 'error');
+      }
     }
   }
 
-  return (
+  function onTwitterClick() {
+    showToast('Opening on X — finish in the new tab', 'info');
+  }
+
+  function onLinkedInClick() {
+    showToast('Opening on LinkedIn — finish in the new tab', 'info');
+  }
+
+  const toastEl = toast ? (
     <div
-      ref={toolbarRef}
-      role="toolbar"
-      aria-label="Share this quote"
-      className="pointer-events-auto fixed z-50 -translate-x-1/2 transition-opacity"
-      style={{
-        top: position.top,
-        left: position.left,
-      }}
+      role="status"
+      aria-live="polite"
+      className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-full text-[12px] font-medium border shadow-2xl backdrop-blur whitespace-nowrap pointer-events-none ${
+        toast.tone === 'success'
+          ? 'bg-emerald-500/15 text-emerald-100 border-emerald-500/30'
+          : toast.tone === 'error'
+          ? 'bg-rose-500/15 text-rose-100 border-rose-500/30'
+          : 'bg-white/10 text-white/90 border-white/20'
+      }`}
     >
-      <div className="flex items-center gap-1 rounded-full border border-white/10 bg-[#0a0a0b]/95 backdrop-blur shadow-xl shadow-black/40 px-1.5 py-1.5">
-        <a
-          href={buildTwitterUrl(intent)}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Share on X (Twitter)"
-          className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-        >
-          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-          </svg>
-        </a>
+      {toast.msg}
+    </div>
+  ) : null;
 
-        <a
-          href={buildLinkedInUrl(intent)}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Share on LinkedIn"
-          className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-        >
-          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-          </svg>
-        </a>
+  if (!intent || !position) return toastEl;
 
-        <button
-          type="button"
-          onClick={onCopy}
-          aria-label={copied ? 'Copied to clipboard' : 'Copy quote and link'}
-          className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-        >
-          {copied ? (
-            <svg className="w-4 h-4 text-emerald-300" viewBox="0 0 24 24" fill="none" strokeWidth={2.5} stroke="currentColor" aria-hidden>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+  const buttonSize = isTouch ? 'w-12 h-12' : 'w-10 h-10';
+  const iconSize = isTouch ? 'w-5 h-5' : 'w-4 h-4';
+
+  return (
+    <>
+      <div
+        ref={toolbarRef}
+        role="toolbar"
+        aria-label="Share this quote"
+        className="pointer-events-auto fixed z-50 -translate-x-1/2 transition-opacity"
+        style={{ top: position.top, left: position.left }}
+      >
+        <div className="flex items-center gap-1 rounded-full border border-white/12 bg-[#0a0a0b]/95 backdrop-blur shadow-2xl shadow-black/60 px-1.5 py-1.5">
+          <a
+            href={buildTwitterUrl(intent)}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onTwitterClick}
+            aria-label="Share on X (Twitter)"
+            className={`group inline-flex items-center justify-center ${buttonSize} rounded-full text-white/75 hover:text-white hover:bg-white/10 active:bg-white/15 transition-colors`}
+          >
+            <svg className={iconSize} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
             </svg>
-          ) : (
-            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" strokeWidth={2} stroke="currentColor" aria-hidden>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
-            </svg>
-          )}
-        </button>
+          </a>
 
-        {hasNativeShare && (
+          <a
+            href={buildLinkedInUrl(intent)}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onLinkedInClick}
+            aria-label="Share on LinkedIn"
+            className={`group inline-flex items-center justify-center ${buttonSize} rounded-full text-white/75 hover:text-white hover:bg-white/10 active:bg-white/15 transition-colors`}
+          >
+            <svg className={iconSize} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
+          </a>
+
           <button
             type="button"
-            onClick={onNativeShare}
-            aria-label="Share via system share sheet"
-            className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+            onClick={onCopy}
+            aria-label="Copy quote and link"
+            className={`group inline-flex items-center justify-center ${buttonSize} rounded-full text-white/75 hover:text-white hover:bg-white/10 active:bg-white/15 transition-colors`}
           >
-            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" strokeWidth={2} stroke="currentColor" aria-hidden>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
+            <svg className={iconSize} viewBox="0 0 24 24" fill="none" strokeWidth={2} stroke="currentColor" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
             </svg>
           </button>
-        )}
 
-        {/* Caret pointing to the selection */}
-        <span
-          aria-hidden
-          className="absolute left-1/2 -bottom-1 -translate-x-1/2 w-2 h-2 rotate-45 bg-[#0a0a0b]/95 border-r border-b border-white/10"
-        />
-      </div>
+          {hasNativeShare && (
+            <button
+              type="button"
+              onClick={onNativeShare}
+              aria-label="Share via system share sheet"
+              className={`group inline-flex items-center justify-center ${buttonSize} rounded-full text-white/75 hover:text-white hover:bg-white/10 active:bg-white/15 transition-colors`}
+            >
+              <svg className={iconSize} viewBox="0 0 24 24" fill="none" strokeWidth={2} stroke="currentColor" aria-hidden>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
+              </svg>
+            </button>
+          )}
 
-      {/* Copy success toast */}
-      {copied && (
-        <div className="absolute left-1/2 -translate-x-1/2 mt-3 px-3 py-1.5 rounded-full bg-emerald-500/15 text-emerald-200 border border-emerald-500/25 text-[11px] font-medium whitespace-nowrap">
-          Quote + link copied
+          <span
+            aria-hidden
+            className="absolute left-1/2 -bottom-1 -translate-x-1/2 w-2 h-2 rotate-45 bg-[#0a0a0b]/95 border-r border-b border-white/12"
+          />
         </div>
-      )}
-    </div>
+      </div>
+      {toastEl}
+    </>
   );
 }


### PR DESCRIPTION
## Why

Frank from mobile: *"not good social sharing not sure it got delivered."*

Selection-based UX was confusing on touch — native iOS/Android selection handles overlap the floating tooltip, and X/LinkedIn intents open in a new tab with no confirmation back on the original page.

## What changed

### Touch / mobile (new)
- Detect touch via `(hover: none) and (pointer: coarse)` matchMedia
- Tap on a `[data-shareable="quote"]` figure opens the toolbar centered above it — no fighting the native selection handles
- Inject a visible **"↗ Tap to share"** badge into each figure on mount for discoverability
- Touch targets bumped to **48×48** (Material spec, exceeds Apple HIG 44×44)

### Confirmation toasts (new)
Every share action raises a screen-reader-announced toast so the user knows the intent fired:
- `"Opening on X — finish in the new tab"`
- `"Opening on LinkedIn — finish in the new tab"`
- `"Quote + link copied"` / `"Could not copy — try again"`
- `"Shared"` on `navigator.share()` success (silent on `AbortError` = user cancel)

Toast persists 2.4s, fixed bottom-center, dismissible.

### Robustness
- Viewport-edge clamping: toolbar `x` stays within `[12px, vw - 12px - half-width]`
- Re-clamps on resize
- If figure top is too close to viewport top, toolbar flips below

### Desktop unchanged
Text selection inside a figure still triggers the floating toolbar with the same X / LinkedIn / Copy / Share intents.

## QA

- [ ] Open `/library/atomic-habits` on phone — see "↗ Tap to share" badge on each quote
- [ ] Tap a quote figure — toolbar appears above it
- [ ] Tap X / LinkedIn — toast confirms "Opening on X — finish in the new tab"
- [ ] Tap Copy — clipboard receives `"text"\n\n— author, source\n permalink`
- [ ] Tap Share (native) — system sheet opens; cancel = silent
- [ ] Resize narrow window — toolbar stays inside viewport
- [ ] Desktop: select text — toolbar still appears above selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quote sharing toolbar now adapts to your device: desktop detects text selection for floating toolbar, mobile shows "Tap to share" badges on quotes
  * Copy and share actions provide visual feedback via toast notifications instead of silent results
  * External share buttons (X/Twitter, LinkedIn) display confirmation toasts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->