### PR TITLE
Add private birthday tribe dedication pages

### DIFF
--- a/app/tribe/[slug]/page.tsx
+++ b/app/tribe/[slug]/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getTribePerson, tribePeople } from '../people'
+
+export const dynamic = 'force-static'
+
+export function generateStaticParams() {
+  return tribePeople.map((person) => ({ slug: person.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
+  const person = getTribePerson(params.slug)
+
+  if (!person) {
+    return {
+      title: 'Private dedication — FrankX',
+      robots: { index: false, follow: false },
+    }
+  }
+
+  return {
+    title: `${person.name} — Private dedication`,
+    description: person.shortGift,
+    robots: {
+      index: false,
+      follow: false,
+      googleBot: {
+        index: false,
+        follow: false,
+      },
+    },
+    openGraph: {
+      title: `${person.name} — Private dedication`,
+      description: person.shortGift,
+      type: 'website',
+      url: `https://frankx.ai/tribe/${person.slug}`,
+      siteName: 'FrankX',
+      images: [
+        {
+          url: '/hero-homepage.png',
+          width: 1200,
+          height: 630,
+          alt: `${person.name} — Private dedication`,
+        },
+      ],
+    },
+  }
+}
+
+export default function TribePersonPage({ params }: { params: { slug: string } }) {
+  const person = getTribePerson(params.slug)
+
+  if (!person) notFound()
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-white">
+      <section className="relative overflow-hidden border-b border-white/10">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.20),transparent_34%),radial-gradient(circle_at_bottom_right,rgba(168,85,247,0.18),transparent_34%),linear-gradient(180deg,rgba(15,23,42,0.28),rgba(2,6,23,1))]" />
+        <div className="relative mx-auto max-w-5xl px-6 py-20 md:px-10 md:py-28">
+          <Link href="/tribe" className="text-sm font-semibold text-sky-300 hover:text-sky-200">
+            ← Back to tribe
+          </Link>
+          <p className="mt-10 w-fit rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-sky-200">
+            Private dedication
+          </p>
+          <h1 className="mt-6 text-5xl font-semibold tracking-tight text-white md:text-7xl">{person.name}</h1>
+          <p className="mt-5 max-w-3xl text-lg uppercase tracking-[0.18em] text-slate-400">{person.role}</p>
+          <p className="mt-8 max-w-3xl text-xl leading-9 text-slate-200 md:text-2xl">{person.shortGift}</p>
+          <div className="mt-10 rounded-3xl border border-white/10 bg-white/[0.06] p-6 text-slate-300 backdrop-blur">
+            <p className="text-sm font-semibold uppercase tracking-[0.22em] text-slate-500">Sharing standard</p>
+            <p className="mt-3 leading-7">{person.privacy}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-6 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-10 md:py-24">
+        <article className="rounded-[2rem] border border-white/10 bg-white/[0.045] p-8 shadow-2xl shadow-black/25 md:p-10">
+          <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">What I see</p>
+          <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-5xl">The dedication</h2>
+          <p className="mt-6 text-lg leading-9 text-slate-300">{person.dedication}</p>
+        </article>
+
+        <aside className="rounded-[2rem] border border-white/10 bg-slate-900/60 p-8 md:p-10">
+          <p className="text-sm font-semibold uppercase tracking-[0.26em] text-purple-300">The vow</p>
+          <blockquote className="mt-5 text-2xl font-semibold leading-tight text-white md:text-3xl">{person.vow}</blockquote>
+        </aside>
+      </section>
+
+      <section className="border-y border-white/10 bg-white/[0.03]">
+        <div className="mx-auto grid max-w-6xl gap-6 px-6 py-16 md:grid-cols-2 md:px-10 md:py-24">
+          <div className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-8">
+            <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">What you unlocked</p>
+            <ul className="mt-6 space-y-4 text-slate-300">
+              {person.unlocked.map((item) => (
+                <li key={item} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 leading-7">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-8">
+            <p className="text-sm font-semibold uppercase tracking-[0.26em] text-purple-300">What I offer back</p>
+            <ul className="mt-6 space-y-4 text-slate-300">
+              {person.offered.map((item) => (
+                <li key={item} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 leading-7">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-4xl px-6 py-20 text-center md:px-10 md:py-28">
+        <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">Birthday gift</p>
+        <h2 className="mt-5 text-3xl font-semibold tracking-tight md:text-5xl">Not a request. A thank-you in form.</h2>
+        <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-slate-300">
+          This page exists because gratitude should become architecture: words, pages, systems, rituals, and offerings that outlive the mood that created them.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/app/tribe/page.tsx
+++ b/app/tribe/page.tsx
@@ -1,9 +1,11 @@
+import Link from 'next/link'
 import { createMetadata } from '@/lib/seo'
+import { tributeArtifacts, tribePeople } from './people'
 
 export const metadata = createMetadata({
   title: 'The Tribe — FrankX',
   description:
-    'A living gratitude page for the people, family, friends, mentors, colleagues, and builders who helped make the work possible.',
+    'A living gratitude index for the people, family, friends, mentors, colleagues, and creators who helped make the work possible.',
   path: '/tribe',
   keywords: [
     'FrankX tribe',
@@ -15,77 +17,6 @@ export const metadata = createMetadata({
   ],
 })
 
-const dedications = [
-  {
-    name: 'Tien',
-    role: 'Love, home, tenderness',
-    gift: 'You remind me that ambition means nothing when it is not held by care, presence, warmth, and devotion.',
-  },
-  {
-    name: 'Family',
-    role: 'Roots, sacrifice, belonging',
-    gift: 'You gave me the first architecture: resilience, loyalty, memory, and the quiet force to keep becoming.',
-  },
-  {
-    name: 'My Mother',
-    role: 'Life, care, emotional strength',
-    gift: 'You shaped the part of me that still believes love can be practical, protective, and endlessly generous.',
-  },
-  {
-    name: 'My Brother',
-    role: 'Grounding, humor, Croatia, reality checks',
-    gift: 'You remind me that big visions need real rooms, real work, real laughter, and people who see through the performance.',
-  },
-  {
-    name: 'Friends',
-    role: 'Mirrors, movement, shared moments',
-    gift: 'You gave contrast, energy, honest reflection, and the proof that a life is not built alone.',
-  },
-  {
-    name: 'Mentors and elders',
-    role: 'Standards, pressure, direction',
-    gift: 'You raised the ceiling of what I considered possible and made excellence feel like a responsibility.',
-  },
-  {
-    name: 'Oracle AI Center of Excellence',
-    role: 'Professional crucible',
-    gift: 'You sharpened the architect in me: enterprise pressure, client reality, cloud systems, AI strategy, and the discipline to translate intelligence into value.',
-  },
-  {
-    name: 'Builders, creators, and collaborators',
-    role: 'Momentum and craft',
-    gift: 'You turned ideas into sharper questions, prototypes, pages, tools, songs, systems, and the next version of the work.',
-  },
-  {
-    name: 'Future tribe',
-    role: 'Readers, students, founders, seekers',
-    gift: 'You are the reason the work cannot stay private. The systems, writings, songs, and tools are meant to become useful beyond me.',
-  },
-]
-
-const artifacts = [
-  {
-    title: 'Poetry',
-    body: 'Words became bridges: between gratitude and ambition, between shadow and light, between the life I had and the life I am building.',
-  },
-  {
-    title: 'Insights',
-    body: 'Each relationship became signal: where I was grasping, where I was growing, where I needed more truth, structure, courage, and love.',
-  },
-  {
-    title: 'Articles',
-    body: 'The conversations, pressure, and lived experiences became public thinking: essays, frameworks, notes, and maps for other builders.',
-  },
-  {
-    title: 'Sites',
-    body: 'FrankX, Starlight, Arcanea, and the wider creator stack are not solo monuments. They are crystallized from many encounters, mirrors, and gifts.',
-  },
-  {
-    title: 'Systems',
-    body: 'The real tribute is operational: cleaner pages, stronger rituals, better knowledge architecture, more useful tools, and work that compounds.',
-  },
-]
-
 export default function TribePage() {
   return (
     <main className="min-h-screen bg-slate-950 text-white">
@@ -93,13 +24,13 @@ export default function TribePage() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(168,85,247,0.18),transparent_32%),linear-gradient(180deg,rgba(15,23,42,0.35),rgba(2,6,23,1))]" />
         <div className="relative mx-auto flex min-h-[72vh] max-w-6xl flex-col justify-center px-6 py-24 md:px-10">
           <p className="mb-5 w-fit rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-sky-200">
-            Birthday dedication
+            Birthday dedication system
           </p>
           <h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-white md:text-7xl">
-            The people who made the work possible.
+            Private pages for the people who made the work possible.
           </h1>
           <p className="mt-8 max-w-2xl text-lg leading-8 text-slate-300 md:text-xl">
-            This page is a living thank-you to the people I love, respect, learn from, build with, and carry forward. My birthday is not only a day to be remembered. It is a day to remember.
+            This is the public doorway. The real gifts are the individual pages: ten private, direct dedications for love, family, friends, mentors, creators, colleagues, builders, and the future tribe this work is meant to serve.
           </p>
           <div className="mt-10 grid gap-4 md:grid-cols-3">
             <div className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
@@ -108,11 +39,11 @@ export default function TribePage() {
             </div>
             <div className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
               <p className="text-sm uppercase tracking-[0.22em] text-slate-400">Gift</p>
-              <p className="mt-3 text-2xl font-semibold">Gratitude made public.</p>
+              <p className="mt-3 text-2xl font-semibold">One page per person.</p>
             </div>
             <div className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
               <p className="text-sm uppercase tracking-[0.22em] text-slate-400">Standard</p>
-              <p className="mt-3 text-2xl font-semibold">Love without auditing.</p>
+              <p className="mt-3 text-2xl font-semibold">Private by default.</p>
             </div>
           </div>
         </div>
@@ -120,23 +51,25 @@ export default function TribePage() {
 
       <section className="mx-auto max-w-6xl px-6 py-20 md:px-10">
         <div className="mb-10 max-w-3xl">
-          <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">The dedication</p>
-          <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-5xl">A clean monument, not a performance.</h2>
+          <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">Top ten pages</p>
+          <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-5xl">A gratitude architecture, not a performance.</h2>
           <p className="mt-5 text-lg leading-8 text-slate-300">
-            Some names are public. Some stay private. The point is not exposure. The point is honor. Every poem, article, system, site, and song carries traces of people who gave me love, pressure, contrast, care, challenge, beauty, and belief.
+            Each page is a private artifact: what I see in them, what they unlocked in me, what I have already started building or freely offered because of them, and what I vow to carry forward.
           </p>
         </div>
 
         <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-          {dedications.map((person) => (
-            <article
-              key={person.name}
+          {tribePeople.map((person) => (
+            <Link
+              key={person.slug}
+              href={`/tribe/${person.slug}`}
               className="group rounded-3xl border border-white/10 bg-white/[0.045] p-6 shadow-2xl shadow-black/20 transition duration-300 hover:-translate-y-1 hover:border-sky-300/40 hover:bg-white/[0.075]"
             >
               <p className="text-sm uppercase tracking-[0.22em] text-slate-500">{person.role}</p>
               <h3 className="mt-3 text-2xl font-semibold text-white">{person.name}</h3>
-              <p className="mt-4 leading-7 text-slate-300">{person.gift}</p>
-            </article>
+              <p className="mt-4 leading-7 text-slate-300">{person.shortGift}</p>
+              <p className="mt-6 text-sm font-semibold text-sky-300">Open dedication →</p>
+            </Link>
           ))}
         </div>
       </section>
@@ -147,12 +80,12 @@ export default function TribePage() {
             <p className="text-sm font-semibold uppercase tracking-[0.26em] text-purple-300">What they unlocked</p>
             <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-5xl">The artifacts are the thank-you.</h2>
             <p className="mt-5 text-lg leading-8 text-slate-300">
-              Gratitude should not stay sentimental. It should become form. Better writing. Cleaner pages. Stronger products. More honest art. A life that makes the people around it glad they invested love, time, and attention.
+              Gratitude should not stay sentimental. It should become form: better writing, cleaner pages, stronger products, more honest art, and work that compounds.
             </p>
           </div>
 
           <div className="grid gap-5 md:grid-cols-5">
-            {artifacts.map((artifact) => (
+            {tributeArtifacts.map((artifact) => (
               <div key={artifact.title} className="rounded-3xl border border-white/10 bg-slate-950/70 p-5">
                 <h3 className="text-xl font-semibold text-white">{artifact.title}</h3>
                 <p className="mt-4 text-sm leading-7 text-slate-400">{artifact.body}</p>
@@ -173,7 +106,7 @@ export default function TribePage() {
         <div className="mt-10 rounded-3xl border border-white/10 bg-white/[0.06] p-6 text-left text-slate-300">
           <p className="text-sm font-semibold uppercase tracking-[0.22em] text-slate-500">Private by design</p>
           <p className="mt-3 leading-7">
-            This page intentionally avoids private stories, sensitive details, and names that deserve consent before becoming public. The public layer honors the tribe. The private layer remains human.
+            The individual pages are unlisted and marked noindex. Real privacy still requires authentication later; this version is designed for intentional sharing, not search discovery.
           </p>
         </div>
       </section>

--- a/app/tribe/page.tsx
+++ b/app/tribe/page.tsx
@@ -1,0 +1,182 @@
+import { createMetadata } from '@/lib/seo'
+
+export const metadata = createMetadata({
+  title: 'The Tribe — FrankX',
+  description:
+    'A living gratitude page for the people, family, friends, mentors, colleagues, and builders who helped make the work possible.',
+  path: '/tribe',
+  keywords: [
+    'FrankX tribe',
+    'creator gratitude',
+    'friends and family',
+    'AI creator journey',
+    'personal operating system',
+    'creative community',
+  ],
+})
+
+const dedications = [
+  {
+    name: 'Tien',
+    role: 'Love, home, tenderness',
+    gift: 'You remind me that ambition means nothing when it is not held by care, presence, warmth, and devotion.',
+  },
+  {
+    name: 'Family',
+    role: 'Roots, sacrifice, belonging',
+    gift: 'You gave me the first architecture: resilience, loyalty, memory, and the quiet force to keep becoming.',
+  },
+  {
+    name: 'My Mother',
+    role: 'Life, care, emotional strength',
+    gift: 'You shaped the part of me that still believes love can be practical, protective, and endlessly generous.',
+  },
+  {
+    name: 'My Brother',
+    role: 'Grounding, humor, Croatia, reality checks',
+    gift: 'You remind me that big visions need real rooms, real work, real laughter, and people who see through the performance.',
+  },
+  {
+    name: 'Friends',
+    role: 'Mirrors, movement, shared moments',
+    gift: 'You gave contrast, energy, honest reflection, and the proof that a life is not built alone.',
+  },
+  {
+    name: 'Mentors and elders',
+    role: 'Standards, pressure, direction',
+    gift: 'You raised the ceiling of what I considered possible and made excellence feel like a responsibility.',
+  },
+  {
+    name: 'Oracle AI Center of Excellence',
+    role: 'Professional crucible',
+    gift: 'You sharpened the architect in me: enterprise pressure, client reality, cloud systems, AI strategy, and the discipline to translate intelligence into value.',
+  },
+  {
+    name: 'Builders, creators, and collaborators',
+    role: 'Momentum and craft',
+    gift: 'You turned ideas into sharper questions, prototypes, pages, tools, songs, systems, and the next version of the work.',
+  },
+  {
+    name: 'Future tribe',
+    role: 'Readers, students, founders, seekers',
+    gift: 'You are the reason the work cannot stay private. The systems, writings, songs, and tools are meant to become useful beyond me.',
+  },
+]
+
+const artifacts = [
+  {
+    title: 'Poetry',
+    body: 'Words became bridges: between gratitude and ambition, between shadow and light, between the life I had and the life I am building.',
+  },
+  {
+    title: 'Insights',
+    body: 'Each relationship became signal: where I was grasping, where I was growing, where I needed more truth, structure, courage, and love.',
+  },
+  {
+    title: 'Articles',
+    body: 'The conversations, pressure, and lived experiences became public thinking: essays, frameworks, notes, and maps for other builders.',
+  },
+  {
+    title: 'Sites',
+    body: 'FrankX, Starlight, Arcanea, and the wider creator stack are not solo monuments. They are crystallized from many encounters, mirrors, and gifts.',
+  },
+  {
+    title: 'Systems',
+    body: 'The real tribute is operational: cleaner pages, stronger rituals, better knowledge architecture, more useful tools, and work that compounds.',
+  },
+]
+
+export default function TribePage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-white">
+      <section className="relative overflow-hidden border-b border-white/10">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(168,85,247,0.18),transparent_32%),linear-gradient(180deg,rgba(15,23,42,0.35),rgba(2,6,23,1))]" />
+        <div className="relative mx-auto flex min-h-[72vh] max-w-6xl flex-col justify-center px-6 py-24 md:px-10">
+          <p className="mb-5 w-fit rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-sky-200">
+            Birthday dedication
+          </p>
+          <h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-white md:text-7xl">
+            The people who made the work possible.
+          </h1>
+          <p className="mt-8 max-w-2xl text-lg leading-8 text-slate-300 md:text-xl">
+            This page is a living thank-you to the people I love, respect, learn from, build with, and carry forward. My birthday is not only a day to be remembered. It is a day to remember.
+          </p>
+          <div className="mt-10 grid gap-4 md:grid-cols-3">
+            <div className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
+              <p className="text-sm uppercase tracking-[0.22em] text-slate-400">Posture</p>
+              <p className="mt-3 text-2xl font-semibold">Overflow, not hunger.</p>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
+              <p className="text-sm uppercase tracking-[0.22em] text-slate-400">Gift</p>
+              <p className="mt-3 text-2xl font-semibold">Gratitude made public.</p>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-white/[0.06] p-5 backdrop-blur">
+              <p className="text-sm uppercase tracking-[0.22em] text-slate-400">Standard</p>
+              <p className="mt-3 text-2xl font-semibold">Love without auditing.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20 md:px-10">
+        <div className="mb-10 max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">The dedication</p>
+          <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-5xl">A clean monument, not a performance.</h2>
+          <p className="mt-5 text-lg leading-8 text-slate-300">
+            Some names are public. Some stay private. The point is not exposure. The point is honor. Every poem, article, system, site, and song carries traces of people who gave me love, pressure, contrast, care, challenge, beauty, and belief.
+          </p>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {dedications.map((person) => (
+            <article
+              key={person.name}
+              className="group rounded-3xl border border-white/10 bg-white/[0.045] p-6 shadow-2xl shadow-black/20 transition duration-300 hover:-translate-y-1 hover:border-sky-300/40 hover:bg-white/[0.075]"
+            >
+              <p className="text-sm uppercase tracking-[0.22em] text-slate-500">{person.role}</p>
+              <h3 className="mt-3 text-2xl font-semibold text-white">{person.name}</h3>
+              <p className="mt-4 leading-7 text-slate-300">{person.gift}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-white/[0.03]">
+        <div className="mx-auto max-w-6xl px-6 py-20 md:px-10">
+          <div className="mb-10 max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.26em] text-purple-300">What they unlocked</p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-5xl">The artifacts are the thank-you.</h2>
+            <p className="mt-5 text-lg leading-8 text-slate-300">
+              Gratitude should not stay sentimental. It should become form. Better writing. Cleaner pages. Stronger products. More honest art. A life that makes the people around it glad they invested love, time, and attention.
+            </p>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-5">
+            {artifacts.map((artifact) => (
+              <div key={artifact.title} className="rounded-3xl border border-white/10 bg-slate-950/70 p-5">
+                <h3 className="text-xl font-semibold text-white">{artifact.title}</h3>
+                <p className="mt-4 text-sm leading-7 text-slate-400">{artifact.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-4xl px-6 py-24 text-center md:px-10">
+        <p className="text-sm font-semibold uppercase tracking-[0.26em] text-sky-300">The vow</p>
+        <blockquote className="mt-6 text-3xl font-semibold leading-tight tracking-tight md:text-5xl">
+          I do not need this life to prove I am loved. I use this life to become love in motion.
+        </blockquote>
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-slate-300">
+          To everyone who shaped me: thank you. I will make the work cleaner, braver, more beautiful, and more useful because you were part of the path.
+        </p>
+        <div className="mt-10 rounded-3xl border border-white/10 bg-white/[0.06] p-6 text-left text-slate-300">
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-slate-500">Private by design</p>
+          <p className="mt-3 leading-7">
+            This page intentionally avoids private stories, sensitive details, and names that deserve consent before becoming public. The public layer honors the tribe. The private layer remains human.
+          </p>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/tribe/people.ts
+++ b/app/tribe/people.ts
@@ -1,0 +1,261 @@
+export type TribePerson = {
+  slug: string
+  name: string
+  role: string
+  privacy: string
+  shortGift: string
+  dedication: string
+  unlocked: string[]
+  offered: string[]
+  vow: string
+}
+
+export const tribePeople: TribePerson[] = [
+  {
+    slug: 'tien',
+    name: 'Tien',
+    role: 'Love, home, tenderness, devotion',
+    privacy: 'Intimate page. Share only with care.',
+    shortGift:
+      'You remind me that ambition means nothing when it is not held by care, presence, warmth, and devotion.',
+    dedication:
+      'You are one of the clearest proofs in my life that love can be gentle and strong at the same time. You give me home, patience, care, and the kind of daily devotion that does not need to announce itself to be real. Because of you, I am learning that the highest version of my work cannot be built from hunger. It has to be built from overflow.',
+    unlocked: [
+      'A deeper standard for presence instead of constant pursuit.',
+      'A cleaner relationship between ambition, loyalty, tenderness, and truth.',
+      'The reminder that the most advanced life still has to be lived kindly at home.',
+    ],
+    offered: [
+      'A more grounded version of myself, not only a more successful one.',
+      'A future where business, beauty, home, health, and love can reinforce each other.',
+      'Systems that create freedom without sacrificing warmth.',
+    ],
+    vow:
+      'I will not use ambition as an escape from love. I will build a life where the people closest to me feel more peace, beauty, and possibility because I existed.',
+  },
+  {
+    slug: 'mother',
+    name: 'My Mother',
+    role: 'Life, care, emotional strength',
+    privacy: 'Family page. Keep dignified and protected.',
+    shortGift:
+      'You shaped the part of me that still believes love can be practical, protective, and endlessly generous.',
+    dedication:
+      'You gave me more than life. You gave me the emotional proof that care is a force. The food, concern, protection, reminders, and sacrifice became part of my operating system long before I had words for it. Many of my ideas about helping people, building useful systems, and creating a better tomorrow carry your imprint.',
+    unlocked: [
+      'The instinct to protect and provide, not only to achieve.',
+      'The capacity to feel deeply while still moving forward.',
+      'A respect for family sacrifice as a foundation, not a side note.',
+    ],
+    offered: [
+      'A son who turns your care into contribution.',
+      'A family legacy that becomes stronger, more beautiful, and more sovereign.',
+      'Work that carries warmth instead of cold ambition.',
+    ],
+    vow:
+      'I will make the life you helped create worth the love, labor, and sacrifice that shaped it.',
+  },
+  {
+    slug: 'brother',
+    name: 'My Brother',
+    role: 'Grounding, humor, Croatia, reality checks',
+    privacy: 'Family page. Share only when it feels right.',
+    shortGift:
+      'You remind me that big visions need real rooms, real work, real laughter, and people who see through the performance.',
+    dedication:
+      'You have a way of cutting through the fantasy layer and bringing me back to concrete reality. That is a gift. The brother bond is not always polished, but it is real: humor, friction, memory, challenge, loyalty, and the strange comfort of being known before the brand, before the ambition, before the grand architecture.',
+    unlocked: [
+      'A stronger respect for practical execution over beautiful abstraction.',
+      'The reminder that lifestyle dreams need real places, real people, and real logistics.',
+      'A more honest balance between vision and grounded brotherhood.',
+    ],
+    offered: [
+      'Creative hubs and future spaces that include family, not only business.',
+      'A path where success can create more time, freedom, and shared experience.',
+      'A version of ambition that still has room for laughter and truth.',
+    ],
+    vow:
+      'I will build in a way that makes the vision real enough to be visited, used, lived in, and shared.',
+  },
+  {
+    slug: 'family-line',
+    name: 'Family Line',
+    role: 'Roots, ancestry, sacrifice, endurance',
+    privacy: 'Ancestral page. Keep sacred and restrained.',
+    shortGift:
+      'You gave me the first architecture: resilience, loyalty, memory, and the quiet force to keep becoming.',
+    dedication:
+      'My family line carries exile, labor, migration, endurance, and the will to survive. That history is not a decoration. It is a pressure field. It asks me to do something cleaner with the life I have been given: build freedom, beauty, intelligence, and dignity from inherited resilience.',
+    unlocked: [
+      'The seriousness to treat freedom as a responsibility.',
+      'A deeper respect for roots, language, memory, and place.',
+      'The instinct to build systems that outlive temporary moods.',
+    ],
+    offered: [
+      'A public body of work that turns survival into sovereignty.',
+      'A future family architecture with more beauty, optionality, and peace.',
+      'A life that honors the past without remaining imprisoned by it.',
+    ],
+    vow:
+      'I will not waste the freedom that earlier generations suffered to make possible.',
+  },
+  {
+    slug: 'close-friends',
+    name: 'Close Friends',
+    role: 'Mirrors, movement, shared moments',
+    privacy: 'Private circle. Add names only with consent.',
+    shortGift:
+      'You gave contrast, energy, honest reflection, and the proof that a life is not built alone.',
+    dedication:
+      'Friendship is one of the great reality checks. Friends show where the persona ends and the human begins. Some friendships gave adventure. Some gave challenge. Some gave disappointment that became clarity. Some gave joy without needing a thesis. All of it shaped the work.',
+    unlocked: [
+      'The courage to be seen outside polished professional identity.',
+      'A better sense for social energy, status, belonging, and generosity.',
+      'The knowledge that community has to be built, not passively waited for.',
+    ],
+    offered: [
+      'More intentional gatherings, better conversations, and cleaner invitations.',
+      'Creative systems that make collaboration easier and more alive.',
+      'A higher standard of friendship: less auditing, more presence.',
+    ],
+    vow:
+      'I will become the kind of friend whose presence gives people more clarity, courage, beauty, and momentum.',
+  },
+  {
+    slug: 'oracle-ai-coe',
+    name: 'Oracle AI Center of Excellence',
+    role: 'Professional crucible, AI architecture, enterprise pressure',
+    privacy: 'Professional page. Keep public-safe and non-confidential.',
+    shortGift:
+      'You sharpened the architect in me: enterprise pressure, client reality, cloud systems, AI strategy, and the discipline to translate intelligence into value.',
+    dedication:
+      'The AI Center of Excellence became a crucible. It forced intelligence to leave the abstract layer and meet customers, architecture, politics, constraints, compute, cost, security, trust, and business value. It taught me that real intelligence has to survive the room.',
+    unlocked: [
+      'A stronger enterprise architecture backbone.',
+      'The ability to translate AI possibility into business language and implementation reality.',
+      'A network of brilliant people, hard lessons, and standards I will carry forward.',
+    ],
+    offered: [
+      'Reusable AI architecture frameworks for builders and enterprises.',
+      'A public knowledge base that turns field lessons into non-confidential education.',
+      'Systems that help others move from AI fascination to operational capability.',
+    ],
+    vow:
+      'I will carry the best of this chapter forward without leaking what should stay protected.',
+  },
+  {
+    slug: 'ai-builders',
+    name: 'AI Builders and Collaborators',
+    role: 'Momentum, craft, prototypes, systems',
+    privacy: 'Collaborator page. Add specific names only when appropriate.',
+    shortGift:
+      'You turned ideas into sharper questions, prototypes, pages, tools, songs, systems, and the next version of the work.',
+    dedication:
+      'Every serious builder changes the field around them. The collaborators, coders, designers, founders, researchers, and AI toolmakers around this journey made the work less theoretical. They made it executable. They proved that ideas become real when the right people touch them.',
+    unlocked: [
+      'A bias toward shipping instead of endless ideation.',
+      'A practical respect for GitHub, Vercel, agents, design systems, and deployment reality.',
+      'The understanding that intelligence compounds fastest in networks.',
+    ],
+    offered: [
+      'Open systems, templates, agent architectures, and creator infrastructure.',
+      'Clearer documentation so others can build faster from what I learn.',
+      'A future collaboration layer where human and AI builders can coordinate cleanly.',
+    ],
+    vow:
+      'I will make the systems more useful, more elegant, and more forkable because serious builders deserve leverage.',
+  },
+  {
+    slug: 'creator-mentors',
+    name: 'Creator Mentors',
+    role: 'Standards, taste, courage, visibility',
+    privacy: 'Appreciation page. Use public figures and creators respectfully.',
+    shortGift:
+      'You raised the ceiling of what I considered possible and made excellence feel like a responsibility.',
+    dedication:
+      'Some creators never met me and still changed me. Writers, strategists, musicians, founders, spiritual teachers, technologists, filmmakers, designers, and high-agency builders gave me patterns to study. They showed that a human can become a signal strong enough to reorganize other people’s futures.',
+    unlocked: [
+      'Higher taste in storytelling, brand, systems, music, and personal standards.',
+      'The permission to merge business, technology, spirituality, health, and art without asking for consensus.',
+      'A clearer sense that creation is not content. It is civilization-scale signaling.',
+    ],
+    offered: [
+      'Curated appreciation essays and public notes on what their work unlocked.',
+      'Derivative-free original systems inspired by their standards, not copied from their surface.',
+      'A creator library that turns admiration into study, synthesis, and contribution.',
+    ],
+    vow:
+      'I will not merely consume brilliance. I will metabolize it into original work that helps others rise.',
+  },
+  {
+    slug: 'spiritual-teachers',
+    name: 'Spiritual and Philosophical Teachers',
+    role: 'Faith, consciousness, identity, inner law',
+    privacy: 'Sacred page. Keep grounded, not performative.',
+    shortGift:
+      'You helped me see that reality is not only built through tools, but through attention, belief, gratitude, discipline, and love.',
+    dedication:
+      'The teachings that shaped me most point back to the same hard truth: inner state becomes perception, perception becomes decision, decision becomes action, and action becomes world. Faith without embodiment becomes fantasy. Strategy without soul becomes machinery. The work has to unify both.',
+    unlocked: [
+      'A deeper respect for gratitude as state calibration, not politeness.',
+      'A more serious relationship with prayer, imagination, identity, and attention.',
+      'The understanding that manifestation must become behavior, systems, and service.',
+    ],
+    offered: [
+      'Manifestation Intelligence Systems that convert inner practice into embodied execution.',
+      'Rituals, songs, prompts, and pages that help people return to clarity.',
+      'A living bridge between consciousness work and practical architecture.',
+    ],
+    vow:
+      'I will keep the sacred practical and the practical sacred.',
+  },
+  {
+    slug: 'future-tribe',
+    name: 'Future Tribe',
+    role: 'Readers, students, founders, seekers, creators',
+    privacy: 'Public-facing page. This is the bridge outward.',
+    shortGift:
+      'You are the reason the work cannot stay private. The systems, writings, songs, and tools are meant to become useful beyond me.',
+    dedication:
+      'Some people are not in my life yet, but the work is already being built for them. The future tribe includes creators, founders, students, builders, seekers, and operators who feel that intelligence should become freedom, beauty, contribution, and self-command.',
+    unlocked: [
+      'A reason to publish instead of hoard insight privately.',
+      'A standard that every system must eventually help someone beyond me.',
+      'The pressure to turn personal transformation into usable architecture.',
+    ],
+    offered: [
+      'FrankX as a creator intelligence hub.',
+      'Arcanea as a transformation universe and imagination engine.',
+      'Starlight Intelligence Systems as a substrate for human and AI coordination.',
+    ],
+    vow:
+      'I will build tools, worlds, and teachings that make other people more capable, sovereign, alive, and awake.',
+  },
+]
+
+export const tributeArtifacts = [
+  {
+    title: 'Poetry',
+    body: 'Words became bridges: between gratitude and ambition, between shadow and light, between the life I had and the life I am building.',
+  },
+  {
+    title: 'Insights',
+    body: 'Each relationship became signal: where I was grasping, where I was growing, where I needed more truth, structure, courage, and love.',
+  },
+  {
+    title: 'Articles',
+    body: 'The conversations, pressure, and lived experiences became public thinking: essays, frameworks, notes, and maps for other builders.',
+  },
+  {
+    title: 'Sites',
+    body: 'FrankX, Starlight, Arcanea, and the wider creator stack are not solo monuments. They are crystallized from many encounters, mirrors, and gifts.',
+  },
+  {
+    title: 'Systems',
+    body: 'The real tribute is operational: cleaner pages, stronger rituals, better knowledge architecture, more useful tools, and work that compounds.',
+  },
+]
+
+export function getTribePerson(slug: string) {
+  return tribePeople.find((person) => person.slug === slug)
+}


### PR DESCRIPTION
## Summary

Adds a `/tribe` birthday gratitude system with a public hub and ten unlisted/noindex dedication pages.

## Intent

- Convert birthday energy into private, direct gift pages instead of one broad public performance
- Make one page per person/category for the top 10 currently-known anchors
- Frame each dedication around:
  - what I see in them
  - what they unlocked in me
  - what I have already started building or freely offered because of them
  - the vow I carry forward
- Keep pages emotionally precise but privacy-safe

## Pages

- `app/tribe/page.tsx` — public index / doorway
- `app/tribe/people.ts` — dedication data model for top 10 pages
- `app/tribe/[slug]/page.tsx` — generated private dedication pages

## Current top 10

1. Tien
2. My Mother
3. My Brother
4. Family Line
5. Close Friends
6. Oracle AI Center of Excellence
7. AI Builders and Collaborators
8. Creator Mentors
9. Spiritual and Philosophical Teachers
10. Future Tribe

## Privacy posture

Individual pages are marked `noindex` and unlisted-by-intent, but this is not true authentication. Real privacy should later be implemented with auth, signed links, or a private notes layer if sensitive personal names/stories are added.

## Notes

This intentionally avoids naming ambiguous private people and avoids turning the pages into emotional evidence. The posture is gift, not audit.