### PR TITLE
fix(vercel): add .vercelignore + styles + postcss to should-deploy allowlist

### DIFF
--- a/scripts/should-deploy.sh
+++ b/scripts/should-deploy.sh
@@ -22,6 +22,7 @@ RELEVANT_PATHS=(
   data
   public
   scripts
+  styles
   package.json
   package-lock.json
   pnpm-lock.yaml
@@ -31,6 +32,10 @@ RELEVANT_PATHS=(
   tsconfig.json
   middleware.ts
   middleware.js
+  .vercelignore
+  .npmrc
+  postcss.config.js
+  postcss.config.mjs
 )
 
 if git diff --quiet HEAD^ HEAD -- "${RELEVANT_PATHS[@]}"; then


### PR DESCRIPTION
## Problem

PR #52 (the .vercelignore root-anchor fix) merged but Vercel marked it Canceled — `should-deploy.sh` correctly identified that `.vercelignore` is not in its RELEVANT_PATHS allowlist, so the build was skipped. The ignoreCommand was working as designed; the allowlist was incomplete.

## Fix

Extend RELEVANT_PATHS in `scripts/should-deploy.sh` to include:
- `.vercelignore` — direct effect on build context
- `.npmrc` — affects install behavior
- `styles/` — common Next.js convention for global CSS (if used)
- `postcss.config.{js,mjs}` — affects CSS processing

This commit changes `scripts/should-deploy.sh` (already in RELEVANT_PATHS via `scripts`), so it WILL trigger a build — which is exactly what we want, because the prior `.vercelignore` hotfix (PR #52) needs to actually deploy.

## Test plan

- [ ] Build runs (does not skip) after this merge
- [ ] Build succeeds with the corrected `.vercelignore` (i.e., `lib/research/visionaries.ts` is in the build context)
- [ ] Verify by checking that the deploy reaches Ready, not Error
