### PR TITLE
feat(library): SEO/AEO depth — Profit First + Fabric of Reality

### DIFF
--- a/app/library/[slug]/page.tsx
+++ b/app/library/[slug]/page.tsx
@@ -42,10 +42,17 @@ export async function generateMetadata({
     keywords: [
       ...review.categories,
       review.author,
+      review.title,
+      `${review.title} ${review.author}`,
       `${review.title} summary`,
+      `${review.title} review`,
       `${review.title} key insights`,
+      `${review.title} explained`,
+      `${review.title} book review`,
+      `${review.author} ${review.title}`,
       'book review',
       'book summary',
+      'book key insights',
     ],
     authors: [{ name: 'Frank' }],
     alternates: { canonical },
@@ -194,9 +201,15 @@ export default async function ReviewPage({
     ? booksRegistry.find((b) => b.slug === review.relatedBook)
     : null;
 
-  const otherReviews = bookReviews
+  const reviewCategories = new Set(review.categories);
+  const scoredReviews = bookReviews
     .filter((r) => r.slug !== review.slug)
-    .slice(0, 3);
+    .map((r) => ({
+      review: r,
+      score: r.categories.filter((c) => reviewCategories.has(c)).length,
+    }))
+    .sort((a, b) => b.score - a.score || (b.review.reviewDate > a.review.reviewDate ? 1 : -1));
+  const otherReviews = scoredReviews.slice(0, 3).map((s) => s.review);
 
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
@@ -519,8 +532,14 @@ export default async function ReviewPage({
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {review.continueReading.map((item, i) => {
+              const isInternalLink = item.url?.startsWith('/');
               const cardInner = (
                 <>
+                  {isInternalLink && (
+                    <p className="text-[10px] uppercase tracking-wider text-cyan-400/60 mb-2">
+                      In this Library
+                    </p>
+                  )}
                   <h3 className="text-[15px] font-semibold text-white group-hover:text-cyan-200 transition-colors leading-snug">
                     {item.title}
                   </h3>
@@ -530,7 +549,7 @@ export default async function ReviewPage({
                   </p>
                   {item.url && (
                     <span className="inline-flex items-center gap-1 mt-4 text-[12px] text-cyan-400/60 group-hover:text-cyan-300 transition-colors">
-                      Get the book
+                      {isInternalLink ? 'Read the review' : 'Get the book'}
                       <svg
                         className="w-3 h-3"
                         fill="none"
@@ -551,6 +570,14 @@ export default async function ReviewPage({
 
               const className =
                 'group block h-full p-5 rounded-xl border border-white/[0.06] bg-white/[0.02] hover:border-cyan-400/20 hover:bg-cyan-500/[0.03] transition-all';
+
+              if (item.url && isInternalLink) {
+                return (
+                  <Link key={i} href={item.url} className={className}>
+                    {cardInner}
+                  </Link>
+                );
+              }
 
               return item.url ? (
                 <a

--- a/data/book-reviews.ts
+++ b/data/book-reviews.ts
@@ -2192,6 +2192,12 @@ export const bookReviews: BookReview[] = [
         reason: 'The personal side of the same lesson. If you run Profit First at the company and Your Money or Your Life at home, you will be in the top 1% of founders for financial health.',
         url: 'https://www.amazon.com/Your-Money-Life-Transforming-Relationship/dp/0143115766',
       },
+      {
+        title: 'Money: Master the Game',
+        author: 'Tony Robbins',
+        reason: 'Already in this library — Robbins runs Profit First\'s logic at the personal-investment level: pay yourself first, automate the percentage, let the system enforce discipline. Pair Profit First (business cash) with Money Master the Game (personal wealth) for a complete financial operating system.',
+        url: '/library/money-master-the-game',
+      },
     ],
     videos: [
       {
@@ -2244,6 +2250,26 @@ export const bookReviews: BookReview[] = [
         q: 'What is the main criticism of Profit First?',
         a: 'Accountants note it is behavioral psychology wrapped around basic cash envelopes, not a new accounting principle. That is also its strength: it works because it is behavioral, not because it is clever.',
       },
+      {
+        q: 'What percentages should I use for each Profit First account?',
+        a: 'Michalowicz publishes Target Allocation Percentages (TAPs) by revenue bracket. For sub-$250K real revenue: 5% Profit, 50% Owner\'s Pay, 15% Tax, 30% Operating Expenses. At $1M–$5M the targets shift to 15% Profit, 10% Owner\'s Pay, 15% Tax, 60% OpEx. Start with your current allocation, compare to the target, and close the gap by 1–2 percentage points each quarter — not all at once.',
+      },
+      {
+        q: 'How long does it take to see profit with Profit First?',
+        a: 'Your first quarterly distribution can happen within 90 days of setup, even at a 1% profit allocation. Most operators reach their full target allocation within 12–18 months. The system works fastest for businesses with healthy revenue but bloated expenses; slower for businesses that need to grow revenue first. Michalowicz argues 90 days of behavioural discipline beats five years of better accounting software.',
+      },
+      {
+        q: 'What if my business is too small for five separate bank accounts?',
+        a: 'Even solo freelancers running $50K/year benefit from the discipline. Some banks charge per account; Michalowicz recommends online banks (Capital One, Mercury, Relay) that offer free sub-accounts. The minimum viable version is just two accounts — Income and Profit, separated. The behavioural firewall of "money I cannot see" works at any scale.',
+      },
+      {
+        q: 'Is Profit First just envelope budgeting for businesses?',
+        a: 'Mechanically, yes — the innovation is treating profit as a non-negotiable envelope and forcing the business to live within the remaining envelopes. Critics point out it is behavioural psychology, not new accounting. Michalowicz\'s response: that is the point. Most cash-flow problems are behavioural, not arithmetic.',
+      },
+      {
+        q: 'Does Profit First work for venture-backed or growth-stage companies?',
+        a: 'It is a poor fit for venture-backed startups optimising for growth over profitability — the entire model assumes profit is the goal, not market capture. Profit First fits owner-operated businesses (freelancers, agencies, e-commerce, services) doing $0–$10M in revenue. Above that, it can adapt with custom TAPs, but the original five-account discipline is designed for owners who pay themselves and want cash to feel calm.',
+      },
     ],
   },
   {
@@ -2293,6 +2319,22 @@ export const bookReviews: BookReview[] = [
       {
         q: 'Should I read The Fabric of Reality or The Beginning of Infinity first?',
         a: 'The Fabric of Reality (1997) lays the foundation — the four strands, Popperian epistemology, the multiverse argument. The Beginning of Infinity (2011) builds on it with a more mature framework around "good explanations" and reaches further into ethics, creativity, and progress. Fabric of Reality first, Beginning of Infinity as the payoff.',
+      },
+      {
+        q: 'How does Deutsch\'s multiverse differ from Marvel or pop-culture multiverses?',
+        a: 'Deutsch\'s multiverse is a literal consequence of quantum mechanics — every quantum event splits the universe into all physically possible outcomes. There is no travel between universes, no narrative continuity, no parallel selves making different life choices. The branches are uncountable, mostly nearly-identical, and physically real. Pop-culture multiverses are dramatic devices; Deutsch\'s is a physics claim grounded in the Everett interpretation.',
+      },
+      {
+        q: 'Why does Deutsch reject the Copenhagen interpretation of quantum mechanics?',
+        a: 'Copenhagen treats quantum measurement as a collapse of possibilities into one classical reality, but Deutsch argues this is unexplained — what counts as "measurement"? Why should observation alter physical law? Many-worlds takes the wave function literally: every outcome happens, in different branches. For Deutsch, that is the parsimonious reading and the only one that makes quantum computation make physical sense.',
+      },
+      {
+        q: 'What is constructor theory and how does it relate to The Fabric of Reality?',
+        a: 'Constructor theory is Deutsch\'s later programme (with Chiara Marletto, 2010s onwards) — a physics framed in terms of which transformations are possible vs impossible, rather than initial conditions and laws of motion. It generalises the computational view from Fabric of Reality. If Fabric of Reality says "the universe is computable", constructor theory says "the universe is best described by what tasks it permits and forbids."',
+      },
+      {
+        q: 'How does The Fabric of Reality differ from Penrose\'s The Emperor\'s New Mind?',
+        a: 'They argue opposite positions on the same question. Penrose claims human consciousness is non-computable — there is something in mathematical insight that no Turing machine can replicate. Deutsch claims the Turing principle: any physical process, including conscious thought, can in principle be simulated by a universal computer. Reading both is the sharpest way to stress-test either side of the AGI question.',
       },
     ],
     quotes: [


### PR DESCRIPTION
## Summary

Library OS gets deeper, not wider — sharpens SEO/AEO surface for the two flagship deep-dives.

## What's in

**Data (`data/book-reviews.ts` +42 lines)**
- Profit First: 4 new long-tail FAQs — TAP percentages, time-to-profit, small-business minimum viable, envelope-budgeting comparison, venture-stage fit. (4 → 9 total Q&As)
- Profit First: 1 new internal cross-link in `continueReading` → `/library/money-master-the-game` (already in library). Pairs business cash discipline with personal-investment discipline.
- Fabric of Reality: 4 new long-tail FAQs — multiverse vs pop-culture, why Copenhagen rejection, constructor theory, Penrose contrast. (5 → 9 total Q&As)
- All 8 new FAQs render as `FAQPage` schema nodes → eligible for Google answer-box, ChatGPT/Perplexity citations.

**Page (`app/library/[slug]/page.tsx`)**
- Sharper metadata keywords: title/author permutations, ‘review’, ‘explained’, ‘book review’ variants for long-tail SERP capture.
- Smart **More from the Library**: scored by category overlap (thematic) instead of `slice(0,3)`. Reading Profit First now surfaces other Wealth/Productivity books, not just whatever is first in the array.
- `continueReading` now detects internal `/library/*` URLs and renders via Next `<Link>` (no `target=_blank`) with **In this Library** badge + **Read the review** CTA. External Amazon links keep `target=_blank` + book-icon affordance.

## Why this matters

The Library has 22 deep-dived books and ~280 quote permalinks already. Width is solved. Depth was the bottleneck:
- AEO needs more direct-answer Q&A for citation rank
- Internal-link graph was thin (only `relatedBook` field, no per-item cross-links inside continueReading)
- ‘More from Library’ was random — now thematic

## Diff note

`app/library/[slug]/page.tsx` shows ~730 lines change due to LF/CRLF normalization on this Windows worktree run. Functional change is **+33 lines** (verified via `git diff --ignore-all-space`).

## Test plan

- [ ] Vercel preview SUCCESS
- [ ] `/library/profit-first` shows new FAQs + Money Master cross-link card with ‘In this Library’ badge
- [ ] `/library/fabric-of-reality` shows 4 new FAQs (Marvel multiverse, Copenhagen, constructor theory, Penrose)
- [ ] Profit First ‘More from Library’ rail shows Wealth-category books (Money Master, Awaken, etc.)
- [ ] Internal `/library/money-master-the-game` link in continueReading does not open new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Continue Reading" section now distinguishes between library reviews and external book links for clarity.
  * Improved related reviews algorithm to display recommendations based on category relevance.

* **Documentation**
  * Expanded FAQ entries with detailed explanations and practical guidance.
  * Added new follow-up reading recommendations to the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->