### PR TITLE
PR #3: feat(seo,workshops) — sitemap Library/OS + workshop server/client split + Course/Event/Breadcrumb schemas

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -311,6 +311,46 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: '/research/methodology', priority: 0.7, changeFrequency: 'monthly' as const },
   ]
 
+  // Library OS hub + manifesto/build/quotes funnels
+  const libraryPages = [
+    { url: '/library', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/library/approach', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/library/build', priority: 0.85, changeFrequency: 'monthly' as const },
+    { url: '/library/quotes', priority: 0.7, changeFrequency: 'weekly' as const },
+  ]
+
+  // Library OS — individual book deep-dives (dynamic from book-reviews registry)
+  let libraryDetailPages: { url: string; priority: number; changeFrequency: 'weekly' | 'monthly' }[] = []
+  try {
+    const reviews = require('@/data/book-reviews').bookReviews as Array<{
+      slug: string
+      reviewDate?: string
+    }>
+    libraryDetailPages = reviews.map((r) => ({
+      url: `/library/${r.slug}`,
+      priority: 0.75,
+      changeFrequency: 'monthly' as const,
+    }))
+  } catch {
+    /* book-reviews may not exist in test envs */
+  }
+
+  // FrankX OS — meta-spine + per-module deep-dives (dynamic from os-modules registry)
+  const osHubPages = [
+    { url: '/os', priority: 0.9, changeFrequency: 'weekly' as const },
+  ]
+  let osDetailPages: { url: string; priority: number; changeFrequency: 'weekly' | 'monthly' }[] = []
+  try {
+    const mods = require('@/data/os-modules').osModules as Array<{ slug: string }>
+    osDetailPages = mods.map((m) => ({
+      url: `/os/${m.slug}`,
+      priority: 0.8,
+      changeFrequency: 'monthly' as const,
+    }))
+  } catch {
+    /* os-modules may not exist */
+  }
+
   // Get dynamic content
   const blogEntries = getBlogEntries()
   const guideSlugs = getGuideSlugs()
@@ -545,6 +585,46 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: currentDate,
       changeFrequency: 'weekly',
       priority: 0.7,
+    })
+  })
+
+  // Library OS — hub + manifesto + build + quotes
+  libraryPages.forEach(page => {
+    entries.push({
+      url: `${BASE_URL}${page.url}`,
+      lastModified: currentDate,
+      changeFrequency: page.changeFrequency,
+      priority: page.priority,
+    })
+  })
+
+  // Library OS — individual book deep-dives
+  libraryDetailPages.forEach(page => {
+    entries.push({
+      url: `${BASE_URL}${page.url}`,
+      lastModified: currentDate,
+      changeFrequency: page.changeFrequency,
+      priority: page.priority,
+    })
+  })
+
+  // FrankX OS — meta-spine hub
+  osHubPages.forEach(page => {
+    entries.push({
+      url: `${BASE_URL}${page.url}`,
+      lastModified: currentDate,
+      changeFrequency: page.changeFrequency,
+      priority: page.priority,
+    })
+  })
+
+  // FrankX OS — per-module deep-dives
+  osDetailPages.forEach(page => {
+    entries.push({
+      url: `${BASE_URL}${page.url}`,
+      lastModified: currentDate,
+      changeFrequency: page.changeFrequency,
+      priority: page.priority,
     })
   })
 

--- a/app/workshops/[slug]/WorkshopClient.tsx
+++ b/app/workshops/[slug]/WorkshopClient.tsx
@@ -1,0 +1,361 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronDown,
+  Clock,
+  ExternalLink,
+  Layers,
+  LinkIcon,
+  Mail,
+  StickyNote,
+  Users,
+} from 'lucide-react'
+import { GlowCard } from '@/components/ui/glow-card'
+import { EmailSignup } from '@/components/email-signup'
+import type { Workshop, WorkshopModule } from '@/data/workshops'
+import type { GlowColor } from '@/components/ui/glow-card'
+
+// ============================================================================
+// MODULE ACCORDION
+// ============================================================================
+
+function ModuleAccordion({
+  module,
+  index,
+  color,
+}: {
+  module: WorkshopModule
+  index: number
+  color: string
+}) {
+  const [isOpen, setIsOpen] = useState(index === 0)
+  const [showNotes, setShowNotes] = useState(false)
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: index * 0.08 }}
+      className="rounded-2xl border border-white/[0.08] bg-white/[0.02] overflow-hidden"
+    >
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center gap-4 p-5 sm:p-6 text-left hover:bg-white/[0.02] transition-colors"
+      >
+        <div className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center text-sm font-semibold text-zinc-400 flex-shrink-0">
+          {index + 1}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base sm:text-lg font-semibold text-white">
+            {module.title}
+          </h3>
+          <p className="text-sm text-zinc-500 mt-0.5 flex items-center gap-1.5">
+            <Clock className="w-3.5 h-3.5" />
+            {module.duration}
+          </p>
+        </div>
+        <ChevronDown
+          className={`w-5 h-5 text-zinc-500 transition-transform duration-200 flex-shrink-0 ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+        />
+      </button>
+
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.25 }}
+            className="overflow-hidden"
+          >
+            <div className="px-5 sm:px-6 pb-5 sm:pb-6 pt-0 space-y-4">
+              <p className="text-sm text-zinc-400 leading-relaxed">
+                {module.description}
+              </p>
+
+              {module.resources.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">
+                    Key Resources
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {module.resources.map((res, i) => {
+                      const isExternal = res.href.startsWith('http')
+                      return (
+                        <Link
+                          key={i}
+                          href={res.href}
+                          target={isExternal ? '_blank' : undefined}
+                          rel={isExternal ? 'noopener noreferrer' : undefined}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-cyan-400 bg-cyan-500/[0.08] border border-cyan-500/20 hover:bg-cyan-500/[0.15] transition-colors"
+                        >
+                          {isExternal ? (
+                            <ExternalLink className="w-3 h-3" />
+                          ) : (
+                            <LinkIcon className="w-3 h-3" />
+                          )}
+                          {res.label}
+                        </Link>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setShowNotes(!showNotes)
+                  }}
+                  className="inline-flex items-center gap-1.5 text-xs font-medium text-zinc-500 hover:text-zinc-300 transition-colors"
+                >
+                  <StickyNote className="w-3.5 h-3.5" />
+                  {showNotes ? 'Hide' : 'Show'} instructor notes
+                </button>
+                <AnimatePresence>
+                  {showNotes && (
+                    <motion.div
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="overflow-hidden"
+                    >
+                      <div className="mt-3 p-4 rounded-xl bg-amber-500/[0.05] border border-amber-500/10">
+                        <p className="text-xs font-medium text-amber-400/80 uppercase tracking-wider mb-1.5">
+                          Instructor Notes
+                        </p>
+                        <p className="text-sm text-zinc-400 leading-relaxed">
+                          {module.instructorNotes}
+                        </p>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  )
+}
+
+// ============================================================================
+// SHARE URL SECTION
+// ============================================================================
+
+function ShareSection({ slug }: { slug: string }) {
+  const [copied, setCopied] = useState(false)
+  const url = `https://frankx.ai/workshops/${slug}`
+
+  function handleCopy() {
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5 sm:p-6">
+      <p className="text-sm font-medium text-zinc-400 mb-3">
+        Share this workshop
+      </p>
+      <div className="flex items-center gap-2">
+        <div className="flex-1 px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-sm text-zinc-400 font-mono truncate">
+          {url}
+        </div>
+        <button
+          onClick={handleCopy}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-white/[0.06] text-zinc-300 hover:bg-white/[0.10] border border-white/[0.08] transition-colors flex-shrink-0"
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// MAIN CLIENT COMPONENT
+// ============================================================================
+
+export default function WorkshopClient({ workshop }: { workshop: Workshop }) {
+  const difficultyColor =
+    workshop.difficulty === 'Beginner'
+      ? 'text-emerald-400'
+      : workshop.difficulty === 'Intermediate'
+        ? 'text-amber-400'
+        : 'text-rose-400'
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0b]">
+      <section className="relative pt-28 pb-16 overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-b from-cyan-500/[0.03] to-transparent" />
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Link
+            href="/workshops"
+            className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 transition-colors mb-8"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            All workshops
+          </Link>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <div className="flex flex-wrap items-center gap-3 mb-4">
+              <span
+                className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium rounded-full border ${
+                  workshop.difficulty === 'Beginner'
+                    ? 'bg-emerald-500/15 text-emerald-400 border-emerald-500/25'
+                    : workshop.difficulty === 'Intermediate'
+                      ? 'bg-amber-500/15 text-amber-400 border-amber-500/25'
+                      : 'bg-rose-500/15 text-rose-400 border-rose-500/25'
+                }`}
+              >
+                {workshop.difficulty}
+              </span>
+              <span className="flex items-center gap-1.5 text-xs text-zinc-500">
+                <Clock className="w-3.5 h-3.5" />
+                {workshop.duration}
+              </span>
+              <span className="flex items-center gap-1.5 text-xs text-zinc-500">
+                <Layers className="w-3.5 h-3.5" />
+                {workshop.moduleCount} modules
+              </span>
+              <span className="flex items-center gap-1.5 text-xs text-zinc-500">
+                <Users className="w-3.5 h-3.5" />
+                {workshop.audience}
+              </span>
+            </div>
+
+            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-3 tracking-tight">
+              {workshop.title}
+            </h1>
+            <p className="text-lg text-zinc-400 mb-8">{workshop.subtitle}</p>
+
+            <p className="text-sm text-zinc-500 leading-relaxed max-w-3xl">
+              {workshop.overview}
+            </p>
+          </motion.div>
+        </div>
+      </section>
+
+      <section className="pb-12">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <GlowCard color={workshop.color as GlowColor}>
+            <div className="p-6 sm:p-8">
+              <h2 className="text-lg font-semibold text-white mb-4">
+                Learning Objectives
+              </h2>
+              <div className="grid sm:grid-cols-2 gap-3">
+                {workshop.objectives.map((obj, i) => (
+                  <div key={i} className="flex items-start gap-2.5">
+                    <div className={`w-1.5 h-1.5 rounded-full mt-2 flex-shrink-0 ${difficultyColor} opacity-60`} />
+                    <p className="text-sm text-zinc-300">{obj}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </GlowCard>
+        </div>
+      </section>
+
+      {workshop.prerequisites.length > 0 && (
+        <section className="pb-12">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-6 sm:p-8">
+              <h2 className="text-lg font-semibold text-white mb-4">
+                Prerequisites
+              </h2>
+              <ul className="space-y-2">
+                {workshop.prerequisites.map((pre, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2.5 text-sm text-zinc-400"
+                  >
+                    <div className="w-1 h-1 rounded-full bg-zinc-600 mt-2 flex-shrink-0" />
+                    {pre}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="pb-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-2xl font-bold text-white mb-6">
+            Workshop Agenda
+          </h2>
+          <div className="space-y-3">
+            {workshop.modules.map((module, index) => (
+              <ModuleAccordion
+                key={index}
+                module={module}
+                index={index}
+                color={workshop.color}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="pb-24">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          <ShareSection slug={workshop.slug} />
+
+          <GlowCard color="emerald">
+            <div className="p-6 sm:p-8 text-center">
+              <Mail className="w-8 h-8 text-emerald-400 mx-auto mb-3" />
+              <h3 className="text-xl font-semibold text-white mb-2">
+                Get the Resource Pack
+              </h3>
+              <p className="text-sm text-zinc-400 mb-5 max-w-md mx-auto">
+                Receive the complete slide deck, handouts, and facilitator guide
+                for this workshop.
+              </p>
+              <div className="max-w-sm mx-auto">
+                <EmailSignup
+                  listType="courses-waitlist"
+                  placeholder="Your email"
+                  buttonText="Send Resource Pack"
+                  compact
+                />
+              </div>
+            </div>
+          </GlowCard>
+
+          <div className="flex items-center justify-between pt-4">
+            <Link
+              href="/workshops"
+              className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              All workshops
+            </Link>
+            <Link
+              href="/workshops/for-educators"
+              className="inline-flex items-center gap-1.5 text-sm text-cyan-400 hover:text-cyan-300 transition-colors"
+            >
+              Educator guide
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/workshops/[slug]/page.tsx
+++ b/app/workshops/[slug]/page.tsx
@@ -1,433 +1,197 @@
-'use client'
-
-import { useState } from 'react'
-import { useParams } from 'next/navigation'
-import Link from 'next/link'
-import { motion, AnimatePresence } from 'framer-motion'
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import {
-  ArrowLeft,
-  ArrowRight,
-  BookOpen,
-  ChevronDown,
-  Clock,
-  ExternalLink,
-  Layers,
-  LinkIcon,
-  Mail,
-  StickyNote,
-  Users,
-} from 'lucide-react'
-import { GlowCard } from '@/components/ui/glow-card'
-import { EmailSignup } from '@/components/email-signup'
-import { getWorkshopBySlug } from '@/data/workshops'
-import type { Workshop, WorkshopModule } from '@/data/workshops'
-import type { GlowColor } from '@/components/ui/glow-card'
+import { getAllWorkshopSlugs, getWorkshopBySlug, type Workshop } from '@/data/workshops'
+import { siteConfig } from '@/lib/seo'
+import { socialLinks } from '@/lib/social-links'
+import WorkshopClient from './WorkshopClient'
 
-// ============================================================================
-// MODULE ACCORDION
-// ============================================================================
+const SITE_URL = siteConfig.url
 
-function ModuleAccordion({
-  module,
-  index,
-  color,
-}: {
-  module: WorkshopModule
-  index: number
-  color: string
-}) {
-  const [isOpen, setIsOpen] = useState(index === 0)
-  const [showNotes, setShowNotes] = useState(false)
+type Params = { slug: string }
 
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 16 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, delay: index * 0.08 }}
-      className="rounded-2xl border border-white/[0.08] bg-white/[0.02] overflow-hidden"
-    >
-      {/* Header */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-4 p-5 sm:p-6 text-left hover:bg-white/[0.02] transition-colors"
-      >
-        <div className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center text-sm font-semibold text-zinc-400 flex-shrink-0">
-          {index + 1}
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="text-base sm:text-lg font-semibold text-white">
-            {module.title}
-          </h3>
-          <p className="text-sm text-zinc-500 mt-0.5 flex items-center gap-1.5">
-            <Clock className="w-3.5 h-3.5" />
-            {module.duration}
-          </p>
-        </div>
-        <ChevronDown
-          className={`w-5 h-5 text-zinc-500 transition-transform duration-200 flex-shrink-0 ${
-            isOpen ? 'rotate-180' : ''
-          }`}
-        />
-      </button>
-
-      {/* Body */}
-      <AnimatePresence initial={false}>
-        {isOpen && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.25 }}
-            className="overflow-hidden"
-          >
-            <div className="px-5 sm:px-6 pb-5 sm:pb-6 pt-0 space-y-4">
-              {/* Description */}
-              <p className="text-sm text-zinc-400 leading-relaxed">
-                {module.description}
-              </p>
-
-              {/* Resources */}
-              {module.resources.length > 0 && (
-                <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">
-                    Key Resources
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    {module.resources.map((res, i) => {
-                      const isExternal = res.href.startsWith('http')
-                      return (
-                        <Link
-                          key={i}
-                          href={res.href}
-                          target={isExternal ? '_blank' : undefined}
-                          rel={isExternal ? 'noopener noreferrer' : undefined}
-                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-cyan-400 bg-cyan-500/[0.08] border border-cyan-500/20 hover:bg-cyan-500/[0.15] transition-colors"
-                        >
-                          {isExternal ? (
-                            <ExternalLink className="w-3 h-3" />
-                          ) : (
-                            <LinkIcon className="w-3 h-3" />
-                          )}
-                          {res.label}
-                        </Link>
-                      )
-                    })}
-                  </div>
-                </div>
-              )}
-
-              {/* Instructor Notes Toggle */}
-              <div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    setShowNotes(!showNotes)
-                  }}
-                  className="inline-flex items-center gap-1.5 text-xs font-medium text-zinc-500 hover:text-zinc-300 transition-colors"
-                >
-                  <StickyNote className="w-3.5 h-3.5" />
-                  {showNotes ? 'Hide' : 'Show'} instructor notes
-                </button>
-                <AnimatePresence>
-                  {showNotes && (
-                    <motion.div
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: 'auto', opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      transition={{ duration: 0.2 }}
-                      className="overflow-hidden"
-                    >
-                      <div className="mt-3 p-4 rounded-xl bg-amber-500/[0.05] border border-amber-500/10">
-                        <p className="text-xs font-medium text-amber-400/80 uppercase tracking-wider mb-1.5">
-                          Instructor Notes
-                        </p>
-                        <p className="text-sm text-zinc-400 leading-relaxed">
-                          {module.instructorNotes}
-                        </p>
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </motion.div>
-  )
+// Pre-render every workshop at build time so metadata + schema are static.
+export function generateStaticParams(): Params[] {
+  return getAllWorkshopSlugs().map((slug) => ({ slug }))
 }
 
-// ============================================================================
-// SHARE URL SECTION
-// ============================================================================
-
-function ShareSection({ slug }: { slug: string }) {
-  const [copied, setCopied] = useState(false)
-  const url = `https://frankx.ai/workshops/${slug}`
-
-  function handleCopy() {
-    navigator.clipboard.writeText(url)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+export async function generateMetadata(
+  { params }: { params: Promise<Params> },
+): Promise<Metadata> {
+  const { slug } = await params
+  const workshop = getWorkshopBySlug(slug)
+  if (!workshop) {
+    return {
+      title: 'Workshop not found · FrankX',
+      robots: { index: false },
+    }
   }
 
-  return (
-    <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5 sm:p-6">
-      <p className="text-sm font-medium text-zinc-400 mb-3">
-        Share this workshop
-      </p>
-      <div className="flex items-center gap-2">
-        <div className="flex-1 px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-sm text-zinc-400 font-mono truncate">
-          {url}
-        </div>
-        <button
-          onClick={handleCopy}
-          className="px-4 py-2 rounded-lg text-sm font-medium bg-white/[0.06] text-zinc-300 hover:bg-white/[0.10] border border-white/[0.08] transition-colors flex-shrink-0"
-        >
-          {copied ? 'Copied' : 'Copy'}
-        </button>
-      </div>
-    </div>
-  )
+  const url = `${SITE_URL}/workshops/${workshop.slug}`
+  const title = `${workshop.title} · FrankX Workshops`
+  const description = workshop.subtitle || workshop.overview.slice(0, 160)
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: siteConfig.shortName,
+      type: 'article',
+      images: [
+        {
+          url: `${SITE_URL}/api/og?title=${encodeURIComponent(workshop.title)}&subtitle=${encodeURIComponent(workshop.subtitle)}`,
+          width: 1200,
+          height: 630,
+          alt: workshop.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      creator: siteConfig.twitter,
+    },
+    keywords: [
+      'workshop',
+      workshop.audience,
+      workshop.difficulty,
+      'AI Architect',
+      'Frank Riemer',
+      ...(workshop.title.split(' ').filter((w) => w.length > 3)),
+    ],
+  }
 }
 
-// ============================================================================
-// SCHEMA MARKUP COMPONENT
-// ============================================================================
-
-function CourseSchema({ workshop }: { workshop: Workshop }) {
-  // Calculate total duration from modules
-  const totalMinutes = workshop.modules.reduce((sum, m) => {
+function totalMinutes(workshop: Workshop): number {
+  return workshop.modules.reduce((sum, m) => {
     const match = m.duration.match(/(\d+)/)
     return sum + (match ? parseInt(match[1], 10) : 0)
   }, 0)
+}
 
-  // All values are static literals from our own data registry, safe for inline rendering
-  const courseLd = JSON.stringify({
+function CourseJsonLd({ workshop }: { workshop: Workshop }) {
+  const minutes = totalMinutes(workshop)
+  const courseLd = {
     '@context': 'https://schema.org',
     '@type': 'Course',
     name: workshop.title,
     description: workshop.overview,
-    url: `https://frankx.ai/workshops/${workshop.slug}`,
+    url: `${SITE_URL}/workshops/${workshop.slug}`,
     provider: {
       '@type': 'Person',
       name: 'Frank Riemer',
-      url: 'https://frankx.ai',
+      url: SITE_URL,
       jobTitle: 'AI Architect',
+      sameAs: [socialLinks.linkedin, socialLinks.github],
     },
     educationalLevel: workshop.difficulty,
-    timeRequired: `PT${totalMinutes}M`,
+    timeRequired: `PT${minutes}M`,
     numberOfCredits: workshop.moduleCount,
     hasCourseInstance: {
       '@type': 'CourseInstance',
-      courseMode: 'onsite',
+      courseMode: 'mixed',
       courseWorkload: workshop.duration,
+      instructor: {
+        '@type': 'Person',
+        name: 'Frank Riemer',
+        url: SITE_URL,
+      },
     },
-  })
+    teaches: workshop.objectives,
+    coursePrerequisites: workshop.prerequisites,
+    audience: {
+      '@type': 'Audience',
+      audienceType: workshop.audience,
+    },
+    inLanguage: 'en',
+  }
 
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: courseLd }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(courseLd) }}
     />
   )
 }
 
-// ============================================================================
-// MAIN PAGE
-// ============================================================================
+function EventJsonLd({ workshop }: { workshop: Workshop }) {
+  // Generic Event schema — for workshops without a specific scheduled date,
+  // we describe the format rather than a concrete instance.
+  const eventLd = {
+    '@context': 'https://schema.org',
+    '@type': 'EducationEvent',
+    name: workshop.title,
+    description: workshop.subtitle,
+    url: `${SITE_URL}/workshops/${workshop.slug}`,
+    eventAttendanceMode: 'https://schema.org/MixedEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: {
+      '@type': 'VirtualLocation',
+      url: `${SITE_URL}/workshops/${workshop.slug}`,
+    },
+    organizer: {
+      '@type': 'Person',
+      name: 'Frank Riemer',
+      url: SITE_URL,
+    },
+    performer: {
+      '@type': 'Person',
+      name: 'Frank Riemer',
+    },
+    audience: {
+      '@type': 'EducationalAudience',
+      audienceType: workshop.audience,
+    },
+    teaches: workshop.objectives,
+    inLanguage: 'en',
+  }
 
-export default function WorkshopDetailPage() {
-  const params = useParams()
-  const slug = params?.slug as string
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(eventLd) }}
+    />
+  )
+}
+
+function BreadcrumbJsonLd({ workshop }: { workshop: Workshop }) {
+  const breadcrumbLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Workshops', item: `${SITE_URL}/workshops` },
+      { '@type': 'ListItem', position: 3, name: workshop.title, item: `${SITE_URL}/workshops/${workshop.slug}` },
+    ],
+  }
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+    />
+  )
+}
+
+export default async function WorkshopDetailPage(
+  { params }: { params: Promise<Params> },
+) {
+  const { slug } = await params
   const workshop = getWorkshopBySlug(slug)
 
   if (!workshop) {
     notFound()
   }
 
-  const difficultyColor =
-    workshop.difficulty === 'Beginner'
-      ? 'text-emerald-400'
-      : workshop.difficulty === 'Intermediate'
-        ? 'text-amber-400'
-        : 'text-rose-400'
-
   return (
-    <div className="min-h-screen bg-[#0a0a0b]">
-      {/* Schema.org Course markup */}
-      <CourseSchema workshop={workshop} />
-
-      {/* Hero */}
-      <section className="relative pt-28 pb-16 overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-b from-cyan-500/[0.03] to-transparent" />
-
-        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Back link */}
-          <Link
-            href="/workshops"
-            className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 transition-colors mb-8"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            All workshops
-          </Link>
-
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            {/* Meta badges */}
-            <div className="flex flex-wrap items-center gap-3 mb-4">
-              <span
-                className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium rounded-full border ${
-                  workshop.difficulty === 'Beginner'
-                    ? 'bg-emerald-500/15 text-emerald-400 border-emerald-500/25'
-                    : workshop.difficulty === 'Intermediate'
-                      ? 'bg-amber-500/15 text-amber-400 border-amber-500/25'
-                      : 'bg-rose-500/15 text-rose-400 border-rose-500/25'
-                }`}
-              >
-                {workshop.difficulty}
-              </span>
-              <span className="flex items-center gap-1.5 text-xs text-zinc-500">
-                <Clock className="w-3.5 h-3.5" />
-                {workshop.duration}
-              </span>
-              <span className="flex items-center gap-1.5 text-xs text-zinc-500">
-                <Layers className="w-3.5 h-3.5" />
-                {workshop.moduleCount} modules
-              </span>
-              <span className="flex items-center gap-1.5 text-xs text-zinc-500">
-                <Users className="w-3.5 h-3.5" />
-                {workshop.audience}
-              </span>
-            </div>
-
-            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-3 tracking-tight">
-              {workshop.title}
-            </h1>
-            <p className="text-lg text-zinc-400 mb-8">{workshop.subtitle}</p>
-
-            {/* Overview */}
-            <p className="text-sm text-zinc-500 leading-relaxed max-w-3xl">
-              {workshop.overview}
-            </p>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Learning Objectives */}
-      <section className="pb-12">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <GlowCard color={workshop.color as GlowColor}>
-            <div className="p-6 sm:p-8">
-              <h2 className="text-lg font-semibold text-white mb-4">
-                Learning Objectives
-              </h2>
-              <div className="grid sm:grid-cols-2 gap-3">
-                {workshop.objectives.map((obj, i) => (
-                  <div key={i} className="flex items-start gap-2.5">
-                    <div className={`w-1.5 h-1.5 rounded-full mt-2 flex-shrink-0 ${difficultyColor} opacity-60`} />
-                    <p className="text-sm text-zinc-300">{obj}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </GlowCard>
-        </div>
-      </section>
-
-      {/* Prerequisites */}
-      {workshop.prerequisites.length > 0 && (
-        <section className="pb-12">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-6 sm:p-8">
-              <h2 className="text-lg font-semibold text-white mb-4">
-                Prerequisites
-              </h2>
-              <ul className="space-y-2">
-                {workshop.prerequisites.map((pre, i) => (
-                  <li
-                    key={i}
-                    className="flex items-start gap-2.5 text-sm text-zinc-400"
-                  >
-                    <div className="w-1 h-1 rounded-full bg-zinc-600 mt-2 flex-shrink-0" />
-                    {pre}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Agenda */}
-      <section className="pb-16">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold text-white mb-6">
-            Workshop Agenda
-          </h2>
-          <div className="space-y-3">
-            {workshop.modules.map((module, index) => (
-              <ModuleAccordion
-                key={index}
-                module={module}
-                index={index}
-                color={workshop.color}
-              />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Share + Email Capture */}
-      <section className="pb-24">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
-          <ShareSection slug={workshop.slug} />
-
-          {/* Resource Pack CTA */}
-          <GlowCard color="emerald">
-            <div className="p-6 sm:p-8 text-center">
-              <Mail className="w-8 h-8 text-emerald-400 mx-auto mb-3" />
-              <h3 className="text-xl font-semibold text-white mb-2">
-                Get the Resource Pack
-              </h3>
-              <p className="text-sm text-zinc-400 mb-5 max-w-md mx-auto">
-                Receive the complete slide deck, handouts, and facilitator guide
-                for this workshop.
-              </p>
-              <div className="max-w-sm mx-auto">
-                <EmailSignup
-                  listType="courses-waitlist"
-                  placeholder="Your email"
-                  buttonText="Send Resource Pack"
-                  compact
-                />
-              </div>
-            </div>
-          </GlowCard>
-
-          {/* Navigation */}
-          <div className="flex items-center justify-between pt-4">
-            <Link
-              href="/workshops"
-              className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              All workshops
-            </Link>
-            <Link
-              href="/workshops/for-educators"
-              className="inline-flex items-center gap-1.5 text-sm text-cyan-400 hover:text-cyan-300 transition-colors"
-            >
-              Educator guide
-              <ArrowRight className="w-4 h-4" />
-            </Link>
-          </div>
-        </div>
-      </section>
-    </div>
+    <>
+      <CourseJsonLd workshop={workshop} />
+      <EventJsonLd workshop={workshop} />
+      <BreadcrumbJsonLd workshop={workshop} />
+      <WorkshopClient workshop={workshop} />
+    </>
   )
 }

--- a/lib/social-links.ts
+++ b/lib/social-links.ts
@@ -95,6 +95,21 @@ export const PRIMARY_SOCIAL_LINKS = Object.values(SOCIAL_PROFILES).filter(
 )
 
 /**
+ * Ergonomic flat-object accessor for url-only consumers.
+ * Mirror of SOCIAL_PROFILES.<key>.url for places that just want the URL string.
+ * Use this in: schema sameAs[], JSX href, email template ${interpolation}.
+ */
+export const socialLinks = {
+  twitter: SOCIAL_PROFILES.x.url,
+  x: SOCIAL_PROFILES.x.url,
+  linkedin: SOCIAL_PROFILES.linkedin.url,
+  github: SOCIAL_PROFILES.github.url,
+  youtube: SOCIAL_PROFILES.youtube.url,
+  instagram: SOCIAL_PROFILES.instagram.url,
+  suno: SOCIAL_PROFILES.suno.url,
+} as const
+
+/**
  * All social links (including secondary)
  */
 export const ALL_SOCIAL_LINKS = Object.values(SOCIAL_PROFILES)


### PR DESCRIPTION
## Summary

Highest revenue-blocking SEO fix from the audit: workshops now ship with proper metadata + schema instead of inheriting the parent layout's defaults via 'use client' silencing.

## Workshop server/client split

- page.tsx: server component, generateStaticParams (8 slugs), generateMetadata (per-slug title/desc/OG), 3 JSON-LD graphs (Course + EducationEvent + BreadcrumbList).
- WorkshopClient.tsx (NEW): client UI with motion + state, accepts workshop prop.

## Sitemap completeness

- /library + /library/{approach,build,quotes} + /library/{slug} dynamic
- /os + /os/{slug} dynamic from data/os-modules.ts

## social-links.ts socialLinks accessor

Flat-object url-only export — adds ergonomic shape without breaking existing SOCIAL_PROFILES consumers.

## Test plan
- [ ] Vercel preview builds green (8 workshops prerender)
- [ ] /workshops/build-first-ai-agent shows unique <title> + meta description
- [ ] view-source on /workshops/{slug} contains 3 JSON-LD blocks
- [ ] /sitemap.xml includes /library, /library/{slug}, /os, /os/{slug} entries

Source: frankxai/FrankX@7c49e878

Co-Authored-By: Claude Opus 4.7 (1M context)