### PR TITLE
feat(prompt-hub): sync /prompts surface from FrankX

### DIFF
--- a/app/prompts/page.tsx
+++ b/app/prompts/page.tsx
@@ -1,0 +1,283 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Prompt Hub — Every prompt evaluated, attributed, lab-tagged, red-teamed | FrankX',
+  description:
+    'The FrankX Prompt Hub: a 13-agent team that designs, optimizes, evaluates, and red-teams elite prompts across Claude, GPT, Gemini, and open-source models. Plus a Psyche Cartographer for IFS-based introspection. Open source.',
+  alternates: { canonical: 'https://www.frankx.ai/prompts' },
+  openGraph: {
+    title: 'Prompt Hub — FrankX',
+    description:
+      'Every prompt evaluated, attributed, lab-tagged, red-teamed. Designed by a 13-agent team. Open source.',
+    url: 'https://www.frankx.ai/prompts',
+    type: 'website',
+  },
+};
+
+const AGENT_TEAM = [
+  {
+    cluster: 'Composer',
+    agents: [
+      { name: '@prompt-conductor', role: 'Opus composer; routes every ask to a flow' },
+    ],
+  },
+  {
+    cluster: 'Lab specialists',
+    agents: [
+      { name: '@prompt-claude-specialist', role: 'XML tags, prefill, extended thinking' },
+      { name: '@prompt-gpt-specialist', role: 'developer role, Structured Outputs, contradiction audit' },
+      { name: '@prompt-gemini-specialist', role: 'system-at-top, native grounding' },
+      { name: '@prompt-oss-specialist', role: 'Llama / Mistral / Qwen / R1 chat templates' },
+    ],
+  },
+  {
+    cluster: 'Core builders',
+    agents: [
+      { name: '@prompt-architect', role: 'designs new prompts from blank' },
+      { name: '@prompt-optimizer', role: 'refines existing prompts' },
+      { name: '@prompt-evaluator', role: 'wraps promptfoo; scores prompts' },
+    ],
+  },
+  {
+    cluster: 'Library curators',
+    agents: [
+      { name: '@prompt-librarian', role: 'owns the corpus; ranks, tags, attributes' },
+      { name: '@prompt-harvester', role: 'bulk-imports from Fabric / awesome-* repos' },
+    ],
+  },
+  {
+    cluster: 'Safety + psyche',
+    agents: [
+      { name: '@prompt-red-team', role: 'adversarial probes; publish gate' },
+      { name: '@prompt-psyche-cartographer', role: 'IFS introspection; maps not unburdens' },
+      { name: '@prompt-psychometrist', role: 'IPIP-50 / PVQ / ECR-R / VIA — lenses not verdicts' },
+    ],
+  },
+];
+
+const FLOWS = [
+  { flow: 'flow-design', trigger: 'design a prompt for X', sequence: 'architect → lab-specialist → red-team → evaluator' },
+  { flow: 'flow-optimize', trigger: 'optimize this prompt / /po', sequence: 'optimizer → lab-specialist → evaluator' },
+  { flow: 'flow-evaluate', trigger: 'evaluate / score this prompt', sequence: 'evaluator → red-team' },
+  { flow: 'flow-harvest', trigger: 'import from Fabric / harvest awesome-*', sequence: 'harvester → red-team → librarian' },
+  { flow: 'flow-curate', trigger: 'rerank / rebuild library', sequence: 'librarian → optimizer → evaluator' },
+  { flow: 'flow-introspect', trigger: 'IFS session / journal', sequence: 'cartographer (solo)' },
+  { flow: 'flow-profile', trigger: 'Big Five / values map', sequence: 'psychometrist → cartographer' },
+  { flow: 'flow-knowledge-base', trigger: 'RAG prompts / ingestion', sequence: 'architect → librarian → evaluator' },
+];
+
+const COMMITMENTS = [
+  {
+    title: 'Every published prompt walks the same gate',
+    body: 'Designed by the architect, shaped by the lab specialist, optimized for token economy, red-teamed against jailbreaks and prompt injection, evaluated against declarative test cases via promptfoo. Score, verdict, and probe count live in each pattern\'s frontmatter. No vibes.',
+  },
+  {
+    title: 'Every contributor uses the same schema',
+    body: 'Frontmatter is the contract: id (verb_topic), version (semver), lane (Claude / GPT / Gemini / OSS / cross-lab), category (analyze / create / extract / ...), provenance (source, URL, attribution, license), eval score, red-team status. Fabric-style folder-per-pattern, promptfoo evals colocated. Bulk imports from awesome-chatgpt-prompts (CC0) and awesome-claude-prompts (MIT) follow the same rules — full attribution, license verified, quality-gated.',
+  },
+  {
+    title: 'Every user can map their own patterns',
+    body: 'The Psyche Cartographer offers IFS-based introspection with Socratic / Stoic / Jungian / IFS-Self voice modes. The Psychometrist administers IPIP-50, Schwartz PVQ, ECR-R, VIA, Enneagram. Both frame results as lenses, never verdicts. Hard boundaries: maps only, never unburdens. Crisis triggers route to 988 / Samaritans / Befrienders. Inspired by Mindsera and Anthropic\'s introspection research.',
+  },
+];
+
+const REPOS = [
+  {
+    name: 'prompt-engine',
+    description: 'The 13-agent team + tooling. Bootable Node project.',
+    license: 'MIT',
+    status: 'scaffolded',
+    url: 'https://github.com/frankxai/prompt-engine',
+  },
+  {
+    name: 'prompt-library',
+    description: 'The Library-of-Alexandria corpus. Curated, ranked, attributed.',
+    license: 'MIT + CC0 imports with attribution',
+    status: 'scaffolded',
+    url: 'https://github.com/frankxai/prompt-library',
+  },
+];
+
+export default function PromptHubPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-50">
+      <article className="mx-auto max-w-5xl px-6 py-20">
+        {/* Hero */}
+        <header className="mb-20">
+          <p className="mb-4 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-400/80">
+            Horizontal substrate · 13 agents · 2 OSS repos · 8 flows
+          </p>
+          <h1 className="mb-6 text-5xl font-semibold tracking-tight text-white md:text-6xl">
+            The Prompt Hub
+          </h1>
+          <p className="max-w-3xl text-xl leading-relaxed text-slate-300">
+            Every prompt evaluated, attributed, lab-tagged, red-teamed.
+            A 13-agent team handling design, optimization, evaluation, harvest, curation, introspection,
+            and psychometric profiling across Claude, GPT, Gemini, and open-source models.
+          </p>
+          <p className="mt-4 max-w-3xl text-base leading-relaxed text-slate-400">
+            Built on the same Personal AI CoE framework as ACOS. Open source. No vibes. No clinical drift.
+          </p>
+        </header>
+
+        {/* Three commitments */}
+        <section className="mb-20">
+          <h2 className="mb-8 text-2xl font-semibold text-white">Three commitments</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {COMMITMENTS.map((c) => (
+              <div
+                key={c.title}
+                className="rounded-2xl border border-slate-800 bg-slate-900/40 p-6"
+              >
+                <h3 className="mb-3 text-lg font-semibold text-white">{c.title}</h3>
+                <p className="text-sm leading-relaxed text-slate-300">{c.body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Agent team */}
+        <section className="mb-20">
+          <h2 className="mb-2 text-2xl font-semibold text-white">The 13-agent team</h2>
+          <p className="mb-8 max-w-3xl text-sm text-slate-400">
+            One top-level Opus composer routes every ask to 2-5 specialists.
+            Lab quirks (Claude XML, GPT Structured Outputs, Gemini grounding, OSS chat templates) each get their own home.
+          </p>
+
+          {AGENT_TEAM.map((cluster) => (
+            <div key={cluster.cluster} className="mb-8">
+              <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-emerald-400">
+                {cluster.cluster}
+              </h3>
+              <ul className="space-y-2">
+                {cluster.agents.map((a) => (
+                  <li key={a.name} className="flex items-start gap-4 rounded-lg border border-slate-800/60 bg-slate-900/30 px-4 py-3">
+                    <code className="shrink-0 font-mono text-sm text-emerald-300">{a.name}</code>
+                    <span className="text-sm text-slate-300">{a.role}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </section>
+
+        {/* Flows */}
+        <section className="mb-20">
+          <h2 className="mb-8 text-2xl font-semibold text-white">The 8 canonical flows</h2>
+          <div className="overflow-hidden rounded-2xl border border-slate-800">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-900/60">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">Flow</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">Trigger</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">Sequence</th>
+                </tr>
+              </thead>
+              <tbody>
+                {FLOWS.map((f, i) => (
+                  <tr key={f.flow} className={i % 2 ? 'bg-slate-900/30' : ''}>
+                    <td className="px-4 py-3 font-mono text-emerald-300">{f.flow}</td>
+                    <td className="px-4 py-3 text-slate-300">{f.trigger}</td>
+                    <td className="px-4 py-3 text-slate-400">{f.sequence}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Repos */}
+        <section className="mb-20">
+          <h2 className="mb-8 text-2xl font-semibold text-white">Open source</h2>
+          <div className="grid gap-6 md:grid-cols-2">
+            {REPOS.map((r) => (
+              <div
+                key={r.name}
+                className="rounded-2xl border border-slate-800 bg-slate-900/40 p-6"
+              >
+                <h3 className="mb-1 font-mono text-base text-emerald-300">frankxai/{r.name}</h3>
+                <p className="mb-3 text-xs uppercase tracking-wider text-slate-500">
+                  {r.license} · {r.status}
+                </p>
+                <p className="mb-4 text-sm leading-relaxed text-slate-300">{r.description}</p>
+                <a
+                  href={r.url}
+                  className="inline-flex items-center gap-2 text-sm font-medium text-emerald-400 hover:text-emerald-300"
+                  rel="noreferrer noopener"
+                >
+                  View repo →
+                </a>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* CTAs */}
+        <section className="mb-20">
+          <h2 className="mb-8 text-2xl font-semibold text-white">Use it</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            <Link
+              href="/prompt-library"
+              className="group rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-emerald-500/40 hover:bg-slate-900/60"
+            >
+              <h3 className="mb-2 text-lg font-semibold text-white">Browse the library</h3>
+              <p className="text-sm text-slate-400">
+                Filter by lane (Claude / GPT / Gemini / OSS) or category. Every entry has eval score + provenance.
+              </p>
+              <span className="mt-4 inline-flex text-sm font-medium text-emerald-400 group-hover:text-emerald-300">
+                Open library →
+              </span>
+            </Link>
+
+            <Link
+              href="/prompts/psyche"
+              className="group rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-emerald-500/40 hover:bg-slate-900/60"
+            >
+              <h3 className="mb-2 text-lg font-semibold text-white">Self-mapping</h3>
+              <p className="text-sm text-slate-400">
+                IFS journal prompts, psychometric instruments, contemplative inquiry. Maps, not verdicts.
+                Crisis routing built in.
+              </p>
+              <span className="mt-4 inline-flex text-sm font-medium text-emerald-400 group-hover:text-emerald-300">
+                Open psyche path →
+              </span>
+            </Link>
+
+            <Link
+              href="/os"
+              className="group rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-emerald-500/40 hover:bg-slate-900/60"
+            >
+              <h3 className="mb-2 text-lg font-semibold text-white">How it fits the OS</h3>
+              <p className="text-sm text-slate-400">
+                The Prompt Hub is one of FrankX&apos;s horizontal substrates — sibling to SIS, Library OS,
+                Visual Intelligence System.
+              </p>
+              <span className="mt-4 inline-flex text-sm font-medium text-emerald-400 group-hover:text-emerald-300">
+                See the OS →
+              </span>
+            </Link>
+          </div>
+        </section>
+
+        {/* Spec */}
+        <footer className="border-t border-slate-800 pt-10 text-sm text-slate-400">
+          <p className="mb-2">
+            Master spec:{' '}
+            <code className="font-mono text-emerald-300">
+              docs/superpowers/specs/2026-05-13-prompt-hub-design.md
+            </code>
+          </p>
+          <p className="mb-2">
+            Skill: <code className="font-mono">prompt-hub</code> · Command:{' '}
+            <code className="font-mono">/prompt-hub</code>
+          </p>
+          <p className="mb-2">
+            Types: <code className="font-mono">lib/prompt-hub/types.ts</code>
+          </p>
+          <p>Inspired by Fabric (Daniel Miessler, MIT) · evaluated via promptfoo (MIT).</p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/app/prompts/psyche/page.tsx
+++ b/app/prompts/psyche/page.tsx
@@ -1,0 +1,180 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Prompts · Psyche — IFS, psychometrics, contemplative inquiry | FrankX',
+  description:
+    'Map yourself through curated prompts: IFS parts mapping, Big Five / Schwartz Values / Attachment instruments, Socratic / Stoic / Jungian voice modes. Maps only — never unburdens. Crisis routing built in.',
+  alternates: { canonical: 'https://www.frankx.ai/prompts/psyche' },
+  robots: { index: false }, // launch-gated; remove when ready
+};
+
+const VOICE_MODES = [
+  { id: 'ifs-self', name: 'IFS-Self', tone: 'Curious, compassionate, courageous', move: 'Name the part. Ask if it will step back so Self can listen.' },
+  { id: 'socratic', name: 'Socratic', tone: 'Recursive questioning', move: '"What do you mean by X?" "What would be true if the opposite held?"' },
+  { id: 'stoic', name: 'Stoic evening review', tone: 'Calm, structured', move: 'Three questions: what did I do well, where did I fall short, what will I do tomorrow.' },
+  { id: 'jungian', name: 'Jungian active imagination', tone: 'Imaginative, embodied', move: 'Dialogue with an inner figure as imaginative play.' },
+  { id: 'buddhist', name: 'Buddhist inquiry', tone: 'Non-conceptual', move: 'Used as a stopping prompt, not a solving one.' },
+  { id: 'shadow-work', name: 'Shadow-work', tone: 'Honest, non-judgmental', move: 'Projection inventory: who triggers you, what trait do they carry?' },
+];
+
+const INSTRUMENTS = [
+  { name: 'IPIP-50', use: 'Big Five baseline (OCEAN)', items: '50 items', license: 'public domain' },
+  { name: 'Schwartz PVQ-21', use: 'Values clarification (10 values)', items: '21 items', license: 'academic' },
+  { name: 'ECR-R', use: 'Adult attachment (anxiety × avoidance)', items: '36 items', license: 'academic' },
+  { name: 'VIA Character Strengths', use: 'Strengths inventory', items: '24 short / 96 full', license: 'free with attribution' },
+  { name: 'Enneagram', use: 'Narrative typology (not psychometric)', items: '36-item RHETI-style', license: 'narrative tradition' },
+];
+
+export default function PsychePromptsPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-50">
+      <article className="mx-auto max-w-4xl px-6 py-20">
+        {/* Mirror-not-mind disclosure (load-bearing) */}
+        <div className="mb-12 rounded-2xl border border-amber-700/40 bg-amber-950/20 p-5">
+          <p className="text-sm font-medium text-amber-200">
+            <strong>This is a mirror, not a mind.</strong> Take what is useful. Leave what is not.
+            If anything here feels like crisis, please use the resources at the bottom of this page —
+            988 (US), Samaritans 116 123 (UK), or Befrienders Worldwide (global directory).
+          </p>
+        </div>
+
+        {/* Hero */}
+        <header className="mb-16">
+          <p className="mb-4 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-400/80">
+            Self-mapping · IFS · psychometric · contemplative
+          </p>
+          <h1 className="mb-6 text-4xl font-semibold tracking-tight text-white md:text-5xl">
+            Map yourself.
+          </h1>
+          <p className="max-w-3xl text-lg leading-relaxed text-slate-300">
+            A curated path of prompts for introspection. IFS parts mapping. Big Five baseline.
+            Schwartz Values. Attachment. Strengths. Socratic, Stoic, Jungian voices when you want company.
+          </p>
+          <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-400">
+            The Psyche Cartographer maps. It does not unburden. It does not diagnose. Every result is a lens,
+            never a verdict. After enough surfacing, it asks you to sit with what you found — and reminds you
+            that a human peer, coach, or therapist holds what a mirror cannot.
+          </p>
+        </header>
+
+        {/* Voice modes */}
+        <section className="mb-16">
+          <h2 className="mb-3 text-2xl font-semibold text-white">Voice modes</h2>
+          <p className="mb-6 max-w-3xl text-sm text-slate-400">
+            Pick the lens. The Cartographer holds the session in your chosen voice.
+          </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            {VOICE_MODES.map((v) => (
+              <div key={v.id} className="rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+                <h3 className="mb-1 text-lg font-semibold text-white">{v.name}</h3>
+                <p className="mb-2 text-xs uppercase tracking-wider text-slate-500">{v.tone}</p>
+                <p className="text-sm text-slate-300">{v.move}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Instruments */}
+        <section className="mb-16">
+          <h2 className="mb-3 text-2xl font-semibold text-white">Instruments</h2>
+          <p className="mb-6 max-w-3xl text-sm text-slate-400">
+            Canonical, citation-defensible. Administered cleanly. Scored correctly. Framed as lenses,
+            never verdicts.
+          </p>
+          <div className="overflow-hidden rounded-2xl border border-slate-800">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-900/60">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">Instrument</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">Use</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">Items</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-300">License</th>
+                </tr>
+              </thead>
+              <tbody>
+                {INSTRUMENTS.map((i, idx) => (
+                  <tr key={i.name} className={idx % 2 ? 'bg-slate-900/30' : ''}>
+                    <td className="px-4 py-3 font-medium text-white">{i.name}</td>
+                    <td className="px-4 py-3 text-slate-300">{i.use}</td>
+                    <td className="px-4 py-3 text-slate-400">{i.items}</td>
+                    <td className="px-4 py-3 text-xs uppercase tracking-wider text-slate-500">
+                      {i.license}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Hard boundaries */}
+        <section className="mb-16 rounded-2xl border border-slate-800 bg-slate-900/40 p-6">
+          <h2 className="mb-4 text-xl font-semibold text-white">Hard boundaries</h2>
+          <ul className="space-y-2 text-sm text-slate-300">
+            <li>Not a therapist. Not diagnostic. Not clinical.</li>
+            <li>No DSM terminology. No &ldquo;you have anxiety / depression / ADHD&rdquo;.</li>
+            <li>No unburdening, no trauma processing, no crisis support — that&apos;s human territory.</li>
+            <li>No claims about your &ldquo;true self&rdquo; or &ldquo;real type&rdquo;. Every framing is a lens.</li>
+            <li>Cooldown injected after 8 exchanges per session. Sit with what surfaces before more.</li>
+            <li>Crisis triggers (suicidality, self-harm, abuse, dissociation) abort the session and route to humans.</li>
+          </ul>
+        </section>
+
+        {/* Inspiration */}
+        <section className="mb-16">
+          <h2 className="mb-4 text-xl font-semibold text-white">Built on</h2>
+          <ul className="space-y-2 text-sm text-slate-400">
+            <li>
+              Schwartz, <em>No Bad Parts</em> (IFS canon)
+            </li>
+            <li>Hadot, <em>Philosophy as a Way of Life</em> (Stoic praxis)</li>
+            <li>Jung&apos;s active imagination (used as imaginative play, not channeling)</li>
+            <li>
+              Anthropic&apos;s introspection research (Nov 2025) and Claude&apos;s Constitution (Jan 2026)
+              for the &ldquo;virtue-as-attractor&rdquo; framing
+            </li>
+            <li>Mindsera and Rosebud (comparable products done right) as UX precedent</li>
+            <li>IFS Institute and Parts &amp; Self community for the line between mapping and therapy</li>
+          </ul>
+        </section>
+
+        {/* Crisis footer (load-bearing) */}
+        <footer className="rounded-2xl border border-rose-700/30 bg-rose-950/20 p-6 text-sm">
+          <p className="mb-3 font-semibold text-rose-200">In crisis? Talk to a human.</p>
+          <ul className="space-y-1 text-slate-300">
+            <li>
+              <strong>US:</strong> 988 Suicide &amp; Crisis Lifeline — call or text 988
+            </li>
+            <li>
+              <strong>UK:</strong> Samaritans — call 116 123 (free, 24/7)
+            </li>
+            <li>
+              <strong>Global:</strong>{' '}
+              <a
+                href="https://www.befrienders.org"
+                className="text-rose-300 underline-offset-2 hover:underline"
+                rel="noreferrer noopener"
+              >
+                Befrienders Worldwide directory
+              </a>
+            </li>
+          </ul>
+          <p className="mt-4 text-slate-400">
+            When you&apos;ve spoken with someone, come back if you want. We&apos;ll be here.
+          </p>
+        </footer>
+
+        {/* Back nav */}
+        <div className="mt-12 text-center">
+          <Link
+            href="/prompts"
+            className="text-sm font-medium text-emerald-400 hover:text-emerald-300"
+          >
+            ← Back to Prompt Hub
+          </Link>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/lib/prompt-hub/crisis-routing.ts
+++ b/lib/prompt-hub/crisis-routing.ts
@@ -1,0 +1,150 @@
+/**
+ * Prompt Hub — Crisis Routing
+ *
+ * Load-bearing safety: detect crisis triggers in user input to Cartographer + Psychometrist
+ * sessions, abort the session, and emit a routing message to human resources.
+ *
+ * THIS IS CODE, NOT POLICY. Spec prose without an implementation is not a safety guarantee.
+ *
+ * Used by:
+ * - @prompt-psyche-cartographer (every user turn)
+ * - @prompt-psychometrist (every user turn)
+ * - Red Team probe: "Crisis exit fires on injected trigger"
+ *
+ * See: docs/superpowers/specs/2026-05-13-prompt-hub-design.md §8
+ *      docs/superpowers/specs/2026-05-13-prompt-hub-psyche-layer.md §3.2
+ */
+
+/**
+ * Crisis trigger regex. Case-insensitive substring match.
+ *
+ * Categories covered:
+ * - Suicidal ideation (suicid, kill myself, end it, want to die)
+ * - Self-harm (self.?harm, hurting myself, cut myself)
+ * - Abuse disclosure (abuse, hurt me, hurting me)
+ * - Dissociation cues (not real, watching myself, outside my body)
+ * - Substance crisis (overdose, too many pills, drinking too much to cope)
+ *
+ * Intentionally over-broad. False positives route to humans, which is fine.
+ * False negatives are unacceptable.
+ */
+export const CRISIS_TRIGGER_REGEX =
+  /\b(suicid|kill\s+myself|end\s+(it\s+all|my\s+life)|want\s+to\s+die|going\s+to\s+die|self.?harm|hurt(ing)?\s+myself|cut(ting)?\s+myself|abus(e|ing|ed)|overdos|too\s+many\s+pills|outside\s+my\s+body|not\s+real\s+anymore|watch(ing)?\s+myself)\b/i;
+
+/**
+ * Crisis resources by region. Surfaced verbatim on trigger.
+ *
+ * Sources verified 2026-05-13. Update if numbers change.
+ */
+export const CRISIS_RESOURCES = {
+  global: 'https://www.befrienders.org',
+  us: '988 — call or text the Suicide & Crisis Lifeline',
+  uk: 'Samaritans — call 116 123 (free, 24/7)',
+  eu: 'https://www.findahelpline.com',
+} as const;
+
+/**
+ * Crisis routing message. Used verbatim when trigger fires.
+ * Plain text, no Markdown noise. Easy to read in a panic.
+ */
+export const CRISIS_MESSAGE = `
+I notice this is heavy territory. I'm not equipped for crisis support, but humans are.
+
+  US — 988 Suicide & Crisis Lifeline: call or text 988
+  UK — Samaritans: call 116 123 (free, 24/7)
+  Global — Befrienders Worldwide directory: https://www.befrienders.org
+  Find a Helpline (any country): https://www.findahelpline.com
+
+When you've spoken with someone, come back if you want. I'll be here.
+`.trim();
+
+/**
+ * Detect crisis trigger in input.
+ *
+ * @param input - User input to scan.
+ * @returns `true` if crisis trigger detected, else `false`.
+ */
+export function detectCrisis(input: string): boolean {
+  return CRISIS_TRIGGER_REGEX.test(input);
+}
+
+/**
+ * Find which categories matched. Useful for logging (without storing content).
+ *
+ * Returns category names only — does NOT return the matched substring,
+ * to avoid storing potentially traumatic content in any log path.
+ */
+export function classifyCrisisCategory(input: string): string[] {
+  if (!detectCrisis(input)) return [];
+  const categories: string[] = [];
+  if (/\b(suicid|kill\s+myself|end\s+(it\s+all|my\s+life)|want\s+to\s+die|going\s+to\s+die)\b/i.test(input)) {
+    categories.push('suicidal-ideation');
+  }
+  if (/\b(self.?harm|hurt(ing)?\s+myself|cut(ting)?\s+myself)\b/i.test(input)) {
+    categories.push('self-harm');
+  }
+  if (/\b(abus(e|ing|ed)|hurt(ing)?\s+me)\b/i.test(input)) {
+    categories.push('abuse-disclosure');
+  }
+  if (/\b(overdos|too\s+many\s+pills)\b/i.test(input)) {
+    categories.push('substance-crisis');
+  }
+  if (/\b(outside\s+my\s+body|not\s+real\s+anymore|watch(ing)?\s+myself)\b/i.test(input)) {
+    categories.push('dissociation-cue');
+  }
+  return categories;
+}
+
+/**
+ * The handler called by Cartographer / Psychometrist on every user turn.
+ *
+ * @returns `{ shouldRoute: boolean; message: string; categories: string[] }`
+ *
+ * When `shouldRoute` is true, the agent MUST:
+ *   1. Output `message` verbatim as the next assistant turn.
+ *   2. End the session.
+ *   3. Commit to SBO with `{type: 'crisis-routing-fired', privacy: 'local-only'}` — categories only, NOT content.
+ *
+ * No exceptions. No "continuing normal flow" with a sidebar. Hard stop.
+ */
+export interface CrisisRoutingResult {
+  shouldRoute: boolean;
+  message: string;
+  categories: string[];
+}
+
+export function checkCrisisAndRoute(input: string): CrisisRoutingResult {
+  const triggered = detectCrisis(input);
+  return {
+    shouldRoute: triggered,
+    message: triggered ? CRISIS_MESSAGE : '',
+    categories: triggered ? classifyCrisisCategory(input) : [],
+  };
+}
+
+/**
+ * Self-test fixtures. Used by the Red Team probe and unit tests.
+ * Each entry MUST trigger; if any fails to trigger, regex is regressed.
+ */
+export const CRISIS_TEST_FIXTURES: ReadonlyArray<{ input: string; expectedCategories: string[] }> = [
+  { input: 'I want to die', expectedCategories: ['suicidal-ideation'] },
+  { input: 'I am thinking about suicide', expectedCategories: ['suicidal-ideation'] },
+  { input: 'I want to kill myself', expectedCategories: ['suicidal-ideation'] },
+  { input: "I'm hurting myself again", expectedCategories: ['self-harm'] },
+  { input: 'He abused me when I was young', expectedCategories: ['abuse-disclosure'] },
+  { input: 'I took too many pills last night', expectedCategories: ['substance-crisis'] },
+  { input: 'I feel like I am outside my body', expectedCategories: ['dissociation-cue'] },
+] as const;
+
+/**
+ * Anti-fixtures. These MUST NOT trigger — they share words with crisis
+ * patterns but aren't crisis content.
+ */
+export const CRISIS_ANTI_FIXTURES: ReadonlyArray<string> = [
+  'I was reading about suicide prevention research',
+  'The character in the novel hurt herself',
+  'My therapist and I discussed dissociation as a concept',
+  // Note: 'abuse' alone is too generic in some contexts (substance abuse policy,
+  // child abuse research). Current regex DOES match these — accepting the false
+  // positive rate as the safer default. Tighten only if user feedback warrants.
+] as const;

--- a/lib/prompt-hub/types.ts
+++ b/lib/prompt-hub/types.ts
@@ -1,0 +1,233 @@
+/**
+ * Prompt Hub — Type Contract
+ *
+ * This file defines the canonical TypeScript types for the Prompt Hub substrate.
+ * Source-of-truth for every consumer: agents, commands, public pages, OSS repos.
+ *
+ * See: docs/superpowers/specs/2026-05-13-prompt-hub-design.md
+ *
+ * Conventions:
+ * - Pattern IDs follow `<verb>_<topic>` (Fabric-style verb-prefix).
+ * - Version follows semver (patch / minor / major bump rules in spec §6).
+ * - Lane segments per-model-family doctrine.
+ * - Provenance is mandatory for any non-original pattern.
+ * - Eval + red_team scores written back by their respective agents.
+ */
+
+// ============================================================================
+// Pattern (the unit of the library)
+// ============================================================================
+
+export type PatternId = string; // e.g. "extract_wisdom", "summarize_podcast"
+
+export type Lane = 'claude' | 'gpt' | 'gemini' | 'oss' | 'cross-lab';
+
+export type Category =
+  | 'analyze'
+  | 'create'
+  | 'extract'
+  | 'summarize'
+  | 'answer'
+  | 'audit'
+  | 'check'
+  | 'compare'
+  | 'improve'
+  | 'write'
+  | 'rate'
+  | 'introspect'    // psyche flows
+  | 'profile';      // psychometric flows
+
+export type Technique =
+  | 'chain-of-thought'
+  | 'tree-of-thought'
+  | 'react'
+  | 'constitutional'
+  | 'self-consistency'
+  | 'atom-of-thoughts'
+  | 'few-shot'
+  | 'zero-shot'
+  | 'prefill'
+  | 'xml-tags'
+  | 'structured-output'
+  | 'retrieval-augmented';
+
+export type License = 'MIT' | 'CC0' | 'Apache-2.0' | 'public-domain' | 'original';
+
+export type ProvenanceSource =
+  | 'original'
+  | 'fabric'
+  | 'awesome-chatgpt-prompts'
+  | 'awesome-claude-prompts'
+  | 'manual'
+  | 'harvested-from-paper'
+  | 'lab-docs';
+
+export interface Provenance {
+  source: ProvenanceSource;
+  source_url?: string;
+  attribution?: string;   // e.g. "Daniel Miessler / Fabric, MIT"
+  license: License;
+}
+
+export type EvalVerdict = 'pass' | 'warn' | 'fail';
+
+export interface EvalScore {
+  score: number;          // 0-5 weighted average
+  last_run: string;       // ISO date
+  test_count: number;
+  verdict: EvalVerdict;
+}
+
+export type RedTeamVerdict = 'pass' | 'warn' | 'fail';
+
+export interface RedTeamReport {
+  status: RedTeamVerdict;
+  audited: string;        // ISO date
+  notes?: string;
+  probes_run?: number;
+  probes_passed?: number;
+  probes_warn?: number;
+  probes_failed?: number;
+}
+
+export type PsycheBoundary = 'maps-only' | 'instruments-only' | 'n/a';
+export type PsycheRisk = 'low' | 'medium' | 'high';
+
+export interface PsycheFlags {
+  applicable: boolean;
+  boundary: PsycheBoundary;
+  risk: PsycheRisk;
+}
+
+export interface PatternFrontmatter {
+  id: PatternId;
+  title: string;
+  version: string;        // semver, e.g. "1.0.0"
+  description: string;
+  lane: Lane;
+  category: Category;
+  tags: string[];
+  techniques: Technique[];
+  provenance: Provenance;
+  eval?: EvalScore;
+  red_team?: RedTeamReport;
+  psyche?: PsycheFlags;
+  created: string;        // ISO date
+  updated: string;        // ISO date
+}
+
+export interface Pattern {
+  frontmatter: PatternFrontmatter;
+  body: string;           // the actual prompt body (markdown)
+  examples?: Example[];
+  variants?: Partial<Record<Lane, string>>;
+  readme?: string;        // 80-word human summary
+}
+
+export interface Example {
+  input: string;
+  output: string;
+  notes?: string;
+}
+
+// ============================================================================
+// Flow + Agent (orchestration types)
+// ============================================================================
+
+export type Flow =
+  | 'flow-design'
+  | 'flow-optimize'
+  | 'flow-evaluate'
+  | 'flow-harvest'
+  | 'flow-curate'
+  | 'flow-introspect'
+  | 'flow-profile'
+  | 'flow-knowledge-base';
+
+export type AgentName =
+  | 'prompt-conductor'
+  | 'prompt-claude-specialist'
+  | 'prompt-gpt-specialist'
+  | 'prompt-gemini-specialist'
+  | 'prompt-oss-specialist'
+  | 'prompt-architect'
+  | 'prompt-optimizer'
+  | 'prompt-evaluator'
+  | 'prompt-librarian'
+  | 'prompt-harvester'
+  | 'prompt-red-team'
+  | 'prompt-psyche-cartographer'
+  | 'prompt-psychometrist';
+
+export interface FlowDispatch {
+  flow: Flow;
+  specialists: AgentName[];
+  parallel?: boolean;     // some legs of a flow can parallelize
+}
+
+// ============================================================================
+// Library invariants
+// ============================================================================
+
+/**
+ * Required-fields check. Patterns missing any of these MUST NOT publish.
+ */
+export const REQUIRED_FRONTMATTER_FIELDS: ReadonlyArray<keyof PatternFrontmatter> = [
+  'id',
+  'title',
+  'version',
+  'description',
+  'lane',
+  'category',
+  'provenance',
+  'created',
+  'updated',
+] as const;
+
+export const PUBLISH_GATES = {
+  MIN_EVAL_SCORE: 3.5,
+  REQUIRED_RED_TEAM_STATUS: 'pass' as RedTeamVerdict,
+  REQUIRED_VOICE_GATE: 'pass',
+} as const;
+
+export function passesPublishGates(p: PatternFrontmatter): boolean {
+  if (!p.eval || p.eval.score < PUBLISH_GATES.MIN_EVAL_SCORE) return false;
+  if (!p.red_team || p.red_team.status !== PUBLISH_GATES.REQUIRED_RED_TEAM_STATUS) return false;
+  return true;
+}
+
+// ============================================================================
+// Ranking
+// ============================================================================
+
+/**
+ * Auto-rank score formula. Per spec §9.2.
+ *
+ * Hand-edits forbidden in rankings/by-eval-score.md — that file is regenerated.
+ */
+export function computeRankScore(p: PatternFrontmatter): number {
+  const evalScore = p.eval?.score ?? 0;
+  const variants = 0; // counted from sibling files at index time
+  const isOriginal = p.provenance.source === 'original';
+  const redTeamPass = p.red_team?.status === 'pass';
+
+  return (
+    evalScore * 0.6 +
+    (variants >= 1 ? 0.5 : 0) +
+    (isOriginal ? 0.3 : 0) +
+    (redTeamPass ? 0.2 : 0)
+  );
+}
+
+// ============================================================================
+// SBO bridge (Cartographer + Psychometrist memory)
+// ============================================================================
+
+export interface SboReflection {
+  type: 'part' | 'theme' | 'reflection' | 'session-close' | 'profile';
+  content: string;
+  voiceMode?: 'ifs-self' | 'socratic' | 'stoic' | 'jungian' | 'buddhist' | 'shadow-work';
+  provenance: 'cartographer' | 'psychometrist';
+  privacy: 'local-only' | 'sync-allowed';
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary

Lands the public Prompt Hub surface on production. Mirrors FrankX/main commit c89762f7 (PR #33).

**Public surface:**
- /prompts — the hub
- /prompts/psyche — model-personality dive

**Substrate (typed-only, no runtime imports yet):**
- lib/prompt-hub/types.ts
- lib/prompt-hub/crisis-routing.ts

Per CLAUDE.md sync contract: substrate + surfaces ship to production; the 13 agent definitions stay private in FrankX/.claude/agents/.

## Test plan

- [ ] Verify /prompts renders at preview URL
- [ ] Verify /prompts/psyche renders
- [ ] No regressions on /studio, /studio/visual, /partnerships

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched Prompt Hub page showcasing agent teams, canonical flows, commitments, and open-source repositories
  * Added Psyche Prompts landing page featuring voice modes, instruments configuration, and safety boundaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankxai/frankx.ai-vercel-website/pull/62)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->