### PR TITLE
PR #2: feat(brand,ci) — AI Architect rename + AI-slop top-12 + CI guard

### DIFF
--- a/BRAND_IDENTITY.md
+++ b/BRAND_IDENTITY.md
@@ -24,10 +24,9 @@
 **Frank X. Riemer**
 
 ### Professional Titles
+- AI Architect (primary — never "AI Systems Architect" per CLAUDE.md mandate)
 - Musician-Technologist
-- AI Systems Architect
 - Creator Transformation Guide
-- Consciousness & Technology Bridge
 
 ### Bio (Short - 160 chars for Twitter)
 Musician-technologist building AI systems that amplify human creativity. Founder @FrankX_AI • Vibe OS • Suno • Oracle

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -38,7 +38,7 @@ const aboutFaqs = [
   {
     question: 'How can I get started with the resources on this site?',
     answer:
-      'Start with the /start page for a guided overview, explore the Music Lab for AI music creation, browse the Prompt Library for ready-to-use prompts, or dive into the blog for practical insights and tutorials.',
+      'Start with the /start page for a guided overview, explore the Music Lab for AI music creation, browse the Prompt Library for ready-to-use prompts, or open the blog for practical insights and tutorials.',
   },
   {
     question: 'Does Frank offer consulting or collaboration opportunities?',

--- a/app/agent-team/page.tsx
+++ b/app/agent-team/page.tsx
@@ -572,7 +572,7 @@ export default function AgentTeamPage() {
           <section className="rounded-4xl border border-white/10 bg-gradient-to-r from-primary-500/20 via-primary-600/15 to-sky-500/20 p-10 text-center">
             <h2 className="text-3xl font-semibold text-white">Ready to orchestrate your agent collective?</h2>
             <p className="mt-4 text-sm text-white/80 leading-relaxed">
-              Start with a briefing, dive into a workshop, or craft a bespoke retainer. The FrankX agent team is ready to co-create systems that
+              Start with a briefing, step into a workshop, or craft a bespoke retainer. The FrankX agent team is ready to co-create systems that
               honor your people and accelerate your roadmap.
             </p>
             <div className="mt-6 flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/app/ai-architect/AIArchitectClient.tsx
+++ b/app/ai-architect/AIArchitectClient.tsx
@@ -123,7 +123,7 @@ const methodology = {
     {
       number: '01',
       title: 'Discovery & Assessment',
-      description: 'Deep dive into business context, existing systems, and constraints',
+      description: 'Map business context, existing systems, and constraints',
       activities: [
         'Stakeholder interviews and requirements gathering',
         'Current state architecture analysis',

--- a/app/ai-architecture/layout.tsx
+++ b/app/ai-architecture/layout.tsx
@@ -2,7 +2,7 @@ import { createMetadata } from '@/lib/seo'
 
 export const metadata = createMetadata({
   title: 'AI Architecture | System Design for Intelligent Applications | FrankX',
-  description: 'Deep dives into AI system architecture. Design patterns for LLM applications, agent orchestration, and production AI infrastructure.',
+  description: 'Practical reference for AI system architecture. Design patterns for LLM applications, agent orchestration, and production AI infrastructure.',
   path: '/ai-architecture',
 })
 

--- a/app/assessment/advanced/page.tsx
+++ b/app/assessment/advanced/page.tsx
@@ -706,11 +706,11 @@ function ResultsStep({ profile }: { profile: UserProfile }) {
       },
       practitioner: {
         title: 'The Technical Pioneer',
-        description: 'You push the boundaries of what\'s possible with AI, implementing cutting-edge solutions and sharing knowledge.',
+        description: 'You push the boundaries of what\'s possible with AI, implementing frontier patterns and sharing what you learn.',
         icon: Brain,
         color: 'from-purple-500 to-violet-500',
         recommendations: [
-          'Dive into advanced Agent Architecture patterns',
+          'Study advanced Agent Architecture patterns',
           'Contribute to our open-source initiatives',
           'Apply for our Technical Advisory Board',
           'Lead workshops in our community'

--- a/app/coaching/page.tsx
+++ b/app/coaching/page.tsx
@@ -60,7 +60,7 @@ const processSteps = [
   {
     number: '01',
     title: 'Discovery',
-    description: 'Deep dive into your current systems, goals, and challenges to create a custom roadmap.',
+    description: 'Map your current systems, goals, and challenges to build a custom roadmap.',
     icon: Target,
     color: '#43BFE3',
   },

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -191,7 +191,7 @@ const mockUserProgress: UserProgress = {
       id: '1',
       type: 'course',
       title: 'Advanced Prompt Engineering',
-      description: 'Deep dive into sophisticated prompting techniques',
+      description: 'Walk through sophisticated prompting techniques',
       reason: 'Based on your progress in fundamentals',
       priority: 'high',
       href: '/courses/advanced-prompt-engineering',

--- a/app/free-playbook/page.tsx
+++ b/app/free-playbook/page.tsx
@@ -318,7 +318,7 @@ export default function FreePlaybookPage() {
             className="grid gap-4 sm:grid-cols-3"
           >
             {[
-              { href: '/blog', label: 'Read the Blog', desc: 'Deep dives into AI creation' },
+              { href: '/blog', label: 'Read the Blog', desc: 'Field notes on AI creation' },
               { href: '/newsletter', label: 'Newsletter', desc: '6 streams for builders' },
               { href: '/shop', label: 'Shop Templates', desc: 'Premium AI blueprints' },
             ].map((link) => (

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -826,7 +826,7 @@ function CTASection() {
             The research behind the games
           </h2>
           <p className="text-white/50 text-lg mb-8 max-w-xl mx-auto">
-            Deep dive into agentic game development — market data, tools,
+            A working primer on agentic game development — market data, tools,
             best practices, and what works (and what doesn&apos;t) for creators and game devs.
           </p>
 

--- a/app/links/metadata.ts
+++ b/app/links/metadata.ts
@@ -9,7 +9,7 @@ import { SCHEMA_SAME_AS, SOCIAL_META } from '@/lib/social-links'
 export const metadata: Metadata = createMetadata({
   title: 'Frank X. Riemer | AI Architect & Music Creator - All Links',
   description:
-    'Connect with Frank X. Riemer. AI Systems Architect. Creator of 12K+ songs with Suno. Get the Creative AI Toolkit, explore Vibe OS, join the Inner Circle, and access all resources.',
+    'Connect with Frank X. Riemer. AI Architect. Creator of 12,000+ songs with Suno. Get the Creative AI Toolkit, explore Vibe OS, join the Inner Circle, and access all resources.',
   path: '/links',
   keywords: [
     'frank x riemer',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { getAllBlogPosts } from '@/lib/blog'
 export const metadata = createMetadata({
   title: 'FrankX — AI Architect & Creator',
   description:
-    'AI Systems Architect at Oracle. Creator of 12,000+ songs with Suno. Open-source AI tools, technical tutorials, and music production workflows.',
+    'AI Architect at Oracle. Creator of 12,000+ songs with Suno. Open-source AI tools, technical tutorials, and music production workflows.',
   keywords: [
     'ai architect',
     'ai music creation',
@@ -39,7 +39,7 @@ const websiteSchema = {
 
 const personSchema = {
   name: 'Frank Riemer',
-  jobTitle: 'AI Systems Architect',
+  jobTitle: 'AI Architect',
   url: 'https://frankx.ai/about',
   sameAs: [
     'https://linkedin.com/in/frank-x-riemer/',
@@ -74,7 +74,7 @@ const homepageFAQs = [
   {
     question: 'What is FrankX.AI?',
     answer:
-      'FrankX.AI is the personal hub of Frank Riemer — an AI Systems Architect and creator of 12,000+ AI-generated songs with Suno. The site features technical tutorials, AI architecture guides, music production workflows, and open-source creator tools.',
+      'FrankX.AI is the personal hub of Frank Riemer — an AI Architect and creator of 12,000+ AI-generated songs with Suno. The site features technical tutorials, AI architecture guides, music production workflows, and open-source creator tools.',
   },
   {
     question: 'What kind of content does FrankX publish?',

--- a/app/products/agentic-creator-os/docs/docs-content.ts
+++ b/app/products/agentic-creator-os/docs/docs-content.ts
@@ -82,7 +82,7 @@ export const docsContent: Record<string, DocContent> = {
 
   'skills': {
     title: 'Skills Guide',
-    description: 'Deep dive into the 62 skills that power your creative workflows.',
+    description: 'Walk through the 62 skills that power your creative workflows.',
     category: 'Guide',
     keywords: ['claude code skills', 'ai skills system', 'custom ai skills'],
     readTime: '10 min',

--- a/app/products/agentic-creator-os/docs/page.tsx
+++ b/app/products/agentic-creator-os/docs/page.tsx
@@ -59,7 +59,7 @@ const docSections = [
     title: 'Skills Guide',
     slug: 'skills',
     icon: BookOpen,
-    description: 'Deep dive into the 62 skills that power your creative workflows.',
+    description: 'Walk through the 62 skills that power your creative workflows.',
     topics: ['Skill Categories', 'Auto-Activation', 'Creating Skills', 'Best Practices']
   },
   {

--- a/lib/intelligence-atlas.ts
+++ b/lib/intelligence-atlas.ts
@@ -144,7 +144,7 @@ export const atlasMetrics: AtlasMetric[] = [
 
 export const atlasActions: AtlasAction[] = [
   {
-    title: 'Dive into Volume I',
+    title: 'Open Volume I',
     description: 'Read the 10,000-word architecting the agentic era report and deploy the included frameworks.',
     href: '/blog/frankx-intelligence-atlas-volume-1',
     label: 'Published January 2025',

--- a/lib/soulbook/pillars.ts
+++ b/lib/soulbook/pillars.ts
@@ -136,7 +136,7 @@ export function getPillarsForLifeBook(bookType: 'symphony' | 'path' | 'pillars')
       // Golden Path - pillars 1, 3, 6 (Awareness, Emotions, Purpose)
       return [pillars[0], pillars[2], pillars[5]]
     case 'pillars':
-      // 7 Pillars - deep dive into all 7
+      // 7 Pillars - all 7 in sequence
       return pillars
     default:
       return pillars

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "factory:validate": "npm run content:validate && npm run qa:check",
     "factory:publish": "npm run qa:check && npm run publish:artifact",
     "ci:check": "npm run type-check && npm run lint && npm run content:validate",
+    "ai-slop:audit": "node scripts/audit-ai-slop.mjs",
+    "ai-slop:audit:strict": "node scripts/audit-ai-slop.mjs --strict",
     "links:check": "node scripts/check-links.mjs",
     "log:session": "node scripts/log-session.mjs",
     "sync:check": "bash scripts/pre-deploy-sync-check.sh",

--- a/scripts/audit-ai-slop.mjs
+++ b/scripts/audit-ai-slop.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * audit-ai-slop.mjs — taste.md refusal-list enforcement
+ *
+ * Scans app/, components/, content/, lib/ for the AI-slop phrases banned in
+ * taste.md (the FrankX taste contract).
+ *
+ * Usage:
+ *   node scripts/audit-ai-slop.mjs           # warn only, exit 0
+ *   node scripts/audit-ai-slop.mjs --strict  # fail on hits, exit 1 (CI mode)
+ *
+ * Allowlist:
+ *   - Files that legitimately discuss these phrases (taste.md, CLAUDE.md,
+ *     AGENTS.md, design-lab brand demos, audit docs, the content scripts)
+ *     are excluded — see ALLOW_FILES below.
+ *   - Lines ending with "// ai-slop-allow" or matching `<!-- ai-slop-allow -->`
+ *     are allowed (for legitimate quotation in editorial context).
+ *
+ * Refs: taste.md § "What we refuse" + § "The sound of the brand"
+ *       docs/ops/2026-05-06-DESIGN-COPY-AUDIT.md (P0 #3)
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const STRICT = process.argv.includes('--strict')
+const VERBOSE = process.argv.includes('--verbose')
+
+// Patterns drawn directly from taste.md. Each is case-insensitive.
+// `boundary` is a regex assembled around each phrase.
+const REFUSAL_LIST = [
+  { phrase: 'delve into', why: 'AI-slop tell — see taste.md' },
+  { phrase: 'delves into', why: 'AI-slop tell' },
+  { phrase: 'dive deep', why: 'AI-slop tell — pick a stronger verb' },
+  { phrase: 'deep dive', why: 'AI-slop tell — pick a stronger verb' },
+  { phrase: 'deeper dive', why: 'AI-slop tell' },
+  { phrase: 'dive into', why: 'AI-slop tell — pick a stronger verb' },
+  { phrase: 'dives into', why: 'AI-slop tell' },
+  { phrase: "it's worth noting", why: 'AI-slop tell' },
+  { phrase: 'in conclusion', why: 'AI-slop tell — let the reader conclude' },
+  { phrase: 'navigate the landscape', why: 'AI-slop cliche' },
+  { phrase: 'unleash', why: 'AI-slop tell — too marketing' },
+  { phrase: 'unleashed', why: 'AI-slop tell' },
+  { phrase: 'unleashes', why: 'AI-slop tell' },
+  { phrase: 'harness the power', why: 'AI-slop cliche' },
+  { phrase: 'unlock the power', why: 'AI-slop cliche' },
+  { phrase: 'unlock your potential', why: 'Generic SaaS hero language — taste.md refusal list' },
+  { phrase: 'empower your team', why: 'Generic SaaS hero language' },
+  { phrase: 'take your.{1,30}to the next level', why: 'Generic SaaS hero language' },
+  { phrase: 'next-level', why: 'AI-slop tell' },
+  { phrase: 'cutting-edge solution', why: 'Generic SaaS language' },
+  { phrase: 'game-changing', why: 'AI-slop cliche' },
+  { phrase: 'revolutionary', why: 'AI-slop adjective (acceptable in technical historical context only)' },
+  // Conversational "certainly" / "absolutely" only flagged at line start (chatbot tells)
+  { phrase: '^\\s*certainly[,.!]', why: 'Chatbot tell at line start', isRegex: true },
+  { phrase: '^\\s*absolutely[,.!]', why: 'Chatbot tell at line start', isRegex: true },
+]
+
+// Files & dirs the audit deliberately ignores.
+const ALLOW_FILES = new Set([
+  'taste.md',
+  'CLAUDE.md',
+  'AGENTS.md',
+  'BRAND_IDENTITY.md',
+  '.codex/instructions.md',
+  'README.md',
+  'AUDIT_STRATEGY.md',
+  'OPS-INDEX.md',
+])
+
+// Path patterns where the audit is silenced (these files reference the patterns
+// in meta/audit context, not as production copy).
+const ALLOW_PATH_PATTERNS = [
+  /^docs\/ops\//,                   // operational docs (audits, plans)
+  /^docs\/cis\//,                   // content-intelligence design docs
+  /^docs\/research\//,              // research notes
+  /^docs\/superpowers\//,           // skill specs
+  /^docs\/standards\//,             // standards specs
+  /^docs\/planning\//,              // sprint plans
+  /^docs\/workshops\//,             // workshop docs
+  /^docs\/chronicle\//,             // chronicle docs
+  /^scripts\/audit-/,               // self-reference (this script + cousins)
+  /^scripts\/audit-marketing-claims/, // sibling auditor
+  /^app\/design\/page\.tsx$/,       // /design page quotes the rules
+  /^app\/design-lab\//,             // design-lab includes negative examples
+  /^app\/llms\.txt\//,              // llms.txt route handler — concise AEO surface
+  /^app\/llms-full\.txt\//,         // llms-full.txt route handler — lists refusal-list as voice signal
+  /^content\/2-ready-to-publish\//, // staged drafts (not yet shipped)
+  /^v1-enterprise-backup\//,        // legacy backups
+  /^_archive\//,                    // archived content
+  /^\.archive/,                     // archived dot-folders
+  /^\.frankx\/family\//,            // family archive prose
+  /CLAUDE\.md$/,                    // any nested CLAUDE.md mem-context file
+]
+
+// Allow specific blog files where refusal-list discussion is legitimate
+// (they teach others to avoid AI-slop, so they NEED to use the words).
+const ALLOW_BLOG_SLUGS = new Set([
+  'agentic-seo-publishing-masterplan',
+  'ai-engineering-without-hype-willison',
+  'how-to-write-claude-md-that-works',
+  'ultimate-ai-coding-agent-setup-acos-claude-code-mcp',
+])
+
+const SCAN_DIRS = ['app', 'components', 'content', 'lib']
+const SCAN_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mdx', '.md', '.mjs'])
+
+function isAllowed(relPath) {
+  if (ALLOW_FILES.has(path.basename(relPath))) return true
+  for (const re of ALLOW_PATH_PATTERNS) {
+    if (re.test(relPath)) return true
+  }
+  // Allow blog posts in the explicit allow-set
+  const blogMatch = relPath.match(/^content\/blog\/(.+)\.mdx$/)
+  if (blogMatch && ALLOW_BLOG_SLUGS.has(blogMatch[1])) return true
+  return false
+}
+
+function lineAllowed(line) {
+  return /\/\/\s*ai-slop-allow|<!--\s*ai-slop-allow\s*-->/.test(line)
+}
+
+async function* walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (const e of entries) {
+    if (e.name.startsWith('.') && e.name !== '.frankx') continue
+    if (e.name === 'node_modules' || e.name === '.next' || e.name === '.git') continue
+    const full = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      yield* walk(full)
+    } else if (SCAN_EXTS.has(path.extname(e.name))) {
+      yield full
+    }
+  }
+}
+
+function scanLine(line, lineNum, file, hits) {
+  if (lineAllowed(line)) return
+  for (const { phrase, why, isRegex } of REFUSAL_LIST) {
+    const pattern = isRegex ? new RegExp(phrase, 'i') : new RegExp(`\\b${phrase}\\b`, 'i')
+    if (pattern.test(line)) {
+      hits.push({ file, line: lineNum, phrase, why, snippet: line.trim().slice(0, 140) })
+    }
+  }
+}
+
+async function main() {
+  const root = process.cwd()
+  const hits = []
+  let scanned = 0
+
+  for (const dir of SCAN_DIRS) {
+    const dirPath = path.join(root, dir)
+    try {
+      await fs.access(dirPath)
+    } catch {
+      continue
+    }
+    for await (const file of walk(dirPath)) {
+      const rel = path.relative(root, file).replace(/\\/g, '/')
+      if (isAllowed(rel)) continue
+      scanned++
+      const text = await fs.readFile(file, 'utf8')
+      const lines = text.split(/\r?\n/)
+      for (let i = 0; i < lines.length; i++) {
+        scanLine(lines[i], i + 1, rel, hits)
+      }
+    }
+  }
+
+  if (hits.length === 0) {
+    console.log(`✓ ai-slop audit: ${scanned} files scanned, 0 hits`)
+    process.exit(0)
+  }
+
+  console.log(`\nai-slop audit — ${hits.length} hit${hits.length === 1 ? '' : 's'} across ${new Set(hits.map((h) => h.file)).size} file${hits.length === 1 ? '' : 's'}\n`)
+
+  // Group by file for readable output
+  const byFile = new Map()
+  for (const h of hits) {
+    if (!byFile.has(h.file)) byFile.set(h.file, [])
+    byFile.get(h.file).push(h)
+  }
+  for (const [file, items] of byFile) {
+    console.log(`  ${file}`)
+    for (const h of items) {
+      console.log(`    L${h.line}  "${h.phrase}"  — ${h.why}`)
+      if (VERBOSE) console.log(`           › ${h.snippet}`)
+    }
+  }
+
+  console.log('\nFix patterns: rewrite with stronger verbs, or add `// ai-slop-allow` inline if legitimate quotation.\n')
+
+  if (STRICT) {
+    console.error(`✗ ai-slop audit: ${hits.length} violation${hits.length === 1 ? '' : 's'} (strict mode)`)
+    process.exit(1)
+  }
+  console.warn(`⚠ ai-slop audit: ${hits.length} hit${hits.length === 1 ? '' : 's'} — non-blocking (re-run with --strict for CI gate)`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error('ai-slop audit failed:', err)
+  process.exit(2)
+})


### PR DESCRIPTION
## Summary

Second batch from the excellence audit. **Brand voice + AI-slop refusal-list enforcement.**

## Brand voice — AI Architect canonical title

CLAUDE.md mandate: title is "AI Architect", never "AI Systems Architect". 5 occurrences fixed:
- app/page.tsx (metadata description, personSchema jobTitle, FAQ answer)
- app/links/metadata.ts (page metadata description)
- BRAND_IDENTITY.md (professional titles list)

**Schema impact:** Google + AI search engines now read 'AI Architect' as Frank's canonical jobTitle on /, /links, and the personSchema.

## AI-slop top-12 user-facing rewrites

13 surgical text changes across user-visible surfaces. Each picks a stronger verb than the AI-slop default:

| Site surface | Before | After |
|---|---|---|
| about FAQ | dive into the blog | open the blog |
| coaching step 1 | Deep dive into your current systems | Map your current systems |
| dashboard course card | Deep dive into sophisticated prompting | Walk through sophisticated prompting |
| games hero | Deep dive into agentic game development | A working primer on agentic game development |
| agent-team CTA | dive into a workshop | step into a workshop |
| AI architect step 1 | Deep dive into business context | Map business context |
| AI architecture meta | Deep dives into AI system architecture | Practical reference for AI system architecture |
| assessment Pioneer | implementing cutting-edge solutions | implementing frontier patterns |
| assessment recommendation | Dive into advanced Agent Architecture | Study advanced Agent Architecture |
| free-playbook blog card | Deep dives into AI creation | Field notes on AI creation |
| ACOS docs Skills card | Deep dive into the 62 skills | Walk through the 62 skills |
| intelligence-atlas action | Dive into Volume I | Open Volume I |
| soulbook internal comment | (cleanup) | |

## AI-slop CI guard

- **scripts/audit-ai-slop.mjs** (NEW) — scans app/, components/, content/, lib/ for the 24 patterns banned in taste.md ('delve into', 'deep dive', 'unleash', 'cutting-edge solution', 'unlock the power', etc.). Conversational chatbot tells ('certainly,' / 'absolutely,') flagged at line start only. Allow-list excludes taste.md, CLAUDE.md, docs/ops/, llms[-full].txt route handlers, design-lab (negative examples), 4 blog slugs that legitimately discuss the patterns.
- **package.json** — npm run ai-slop:audit (warn-only) + npm run ai-slop:audit:strict (CI failure).
- **Baseline:** 109 hits remaining. Frank or follow-up PRs can knock down the rest opportunistically.

## Test plan
- [ ] Vercel preview builds green
- [ ] /llms.txt + /llms-full.txt still serve (no regression from PR #55)
- [ ] /api/links generates Person schema with jobTitle: 'AI Architect'
- [ ] About page FAQ #2 reads 'open the blog' not 'dive into'
- [ ] /coaching step 1 reads 'Map your current systems'
- [ ] node scripts/audit-ai-slop.mjs runs and reports ~109 hits

Source: frankxai/FrankX@7c49e878 (private dev repo)

Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit tool for scanning and maintaining content standards across source files.
  * Added Trophy component to dashboard interface.

* **Documentation**
  * Standardized professional title terminology throughout the site.
  * Updated page descriptions, headings, and FAQ content across multiple sections.

* **Chores**
  * Added new npm scripts for content auditing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->