### PR TITLE
fix(runtime): /api/newsletter accepts JSON+formData, KV cron lazy-import, /api/og simpler bg

### DIFF
--- a/app/api/cron/welcome-sequence/route.ts
+++ b/app/api/cron/welcome-sequence/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { kv } from '@vercel/kv'
 import { welcomeEmail2, welcomeEmail3 } from '@/lib/email-templates-welcome'
+// @vercel/kv is lazy-imported inside the handler so this route doesn't 500
+// at module load when KV env vars are not configured (the package validates
+// env on import). The cron schedule (`0 */6 * * *` per vercel.json) was
+// firing 4x/day with "Error: @vercel/kv: Missing KV_REST_API_URL" — silent
+// to users but it pollutes Vercel runtime logs and consumes invocations.
 
 const RESEND_API_KEY = process.env.RESEND_API_KEY
 const CRON_SECRET = process.env.CRON_SECRET
@@ -33,6 +37,22 @@ export async function GET(request: NextRequest) {
   if (!RESEND_API_KEY) {
     return NextResponse.json({ error: 'RESEND_API_KEY not configured' }, { status: 500 })
   }
+
+  // Early-return if KV env not configured. The @vercel/kv package crashes
+  // on import without these — that's why we lazy-import below. Returning 200
+  // here keeps the cron successful (no false-alarm 500s) while making it
+  // clear the queue is being skipped.
+  if (!process.env.KV_REST_API_URL || !process.env.KV_REST_API_TOKEN) {
+    return NextResponse.json({
+      ok: true,
+      skipped: true,
+      reason: 'KV env vars not configured — welcome sequence queue is paused',
+      now: new Date().toISOString(),
+    })
+  }
+
+  // Lazy import — only after env check passes
+  const { kv } = await import('@vercel/kv')
 
   const now = Date.now()
   const TWO_DAYS = 2 * 24 * 60 * 60 * 1000

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -40,9 +40,21 @@ async function subscribeWebhook(email: string) {
 
 export async function POST(request: NextRequest) {
   try {
-    const formData = await request.formData()
-    const email = (formData.get('email') as string)?.trim().toLowerCase()
-    const redirectTo = formData.get('redirect') as string | null
+    // Accept both formData (HTML form posts, e.g. /soul-frequency-quiz) and JSON
+    // (fetch() callers, e.g. /links Linktree page) so a single endpoint serves
+    // every signup surface without each caller knowing the wire format.
+    let email: string | undefined
+    let redirectTo: string | null = null
+    const contentType = request.headers.get('content-type') || ''
+    if (contentType.includes('application/json')) {
+      const json = await request.json().catch(() => ({} as Record<string, unknown>))
+      email = (json.email as string | undefined)?.trim?.().toLowerCase()
+      redirectTo = (json.redirect as string | undefined) ?? null
+    } else {
+      const formData = await request.formData()
+      email = (formData.get('email') as string)?.trim?.().toLowerCase()
+      redirectTo = formData.get('redirect') as string | null
+    }
 
     if (!email || !email.includes('@')) {
       return NextResponse.json({ error: 'Valid email address required' }, { status: 400 })

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -19,7 +19,13 @@ export async function GET(req: Request) {
           flexDirection: 'column',
           justifyContent: 'center',
           alignItems: 'center',
-          background: 'radial-gradient(circle at top, rgba(16,185,129,0.25), transparent 60%), radial-gradient(circle at 20% 70%, rgba(34,211,238,0.2), transparent 60%), radial-gradient(circle at 80% 80%, rgba(245,158,11,0.18), transparent 60%), #0b0d10',
+          // Single solid bg + a single radial accent. next/og's CSS parser
+          // reliably handles solid colors and one gradient. The previous
+          // 3-stacked-radial-gradient + comma-separated background was logging
+          // "Error: Invalid background image" in production runtime logs —
+          // the response was 200 with empty body. Simpler bg = guaranteed render.
+          backgroundColor: '#0b0d10',
+          backgroundImage: 'radial-gradient(circle at 30% 30%, rgba(34,211,238,0.18), transparent 65%)',
           color: '#e8eef5',
           fontSize: 64,
           fontFamily: 'Inter, Arial, sans-serif',


### PR DESCRIPTION
## Summary

Three silent runtime bugs surfaced by the 2026-05-04 audit + Vercel runtime logs. Each was logging errors but not blocking deploys, so they accumulated.

## What ships

### 1. `app/api/newsletter/route.ts` — Accept JSON OR formData

**Bug:** `/links` Linktree page POSTs `{ email }` as JSON (`Content-Type: application/json`). The route called `request.formData()` which silently fails on JSON requests — `email` becomes `undefined`, validation fails, and every newsletter signup from /links returns 400.

**Fix:** Detect `Content-Type` header and parse accordingly. Both JSON and formData callers now work without each side knowing the other's wire format.

### 2. `app/api/cron/welcome-sequence/route.ts` — Lazy-import @vercel/kv + early return

**Bug:** The cron fires every 6 hours per `vercel.json` and 500s every time with `Error: @vercel/kv: Missing KV_REST_API_URL`. The `@vercel/kv` package validates env vars on module-load (top-level import), so the route crashes before the handler even runs.

**Fix:**
- Move `import { kv } from '@vercel/kv'` from top-level to a dynamic `await import()` inside the handler
- Add an early-return when `KV_REST_API_URL`/`KV_REST_API_TOKEN` are missing, returning a friendly 200 with `skipped: true` instead of 500
- Cron invocations now report success cleanly, no more 4 false-alarm 500s/day in runtime logs

This is the same lazy-import pattern from PR #25's `ba37e131` commit (closed PR — content was direct-pushed for everything else, this fix wasn't).

### 3. `app/api/og/route.tsx` — Single bg color + single radial accent

**Bug:** Production runtime logs showed `Error: Invalid background image` on every `/api/og` request. The response was 200 with empty body (0 bytes). Several pages still using `/api/og?title=...` for OG images were getting blank social cards.

**Root cause:** `next/og`'s CSS parser doesn't reliably handle 3 stacked `radial-gradient(...)` declarations comma-separated with a fallback color. The whole `background: ...` shorthand was being rejected.

**Fix:** Split into `backgroundColor` + a single `backgroundImage: radial-gradient(...)`. next/og handles solid colors and one gradient consistently. Same visual register, no more empty-body errors.

## Audit provenance

- Vercel runtime log query (`level=error`, last 24h, project frankx-ai-vercel-website) showed all 3 bugs firing repeatedly
- Funnel audit identified `/links` JSON/formData mismatch by reading both files
- The KV bug was originally fixed in unmerged PR #25's `ba37e131` (closed for being superseded — only this one commit still applied)

## Test plan

- [ ] After merge: `curl -X POST -H 'Content-Type: application/json' -d '{"email":"test@example.com"}' https://frankx.ai/api/newsletter` returns a thank-you redirect (303), not 400
- [ ] After merge: next cron fire of `/api/cron/welcome-sequence` returns 200 with `skipped: true` (until KV env is set), instead of 500
- [ ] After merge: `curl -sIL 'https://frankx.ai/api/og?title=Test'` returns 200 with `Content-Length: > 5000` (real PNG body, not 0 bytes)
- [ ] Vercel runtime logs (next 24h, level=error) should show ZERO occurrences of all three bug signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code) · all-night cleanup 2026-05-04
