### PR TITLE
fix: site quality batch — RSS 500 + chronicle canonical + sitemap orphans + footer

### DIFF
--- a/app/chronicle/page.tsx
+++ b/app/chronicle/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 
-const SITE_URL = 'https://www.frankx.ai';
+const SITE_URL = 'https://frankx.ai';
 
 export const metadata: Metadata = {
   title: 'The Starlight Chronicle — A Practice of Witnessing | FrankX',

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -242,11 +242,32 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: '/downloads', priority: 0.7, changeFrequency: 'monthly' as const },
     { url: '/changelog', priority: 0.5, changeFrequency: 'weekly' as const },
     { url: '/design-system', priority: 0.5, changeFrequency: 'monthly' as const },
+    { url: '/design', priority: 0.6, changeFrequency: 'monthly' as const },
     { url: '/ai-architect', priority: 0.7, changeFrequency: 'monthly' as const },
     { url: '/ai-architecture', priority: 0.7, changeFrequency: 'monthly' as const },
     { url: '/ai-architectures', priority: 0.7, changeFrequency: 'monthly' as const },
     { url: '/music', priority: 0.6, changeFrequency: 'monthly' as const },
     { url: '/prototypes', priority: 0.5, changeFrequency: 'monthly' as const },
+    // Newly indexed orphan pages (audit 2026-05-04)
+    { url: '/chronicle', priority: 0.8, changeFrequency: 'weekly' as const },
+    { url: '/bio', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/library', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/library/approach', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/books', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/books/golden-age-of-intelligence', priority: 0.9, changeFrequency: 'weekly' as const },
+    // 12 chapters of Golden Age of Intelligence
+    { url: '/books/golden-age-of-intelligence/chapter-01-the-two-intelligences-awakening', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-02-the-twenty-watt-miracle', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-03-what-the-ancients-knew', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-04-stimulus-and-response', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-05-states-not-stages', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-06-the-imagination-engine', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-07-memory-sleep-replay', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-08-ai-as-mirror', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-09-personal-center-of-excellence', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-10-creators-renaissance', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-11-governance-of-the-self', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/books/golden-age-of-intelligence/chapter-12-transmission', priority: 0.7, changeFrequency: 'monthly' as const },
   ]
 
   // Sub-route pages (nested under parent sections)
@@ -297,6 +318,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: '/research', priority: 0.9, changeFrequency: 'weekly' as const },
     { url: '/research/sources', priority: 0.7, changeFrequency: 'weekly' as const },
     { url: '/research/methodology', priority: 0.7, changeFrequency: 'monthly' as const },
+    // Architecture of Intelligence series — 5-domain spine, flagship blog 2026-05-04
+    { url: '/research/series/architecture-of-intelligence', priority: 0.95, changeFrequency: 'weekly' as const },
   ]
 
   // Get dynamic content

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -75,6 +75,9 @@ export default function Footer() {
               <li><Link href="/guides" className="hover:text-white transition-colors">Guides</Link></li>
               <li><Link href="/blog" className="hover:text-white transition-colors">Blog</Link></li>
               <li><Link href="/library" className="hover:text-white transition-colors">Library</Link></li>
+              <li><Link href="/chronicle" className="hover:text-white transition-colors">Chronicle</Link></li>
+              <li><Link href="/research" className="hover:text-white transition-colors">Research</Link></li>
+              <li><Link href="/workshops" className="hover:text-white transition-colors">Workshops</Link></li>
               <li><Link href="/study" className="hover:text-white transition-colors">Study</Link></li>
             </ul>
           </div>

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -49,6 +49,19 @@ function normalizeFrontmatter(data: Record<string, any>): Record<string, any> {
   if (!normalized.keywords && normalized.seo?.keywords) {
     normalized.keywords = normalized.seo.keywords
   }
+  // Normalize categories array → category string for legacy plural frontmatter.
+  // Without this, RSS feed and other consumers crash on `escapeXml(undefined)`.
+  if (!normalized.category && Array.isArray(normalized.categories) && normalized.categories.length > 0) {
+    normalized.category = normalized.categories[0]
+  }
+  // Final defense: ensure category is always a string so consumers can call
+  // .replace() etc. without null checks. Title/description/author get the
+  // same fallback so RSS, sitemap, and listing pages never throw on a
+  // malformed post.
+  if (typeof normalized.category !== 'string') normalized.category = ''
+  if (typeof normalized.title !== 'string') normalized.title = ''
+  if (typeof normalized.description !== 'string') normalized.description = ''
+  if (typeof normalized.author !== 'string') normalized.author = ''
   return normalized
 }
 


### PR DESCRIPTION
## Summary

Four quality fixes from the all-night excellence audit (2026-05-04). Each is independent but they ship together for atomicity.

## What ships

### 1. `lib/blog.ts` — Defensive frontmatter normalization (fixes /rss.xml 500)

**Root cause:** `app/rss.xml/route.ts` calls `escapeXml(post.category)`, which throws `TypeError: Cannot read properties of undefined (reading 'replace')` when `post.category` is `undefined`. Several blog posts use `categories: ["x", "y"]` (plural array) instead of `category: "x"` (singular string). The plural form was never normalized, so the RSS feed has been 500ing for those posts.

**Fix:** Add to `normalizeFrontmatter()`:
- `categories[0] → category` fallback for legacy plural frontmatter
- Final string-fallback defense for `category`, `title`, `description`, `author` so consumers can call `.replace()` etc. without null guards

**Verification:** Run any consumer of `getAllBlogPosts()` (rss.xml, sitemap, blog listing) — every post returns a string-typed category.

### 2. `app/chronicle/page.tsx` — Fix canonical to non-www (matches site convention)

**Root cause:** `SITE_URL = 'https://www.frankx.ai'` while the rest of the codebase uses `'https://frankx.ai'`. This emits `<link rel="canonical" href="https://www.frankx.ai/chronicle">` and OG `og:url` with `www` — different from the resolved domain. Per Google's canonicalization rules, this is a self-conflict.

**Fix:** Replace `https://www.frankx.ai` → `https://frankx.ai` (3 occurrences in canonical + og:url + og:image).

### 3. `app/sitemap.ts` — Add 18 orphaned indexable pages

**Root cause (per audit):** Several fully-indexable pages exist on prod but are absent from the sitemap, leaving them dependent on link discovery only. This includes the flagship Architecture of Intelligence series page, /chronicle, /bio, /library, /books, and 12 chapter pages of *The Golden Age of Intelligence*.

**Fix:** Add to sitemap:
- `/research/series/architecture-of-intelligence` (priority 0.95)
- `/chronicle` (priority 0.8)
- `/bio` (priority 0.7)
- `/library` and `/library/approach` (priority 0.9, 0.8)
- `/books` and `/books/golden-age-of-intelligence` (priority 0.9)
- 12 Golden Age chapter pages (priority 0.7 each)
- `/design` (priority 0.6, fixes `/design-system` mismatch documented in audit)

### 4. `components/Footer.tsx` — Add Chronicle, Research, Workshops to Learn footer column

**Root cause:** Three high-value hubs are indexable and shipped but absent from the global footer: `/chronicle` (reflective layer of FrankX OS), `/research` (research hub), `/workshops` (workshop landing). The Learn column in the footer had Library + Study but skipped these.

**Fix:** Add three Link entries to the Learn column.

## Audit provenance

All four fixes were surfaced by the 2026-05-04 all-night cleanup session. Findings synthesized from:
- Vercel runtime logs (rss.xml 500 errors)
- Site URL health audit (5 routes 200ing but soft-404)
- Interlinking + navigation audit (orphan pages, sitemap gaps)
- SEO + JSON-LD audit (chronicle www-prefix mismatch)

## Test plan

- [ ] After merge, `curl -sI https://frankx.ai/rss.xml` returns `200 OK` (was 500)
- [ ] `curl -sL https://frankx.ai/chronicle | grep canonical` shows `https://frankx.ai/chronicle` (no www)
- [ ] `curl -sL https://frankx.ai/sitemap.xml | grep -c '<url>'` shows ~640 entries (up from ~621)
- [ ] `/sitemap.xml` includes `/research/series/architecture-of-intelligence` (currently 404 in prod, deploy gap; will become live when Thursday routine ships the second wave)
- [ ] Footer on any page shows new Chronicle / Research / Workshops links

🤖 Generated with [Claude Code](https://claude.com/claude-code) · all-night cleanup 2026-05-04


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chronicle, Research, and Workshops links to footer navigation
  * Expanded site coverage with new pages including design, library, and research collections

* **Bug Fixes**
  * Improved metadata handling to ensure consistent data integrity across content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->