### PR TITLE
feat(workshops/ikigai): presenter mode + 3 modules + 14-slide deck

### DIFF
--- a/app/workshops/ikigai-branding/page.tsx
+++ b/app/workshops/ikigai-branding/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { motion } from 'framer-motion'
@@ -14,6 +14,7 @@ import {
   Sparkles,
   Compass,
   MessageSquareMore,
+  Presentation,
 } from 'lucide-react'
 import { GlowCard } from '@/components/ui/glow-card'
 import { EmailSignup } from '@/components/email-signup'
@@ -21,8 +22,24 @@ import { IkigaiWizard } from '@/components/workshops/ikigai/IkigaiWizard'
 import { SynthesisPanel } from '@/components/workshops/ikigai/SynthesisPanel'
 import { BrandingBridge } from '@/components/workshops/ikigai/BrandingBridge'
 import { CoachGPTCard } from '@/components/workshops/ikigai/CoachGPTCard'
+import { ContentOperatingPlan } from '@/components/workshops/ikigai/ContentOperatingPlan'
+import { GenCreatorStack } from '@/components/workshops/ikigai/GenCreatorStack'
+import { LiveArtifact } from '@/components/workshops/ikigai/LiveArtifact'
+import { PresenterOverlay } from '@/components/workshops/ikigai/PresenterOverlay'
 import { emptyIkigai, type IkigaiState } from '@/components/workshops/ikigai/types'
 import { getWorkshopBySlug } from '@/data/workshops'
+
+const PRESENTER_SECTIONS = [
+  'intro',
+  'three-cs',
+  'module-1',
+  'synthesis',
+  'brand-bridge',
+  'content-plan',
+  'gencreator-stack',
+  'live-artifact',
+  'activation',
+]
 
 function CourseSchema() {
   const ld = JSON.stringify({
@@ -30,7 +47,7 @@ function CourseSchema() {
     '@type': 'Course',
     name: 'Ikigai & Branding Workshop',
     description:
-      'Interactive, coach-guided workshop. Map your Ikigai, write your purpose statement, and translate it into a brand positioning, audience-of-one, and content pillars.',
+      'Interactive, coach-guided workshop. Map your Ikigai, write your purpose statement, translate it into a brand positioning, and ship a 30-day content plan across LinkedIn + newsletter + video.',
     url: 'https://frankx.ai/workshops/ikigai-branding',
     provider: {
       '@type': 'Person',
@@ -39,13 +56,13 @@ function CourseSchema() {
       jobTitle: 'AI Architect',
     },
     educationalLevel: 'Beginner',
-    timeRequired: 'PT55M',
-    numberOfCredits: 4,
+    timeRequired: 'PT75M',
+    numberOfCredits: 7,
     isAccessibleForFree: true,
     hasCourseInstance: {
       '@type': 'CourseInstance',
       courseMode: 'online',
-      courseWorkload: 'PT55M',
+      courseWorkload: 'PT75M',
     },
   })
   return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ld }} />
@@ -54,13 +71,21 @@ function CourseSchema() {
 export default function IkigaiBrandingWorkshopPage() {
   const workshop = getWorkshopBySlug('ikigai-branding')!
   const [ikigai, setIkigai] = useState<IkigaiState>(emptyIkigai)
+  const [presenterActive, setPresenterActive] = useState(false)
+
+  // Activate presenter overlay via ?present=1 query param (read on mount, no Suspense needed)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('present') === '1') setPresenterActive(true)
+  }, [])
 
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
       <CourseSchema />
 
       {/* Hero */}
-      <section className="relative pt-28 pb-12 overflow-hidden">
+      <section id="intro" className="relative pt-28 pb-12 overflow-hidden scroll-mt-24">
         <div className="absolute inset-0 bg-gradient-to-b from-violet-500/[0.05] via-amber-500/[0.02] to-transparent" />
         <div className="absolute top-20 left-1/3 w-[500px] h-[500px] bg-violet-500/[0.06] rounded-full blur-[140px]" />
         <div className="absolute top-40 right-1/3 w-[400px] h-[400px] bg-amber-500/[0.05] rounded-full blur-[120px]" />
@@ -89,7 +114,7 @@ export default function IkigaiBrandingWorkshopPage() {
               </span>
               <span className="flex items-center gap-1.5 text-xs text-zinc-500">
                 <Layers className="w-3.5 h-3.5" />
-                {workshop.moduleCount} modules
+                7 modules
               </span>
               <span className="flex items-center gap-1.5 text-xs text-zinc-500">
                 <Users className="w-3.5 h-3.5" />
@@ -113,6 +138,23 @@ export default function IkigaiBrandingWorkshopPage() {
 
             <div className="mt-8 max-w-xl">
               <CoachGPTCard />
+            </div>
+
+            {/* Presenter tools — visible to anyone, useful for facilitators */}
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <Link
+                href="/workshops/ikigai-branding/present"
+                className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-xs font-medium text-zinc-300 bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.08] hover:text-white transition-colors"
+              >
+                <Presentation className="w-3.5 h-3.5" />
+                Open presenter mode
+              </Link>
+              <button
+                onClick={() => setPresenterActive((v) => !v)}
+                className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-xs font-medium text-zinc-400 bg-white/[0.02] border border-white/[0.06] hover:bg-white/[0.06] hover:text-zinc-200 transition-colors"
+              >
+                {presenterActive ? 'Hide' : 'Show'} on-page HUD
+              </button>
             </div>
           </motion.div>
         </div>
@@ -150,14 +192,22 @@ export default function IkigaiBrandingWorkshopPage() {
                     <p className="text-sm text-zinc-300">{obj}</p>
                   </div>
                 ))}
+                <div className="flex items-start gap-2.5">
+                  <div className="w-1.5 h-1.5 rounded-full mt-2 flex-shrink-0 bg-emerald-400 opacity-70" />
+                  <p className="text-sm text-zinc-300">A 30-day content plan generated from your three pillars — exportable to Notion, Google Sheets, or CSV.</p>
+                </div>
+                <div className="flex items-start gap-2.5">
+                  <div className="w-1.5 h-1.5 rounded-full mt-2 flex-shrink-0 bg-emerald-400 opacity-70" />
+                  <p className="text-sm text-zinc-300">The GenCreator Stack — five tools across Capture · Think · Make · Ship · Measure.</p>
+                </div>
               </div>
             </div>
           </GlowCard>
         </div>
       </section>
 
-      {/* The 3Cs — framework preserved from legacy page */}
-      <section id="three-cs" className="pb-16">
+      {/* The 3Cs */}
+      <section id="three-cs" className="pb-16 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-zinc-500 mb-2">
@@ -236,7 +286,7 @@ export default function IkigaiBrandingWorkshopPage() {
       </section>
 
       {/* Module 1: The Ikigai Map */}
-      <section className="pb-12">
+      <section id="module-1" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">
@@ -257,7 +307,7 @@ export default function IkigaiBrandingWorkshopPage() {
       </section>
 
       {/* Module 2: Synthesis */}
-      <section className="pb-12">
+      <section id="synthesis" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2">
@@ -277,7 +327,7 @@ export default function IkigaiBrandingWorkshopPage() {
       </section>
 
       {/* Module 3: Brand Bridge */}
-      <section className="pb-12">
+      <section id="brand-bridge" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
           <div className="rounded-3xl overflow-hidden border border-white/[0.06] bg-white/[0.01]">
             <Image
@@ -292,12 +342,69 @@ export default function IkigaiBrandingWorkshopPage() {
         </div>
       </section>
 
-      {/* Module 4: Activation + Email capture */}
-      <section className="pb-24">
+      {/* Module 4: Content Operating Plan — NEW */}
+      <section id="content-plan" className="pb-12 scroll-mt-24">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-6">
+            <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">
+              Module 4 · Content Operating Plan
+            </p>
+            <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
+              From positioning to publishing
+            </h2>
+            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+              The pillars tell you what to write about. This module gives you the patterns, the rhythm,
+              and the calendar so blank-page mornings end. Anchored to your three pillars from Module 3.
+            </p>
+          </div>
+          <ContentOperatingPlan value={ikigai} />
+        </div>
+      </section>
+
+      {/* Module 5: GenCreator Stack — NEW */}
+      <section id="gencreator-stack" className="pb-12 scroll-mt-24">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-6">
+            <p className="text-xs font-medium uppercase tracking-wider text-sky-300 mb-2">
+              Module 5 · The GenCreator Stack
+            </p>
+            <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
+              Five jobs. Five tools. One creator hub.
+            </h2>
+            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+              The opinionated short-list of MCPs, extensions, and apps that compound your craft
+              instead of fragmenting your attention. Build the hub once; ship for years.
+            </p>
+          </div>
+          <GenCreatorStack />
+        </div>
+      </section>
+
+      {/* Module 6: Live Artifact — NEW */}
+      <section id="live-artifact" className="pb-12 scroll-mt-24">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-6">
+            <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2">
+              Module 6 · The Artifact
+            </p>
+            <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
+              AI-assisted. Voice-preserved.
+            </h2>
+            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+              The whole workshop in one demo. Watch a LinkedIn post get written — with rejections, redirects,
+              and the prompt scaffold you can keep.
+            </p>
+          </div>
+          <LiveArtifact />
+        </div>
+      </section>
+
+      {/* Module 7: Activation + Email capture (was Module 4) */}
+      <section id="activation" className="pb-24 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
           <div className="mb-2">
             <p className="text-xs font-medium uppercase tracking-wider text-emerald-400 mb-2">
-              Module 4 · Activation
+              Module 7 · Activation
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
               Ship the brand into reality
@@ -315,7 +422,7 @@ export default function IkigaiBrandingWorkshopPage() {
                 Get the Resource Pack
               </h3>
               <p className="text-sm text-zinc-400 mb-5 max-w-md mx-auto">
-                Templates for the positioning sentence, avatar, and 30-day expression plan. Plus a Day-7 check-in from Frank.
+                Templates for the positioning sentence, avatar, 30-day expression plan, and the GenCreator Stack checklist. Plus a Day-7 check-in from Frank.
               </p>
               <div className="max-w-sm mx-auto">
                 <EmailSignup
@@ -367,6 +474,9 @@ export default function IkigaiBrandingWorkshopPage() {
           </div>
         </div>
       </section>
+
+      {/* Presenter HUD overlay — activates via state toggle or ?present=1 */}
+      <PresenterOverlay sectionIds={PRESENTER_SECTIONS} active={presenterActive} />
     </div>
   )
 }

--- a/app/workshops/ikigai-branding/present/layout.tsx
+++ b/app/workshops/ikigai-branding/present/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Ikigai & Branding · Presenter Mode',
+  description:
+    'Fullscreen slide presenter for the Ikigai & Branding workshop. Keyboard navigation, speaker notes, timer, print-to-PDF.',
+  robots: { index: false, follow: false },
+}
+
+export default function PresentLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/app/workshops/ikigai-branding/present/page.tsx
+++ b/app/workshops/ikigai-branding/present/page.tsx
@@ -1,0 +1,801 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  ArrowLeft,
+  ArrowRight,
+  Maximize2,
+  StickyNote,
+  X,
+  Compass,
+  Sparkles,
+  Target,
+  UserCircle,
+  Layers3,
+  TrendingUp,
+  Calendar,
+  Wand2,
+  Send,
+  Brain,
+  Mic,
+  BarChart3,
+  Play,
+  Rocket,
+  Mail,
+  Pause,
+  RotateCcw,
+} from 'lucide-react'
+
+// ---- Slide data ---------------------------------------------------------
+
+interface SlideDef {
+  id: string
+  eyebrow: string
+  title: string
+  module?: string
+  minutes: number
+  color: 'violet' | 'amber' | 'emerald' | 'sky' | 'rose'
+  speakerNotes: string[]
+  body: () => React.ReactNode
+}
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+function formatTime(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`
+}
+
+const SLIDES: SlideDef[] = [
+  // 0 — Cover
+  {
+    id: 'cover',
+    eyebrow: 'A 75-minute workshop',
+    title: 'Ikigai & Branding',
+    minutes: 1,
+    color: 'violet',
+    speakerNotes: [
+      'Open with: "Today you leave with a purpose statement and a 30-day plan. Not a feeling."',
+      'Set tone: practical, generous, no fluff. Phones face down for the wizard sections.',
+    ],
+    body: () => (
+      <div className="text-center space-y-8">
+        <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border border-violet-500/20 bg-violet-500/[0.06] text-xs font-medium text-violet-300 uppercase tracking-wider">
+          <Compass className="w-3 h-3" />
+          A 75-minute workshop
+        </div>
+        <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tight">
+          <span className="text-white">Ikigai </span>
+          <span className="text-zinc-500">&amp;</span>
+          <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-amber-400"> Branding</span>
+        </h1>
+        <p className="text-xl text-zinc-400 max-w-2xl mx-auto leading-relaxed">
+          Find what makes time disappear. Translate it into a brand the world remembers.
+        </p>
+        <div className="text-sm text-zinc-600 pt-12">
+          frankx.ai · Frank Riemer · AI Architect
+        </div>
+      </div>
+    ),
+  },
+  // 1 — Outcomes
+  {
+    id: 'outcomes',
+    eyebrow: 'The promise',
+    title: 'What you walk out with',
+    minutes: 4,
+    color: 'amber',
+    speakerNotes: [
+      'Read the four bullets aloud. Pause after each.',
+      'Frame: "If you write all four down today, the next 30 days plan themselves."',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-2 gap-4">
+        {[
+          { title: 'A purpose statement', sub: 'Two lines. Fits on a business card.', icon: Compass, color: 'violet' },
+          { title: 'A brand positioning', sub: 'Positioning sentence + audience-of-one + 3 content pillars.', icon: Target, color: 'amber' },
+          { title: 'A 30-day content plan', sub: 'Calendar generated from your pillars. CSV + Notion + Sheet.', icon: Calendar, color: 'emerald' },
+          { title: 'The GenCreator Stack', sub: 'Five tools across Capture · Think · Make · Ship · Measure.', icon: Wand2, color: 'sky' },
+        ].map((o) => {
+          const Icon = o.icon
+          return (
+            <div key={o.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 flex gap-4">
+              <div className="w-10 h-10 rounded-lg bg-violet-500/10 border border-violet-500/20 flex items-center justify-center flex-shrink-0">
+                <Icon className="w-5 h-5 text-violet-300" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-white mb-1">{o.title}</h3>
+                <p className="text-sm text-zinc-400">{o.sub}</p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+  // 2 — 3Cs
+  {
+    id: '3cs',
+    eyebrow: 'Framework',
+    title: 'The 3Cs — Skills that compound with AI',
+    minutes: 6,
+    color: 'sky',
+    speakerNotes: [
+      'Ikigai = WHAT to build. 3Cs = HOW to build it without getting automated around.',
+      'Collaboration = pair with AI (PAIR · PACE). Communication = make outputs land (BLUF · SCQA). Creation = ship small.',
+    ],
+    body: () => (
+      <div className="grid md:grid-cols-3 gap-4">
+        {[
+          { title: 'Collaboration', items: ['PACE: Plan → Act → Check → Evolve', 'PAIR with AI: Plan · Ask · Iterate · Review', 'Iteration speed + decision clarity'], color: 'violet' },
+          { title: 'Communication', items: ['BLUF and SCQA frameworks', 'Design docs + demo scripts', 'Clear, reproducible outputs'], color: 'amber' },
+          { title: 'Creation', items: ['Goldilocks scope', 'Build → measure → learn', "Ship small. Show, don't tell."], color: 'emerald' },
+        ].map((c) => (
+          <div key={c.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
+            <h3 className="text-xl font-semibold text-white mb-4">{c.title}</h3>
+            <ul className="space-y-3">
+              {c.items.map((i, idx) => (
+                <li key={idx} className="text-sm text-zinc-400 flex items-start gap-2 leading-relaxed">
+                  <span className="text-zinc-600">—</span>
+                  <span>{i}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+  // 3 — Module 1 intro
+  {
+    id: 'module-1-intro',
+    eyebrow: 'Module 1 · 15 min',
+    title: 'Map your four circles',
+    module: 'Module 1',
+    minutes: 3,
+    color: 'violet',
+    speakerNotes: [
+      'Four circles: love · good · needs · pays.',
+      'External evidence beats internal guessing. Other people\'s words, not yours.',
+    ],
+    body: () => (
+      <div className="relative max-w-3xl mx-auto">
+        <Image
+          src="/images/workshops/ikigai-branding/ikigai-venn.jpg"
+          alt="Ikigai Venn diagram"
+          width={1920}
+          height={960}
+          priority
+          className="w-full h-auto rounded-3xl border border-white/[0.06]"
+        />
+      </div>
+    ),
+  },
+  // 4 — Module 1 deep
+  {
+    id: 'module-1-deep',
+    eyebrow: 'Module 1',
+    title: 'Four questions. Specific answers.',
+    module: 'Module 1',
+    minutes: 12,
+    color: 'violet',
+    speakerNotes: [
+      'Run the wizard live. 3 min per circle. Use Coach GPT deep-links if a participant stalls.',
+      'Push past generic. "Specificity beats volume."',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-2 gap-4">
+        {[
+          { label: 'What I love', q: 'What activities make time disappear for you?', hint: 'Name specific moments from the last 12 months.' },
+          { label: "What I'm good at", q: 'What do people keep thanking you for?', hint: "External evidence only. Other people's words." },
+          { label: 'What the world needs', q: 'Whose problem do you care about for ten years?', hint: 'The narrower the "who", the stronger the answer.' },
+          { label: 'What pays', q: 'What are people already paying for in this space?', hint: 'Real invoices. Real courses. Follow the money.' },
+        ].map((c) => (
+          <div key={c.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+            <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">{c.label}</p>
+            <p className="text-lg font-semibold text-white mb-2 leading-snug">{c.q}</p>
+            <p className="text-xs text-zinc-500">{c.hint}</p>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+  // 5 — Module 2
+  {
+    id: 'module-2',
+    eyebrow: 'Module 2 · 10 min',
+    title: 'Write the sentence',
+    module: 'Module 2',
+    minutes: 10,
+    color: 'amber',
+    speakerNotes: [
+      'Two to three lines. Fits on a business card.',
+      'Quality test: if a competitor could say the same sentence verbatim, sharpen it.',
+    ],
+    body: () => (
+      <div className="space-y-6">
+        <div className="rounded-3xl border border-amber-500/20 bg-gradient-to-br from-amber-500/[0.06] to-violet-500/[0.04] p-8">
+          <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-3">The template</p>
+          <p className="text-2xl sm:text-3xl text-white leading-relaxed font-medium tracking-tight">
+            I help <span className="text-amber-300">[who]</span> achieve <span className="text-emerald-300">[outcome]</span>
+            <br />by <span className="text-violet-300">[how]</span>, using <span className="text-sky-300">[skills]</span> in <span className="text-rose-300">[domain]</span>.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500 mb-2">Worked example</p>
+          <p className="text-base text-zinc-300 leading-relaxed italic">
+            "I help early-career analysts turn messy spreadsheets into decisions,
+            by pairing them with AI workflows, using ten years of consulting craft, in finance and operations teams."
+          </p>
+        </div>
+      </div>
+    ),
+  },
+  // 6 — Module 3 Brand Bridge
+  {
+    id: 'module-3',
+    eyebrow: 'Module 3 · 10 min',
+    title: 'The Brand Bridge',
+    module: 'Module 3',
+    minutes: 10,
+    color: 'amber',
+    speakerNotes: [
+      'Three exercises. Each anchored to the Module 2 statement.',
+      'Audience-of-One is the hardest. Force a single real-feeling name.',
+    ],
+    body: () => (
+      <div className="grid md:grid-cols-3 gap-4">
+        {[
+          { icon: Target, title: 'Positioning Sentence', sub: 'Force a trade-off. Who you are NOT for.' },
+          { icon: UserCircle, title: 'Audience of One', sub: 'A single name. A specific situation. This week\'s problem.' },
+          { icon: Layers3, title: 'Three Content Pillars', sub: '12 months of posts without repeating.' },
+        ].map((b) => {
+          const Icon = b.icon
+          return (
+            <div key={b.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
+              <div className="w-12 h-12 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mb-4">
+                <Icon className="w-6 h-6 text-violet-300" />
+              </div>
+              <h3 className="text-lg font-semibold text-white mb-2">{b.title}</h3>
+              <p className="text-sm text-zinc-400 leading-relaxed">{b.sub}</p>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+  // 7 — Module 4 hooks
+  {
+    id: 'module-4-hooks',
+    eyebrow: 'Module 4 · LinkedIn Top Voice',
+    title: 'Five hook formats',
+    module: 'Module 4',
+    minutes: 5,
+    color: 'emerald',
+    speakerNotes: [
+      'Pattern over creativity. Rotate the five so you never stare at a blank page.',
+      'Have them pick ONE format and draft a real hook for their pillar live.',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-2 gap-3 text-sm">
+        {[
+          { name: 'Contrarian Take', pattern: 'Everyone says X. I think the opposite — and here is why.' },
+          { name: 'Story Open', pattern: 'Last [time], [vivid moment]. Here is what it taught me.' },
+          { name: 'Counter-Wisdom', pattern: 'The advice is X. The advice is wrong for [audience].' },
+          { name: 'Numbered Breakdown', pattern: '[N] things I learned about Y after [proof of work].' },
+          { name: 'Vulnerable Confession', pattern: 'I used to [bad pattern]. Here is what changed it.' },
+        ].map((h) => (
+          <div key={h.name} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4">
+            <p className="font-semibold text-white mb-1.5">{h.name}</p>
+            <p className="text-zinc-400 italic leading-relaxed text-xs">"{h.pattern}"</p>
+          </div>
+        ))}
+        <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-4 flex items-center">
+          <p className="text-emerald-200 font-medium text-sm">
+            Pick ONE. Draft a hook for your pillar in the next 90 seconds.
+          </p>
+        </div>
+      </div>
+    ),
+  },
+  // 8 — Weekly rhythm + channels
+  {
+    id: 'module-4-rhythm',
+    eyebrow: 'Module 4',
+    title: '3 · 2 · 1 · 1 — Weekly rhythm',
+    module: 'Module 4',
+    minutes: 4,
+    color: 'emerald',
+    speakerNotes: [
+      'Three Insight · Two Build-in-Public · One Connection · One Rest.',
+      'Rest day is non-negotiable. Algorithm rewards consistency, not exhaustion.',
+    ],
+    body: () => (
+      <div className="space-y-6">
+        <div className="grid grid-cols-4 gap-3">
+          {[
+            { label: 'Insight', count: 3, color: 'violet-500' },
+            { label: 'Build-in-Public', count: 2, color: 'amber-500' },
+            { label: 'Connection', count: 1, color: 'emerald-500' },
+            { label: 'Rest', count: 1, color: 'zinc-700' },
+          ].map((r) => (
+            <div key={r.label} className={`rounded-2xl border border-${r.color}/30 bg-${r.color}/10 p-5 text-center`}>
+              <p className="text-4xl font-bold text-white mb-1">{r.count}</p>
+              <p className="text-xs text-zinc-300 uppercase tracking-wider">{r.label}</p>
+            </div>
+          ))}
+        </div>
+        <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+          <p className="text-sm text-zinc-400 leading-relaxed">
+            <span className="text-white font-medium">Each channel has a different job.</span>{' '}
+            LinkedIn = authority. Threads = raw thinking. Newsletter = consolidation. Shorts = visualize pillars.
+            Stop reposting the same thing four times.
+          </p>
+        </div>
+      </div>
+    ),
+  },
+  // 9 — 30-day calendar
+  {
+    id: 'module-4-calendar',
+    eyebrow: 'Module 4 · The deliverable',
+    title: 'Your 30-day calendar',
+    module: 'Module 4',
+    minutes: 3,
+    color: 'emerald',
+    speakerNotes: [
+      'Three formats: Notion · Google Sheet · CSV. They pick what they live in.',
+      'Pro tip: 60 min Sunday batch. Schedule with Buffer / Typefully. Real attention compounds.',
+    ],
+    body: () => (
+      <div className="space-y-4">
+        <div className="grid grid-cols-7 gap-1.5 text-xs">
+          {Array.from({ length: 28 }).map((_, i) => {
+            const day = i % 7
+            const isRest = day === 6
+            const archetype = day < 3 ? 'Insight' : day < 5 ? 'Build' : day === 5 ? 'Connect' : 'Rest'
+            const colorClass = isRest
+              ? 'border-white/[0.04] bg-white/[0.01] text-zinc-700'
+              : day < 3
+                ? 'border-violet-500/20 bg-violet-500/[0.04] text-violet-200'
+                : day < 5
+                  ? 'border-amber-500/20 bg-amber-500/[0.04] text-amber-200'
+                  : 'border-emerald-500/20 bg-emerald-500/[0.04] text-emerald-200'
+            return (
+              <div key={i} className={`rounded-lg border p-2 text-center ${colorClass}`}>
+                <div className="font-semibold text-[10px]">D{i + 1}</div>
+                <div className="text-[9px] mt-0.5 leading-tight">{archetype}</div>
+              </div>
+            )
+          })}
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <div className="px-4 py-2 rounded-lg bg-gradient-to-r from-violet-500 to-violet-600 text-white text-sm font-semibold">
+            Notion template
+          </div>
+          <div className="px-4 py-2 rounded-lg bg-white/[0.06] border border-white/[0.10] text-zinc-200 text-sm font-medium">
+            Google Sheet
+          </div>
+          <div className="px-4 py-2 rounded-lg bg-white/[0.06] border border-white/[0.10] text-zinc-200 text-sm font-medium">
+            Download CSV
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  // 10 — GenCreator Stack
+  {
+    id: 'module-5',
+    eyebrow: 'Module 5 · 5 min',
+    title: 'The GenCreator Stack',
+    module: 'Module 5',
+    minutes: 5,
+    color: 'sky',
+    speakerNotes: [
+      'Five jobs every creator runs. Pick one tool per job. Master it. Then expand.',
+      'Discipline: add a tool only when an existing tool fails you twice.',
+    ],
+    body: () => (
+      <div className="grid grid-cols-5 gap-3">
+        {[
+          { icon: Mic, title: 'Capture', tool: 'Loom', color: 'violet' },
+          { icon: Brain, title: 'Think', tool: 'Claude Cowork', color: 'sky' },
+          { icon: Wand2, title: 'Make', tool: 'Suno · NB2', color: 'amber' },
+          { icon: Send, title: 'Ship', tool: 'Buffer · Beehiiv', color: 'emerald' },
+          { icon: BarChart3, title: 'Measure', tool: 'Plausible', color: 'rose' },
+        ].map((c) => {
+          const Icon = c.icon
+          return (
+            <div key={c.title} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-center">
+              <div className="w-12 h-12 rounded-xl bg-white/[0.04] border border-white/[0.08] flex items-center justify-center mx-auto mb-3">
+                <Icon className="w-6 h-6 text-zinc-300" />
+              </div>
+              <p className="text-sm font-semibold text-white mb-1">{c.title}</p>
+              <p className="text-xs text-zinc-500">{c.tool}</p>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+  // 11 — Live artifact
+  {
+    id: 'module-6',
+    eyebrow: 'Module 6 · The artifact',
+    title: 'Watch the post get written',
+    module: 'Module 6',
+    minutes: 5,
+    color: 'amber',
+    speakerNotes: [
+      'Play Loom OR demo live: Claude Cowork in second window.',
+      'Narrate: "Notice I rejected the first 2 hooks. Specificity beats template."',
+      'Close: "AI-assisted. Voice-preserved. Ship today."',
+    ],
+    body: () => (
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] overflow-hidden">
+        <div className="aspect-video bg-[#050507] flex items-center justify-center relative">
+          <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.06] via-amber-500/[0.04] to-transparent" />
+          <div className="relative text-center">
+            <div className="w-20 h-20 rounded-full bg-white/[0.06] border border-white/[0.10] flex items-center justify-center mx-auto mb-4">
+              <Play className="w-9 h-9 text-amber-300 ml-1" fill="currentColor" />
+            </div>
+            <p className="text-base text-zinc-300 font-medium">90 seconds · Claude Cowork demo</p>
+            <p className="text-xs text-zinc-500 mt-1">A LinkedIn post written in real time</p>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  // 12 — Activation
+  {
+    id: 'module-7',
+    eyebrow: 'Module 7 · Activation',
+    title: '4 visible artifacts in 30 days',
+    module: 'Module 7',
+    minutes: 4,
+    color: 'emerald',
+    speakerNotes: [
+      'Public commitment increases follow-through 3×.',
+      'Have them text the commitment to one person before leaving the room.',
+    ],
+    body: () => (
+      <div className="space-y-6">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            { icon: TrendingUp, title: '1 post', sub: 'Pick one hook format. Ship Monday.' },
+            { icon: Play, title: '1 short video', sub: '45–90 seconds. Captions on. Pillar in title.' },
+            { icon: UserCircle, title: '1 conversation', sub: 'DM or email to your audience-of-one.' },
+            { icon: Rocket, title: '1 small product', sub: 'Template · checklist · mini-guide.' },
+          ].map((a) => {
+            const Icon = a.icon
+            return (
+              <div key={a.title} className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-5 text-center">
+                <div className="w-12 h-12 rounded-xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center mx-auto mb-3">
+                  <Icon className="w-6 h-6 text-emerald-300" />
+                </div>
+                <p className="text-base font-semibold text-white mb-1">{a.title}</p>
+                <p className="text-xs text-zinc-400 leading-relaxed">{a.sub}</p>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    ),
+  },
+  // 13 — Outro
+  {
+    id: 'outro',
+    eyebrow: 'Stay in touch',
+    title: 'Three ways to keep going',
+    minutes: 3,
+    color: 'violet',
+    speakerNotes: [
+      'Show QR codes. Promise Resource Pack lands in inbox tonight.',
+      'Day-7 check-in is the secret weapon.',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-3 gap-4">
+        {[
+          { icon: Sparkles, title: 'Coach GPT', sub: 'Walk through everything in chat.', url: 'frankx.ai/go/ikigai-coach', color: 'violet' },
+          { icon: Mail, title: 'Resource Pack', sub: 'Templates + Day-7 check-in.', url: 'frankx.ai/workshops/ikigai-branding', color: 'amber' },
+          { icon: Compass, title: 'AI Architect Newsletter', sub: 'Weekly intelligence for makers.', url: 'frankx.ai/newsletter', color: 'emerald' },
+        ].map((c) => {
+          const Icon = c.icon
+          return (
+            <div key={c.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 text-center">
+              <div className="w-14 h-14 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mx-auto mb-4">
+                <Icon className="w-7 h-7 text-violet-300" />
+              </div>
+              <h3 className="text-lg font-semibold text-white mb-1">{c.title}</h3>
+              <p className="text-sm text-zinc-400 mb-3">{c.sub}</p>
+              <p className="text-xs text-zinc-500 font-mono break-all">{c.url}</p>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+]
+
+// ---- Component ---------------------------------------------------------
+
+export default function IkigaiPresentPage() {
+  const [index, setIndex] = useState(0)
+  const [notesOpen, setNotesOpen] = useState(false)
+  const [running, setRunning] = useState(false)
+  const [elapsed, setElapsed] = useState(0)
+  const startRef = useRef<number>(Date.now())
+  const tickRef = useRef<number | null>(null)
+
+  const slide = SLIDES[index]
+  const total = SLIDES.length
+
+  const next = useCallback(() => setIndex((i) => Math.min(total - 1, i + 1)), [total])
+  const prev = useCallback(() => setIndex((i) => Math.max(0, i - 1)), [])
+
+  const startTimer = useCallback(() => {
+    startRef.current = Date.now() - elapsed
+    setRunning(true)
+  }, [elapsed])
+
+  const pauseTimer = useCallback(() => setRunning(false), [])
+
+  const resetTimer = useCallback(() => {
+    setElapsed(0)
+    startRef.current = Date.now()
+  }, [])
+
+  useEffect(() => {
+    if (!running) return
+    tickRef.current = window.setInterval(() => {
+      setElapsed(Date.now() - startRef.current)
+    }, 250) as unknown as number
+    return () => {
+      if (tickRef.current) window.clearInterval(tickRef.current)
+    }
+  }, [running])
+
+  // Keyboard nav
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
+      if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') {
+        e.preventDefault()
+        next()
+      } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+        e.preventDefault()
+        prev()
+      } else if (e.key === 'n' || e.key === 'N') {
+        setNotesOpen((v) => !v)
+      } else if (e.key === 'r' || e.key === 'R') {
+        resetTimer()
+      } else if (e.key === 'p' || e.key === 'P') {
+        setRunning((v) => !v)
+      } else if (e.key === 'f' || e.key === 'F') {
+        if (!document.fullscreenElement) {
+          document.documentElement.requestFullscreen().catch(() => {})
+        } else {
+          document.exitFullscreen().catch(() => {})
+        }
+      } else if (e.key === 'Escape') {
+        setNotesOpen(false)
+      } else if (/^[0-9]$/.test(e.key)) {
+        const target = parseInt(e.key, 10)
+        if (target < SLIDES.length) setIndex(target)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [next, prev, resetTimer])
+
+  const progress = useMemo(() => ((index + 1) / total) * 100, [index, total])
+
+  return (
+    <div className="fixed inset-0 bg-[#0a0a0b] text-white overflow-hidden">
+      {/* Backdrop gradients */}
+      <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.04] via-transparent to-amber-500/[0.03] pointer-events-none" />
+      <div className="absolute top-0 left-1/3 w-[600px] h-[600px] bg-violet-500/[0.05] rounded-full blur-[160px] pointer-events-none" />
+      <div className="absolute bottom-0 right-1/4 w-[500px] h-[500px] bg-amber-500/[0.04] rounded-full blur-[140px] pointer-events-none" />
+
+      {/* Slide stage */}
+      <div className="relative h-full flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-8 py-5 border-b border-white/[0.04] print:hidden">
+          <Link
+            href="/workshops/ikigai-branding"
+            className="inline-flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" />
+            Back to workshop page
+          </Link>
+          <div className="text-xs text-zinc-600 font-mono">
+            {pad(index + 1)} / {pad(total)}
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-0.5 bg-white/[0.04] print:hidden">
+          <motion.div
+            className="h-full bg-gradient-to-r from-violet-400 to-amber-400"
+            initial={false}
+            animate={{ width: `${progress}%` }}
+            transition={{ duration: 0.4 }}
+          />
+        </div>
+
+        {/* Slide content */}
+        <div className="flex-1 flex items-center justify-center px-8 py-8 overflow-hidden">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={slide.id}
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -16 }}
+              transition={{ duration: 0.3 }}
+              className="w-full max-w-6xl mx-auto"
+            >
+              {slide.eyebrow && (
+                <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-3">
+                  {slide.eyebrow}
+                </p>
+              )}
+              {slide.id !== 'cover' && (
+                <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white tracking-tight mb-10 max-w-4xl">
+                  {slide.title}
+                </h2>
+              )}
+              {slide.body()}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Footer HUD */}
+        <div className="flex items-center justify-between px-8 py-4 border-t border-white/[0.04] print:hidden">
+          {/* Nav dots */}
+          <div className="flex items-center gap-1">
+            {SLIDES.map((s, i) => (
+              <button
+                key={s.id}
+                onClick={() => setIndex(i)}
+                aria-label={`Go to slide ${i + 1}: ${s.title}`}
+                className={`h-1.5 rounded-full transition-all ${
+                  i === index ? 'w-6 bg-violet-400' : 'w-1.5 bg-white/[0.12] hover:bg-white/[0.25]'
+                }`}
+              />
+            ))}
+          </div>
+
+          {/* Timer + controls */}
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1.5 text-sm font-mono">
+              <span className={running ? 'text-emerald-300' : 'text-zinc-500'}>
+                {formatTime(elapsed)}
+              </span>
+              <button
+                onClick={running ? pauseTimer : startTimer}
+                className="text-zinc-400 hover:text-white p-1"
+                aria-label={running ? 'Pause timer' : 'Start timer'}
+              >
+                {running ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+              </button>
+              <button
+                onClick={resetTimer}
+                className="text-zinc-500 hover:text-white p-1"
+                aria-label="Reset timer"
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+              </button>
+            </div>
+
+            <div className="w-px h-5 bg-white/[0.08]" />
+
+            <button
+              onClick={() => setNotesOpen((v) => !v)}
+              className={`p-1.5 rounded-md hover:bg-white/[0.06] ${notesOpen ? 'text-amber-300' : 'text-zinc-400 hover:text-white'}`}
+              aria-label="Toggle notes"
+            >
+              <StickyNote className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => {
+                if (!document.fullscreenElement) {
+                  document.documentElement.requestFullscreen().catch(() => {})
+                } else {
+                  document.exitFullscreen().catch(() => {})
+                }
+              }}
+              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06]"
+              aria-label="Fullscreen"
+            >
+              <Maximize2 className="w-4 h-4" />
+            </button>
+
+            <div className="w-px h-5 bg-white/[0.08]" />
+
+            <button
+              onClick={prev}
+              disabled={index === 0}
+              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Previous slide"
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </button>
+            <button
+              onClick={next}
+              disabled={index === total - 1}
+              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Next slide"
+            >
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Notes drawer */}
+      <AnimatePresence>
+        {notesOpen && (
+          <motion.div
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 25, stiffness: 220 }}
+            className="absolute inset-x-0 bottom-16 z-40 px-8 print:hidden"
+          >
+            <div className="max-w-3xl mx-auto rounded-2xl border border-white/[0.10] bg-[#0a0a0b]/95 backdrop-blur-xl shadow-2xl shadow-black/60 p-5">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <StickyNote className="w-4 h-4 text-amber-300" />
+                  <p className="text-sm font-semibold text-white">Speaker notes</p>
+                  <span className="text-xs text-zinc-500">· suggested {slide.minutes} min</span>
+                </div>
+                <button
+                  onClick={() => setNotesOpen(false)}
+                  className="text-zinc-500 hover:text-zinc-200"
+                  aria-label="Close notes"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <ul className="space-y-1.5">
+                {slide.speakerNotes.map((n, i) => (
+                  <li key={i} className="text-sm text-zinc-300 flex items-start gap-2 leading-relaxed">
+                    <span className="text-amber-300/60 mt-0.5">›</span>
+                    <span>{n}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Keyboard hint */}
+      <p className="absolute bottom-1 inset-x-0 text-center text-[10px] text-zinc-700 print:hidden">
+        ← → next · N notes · P pause · R reset · F fullscreen · 0-9 jump
+      </p>
+
+      {/* Print styles — generates PDF with every slide on its own page */}
+      <style jsx global>{`
+        @media print {
+          html, body {
+            background: white !important;
+            color: black !important;
+          }
+          .fixed {
+            position: static !important;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/components/workshops/ikigai/ContentOperatingPlan.tsx
+++ b/components/workshops/ikigai/ContentOperatingPlan.tsx
@@ -1,0 +1,379 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  Calendar,
+  Sparkles,
+  TrendingUp,
+  Repeat,
+  Layers,
+  Download,
+  ExternalLink,
+  Copy,
+  Check,
+  FileSpreadsheet,
+  FileText,
+} from 'lucide-react'
+import type { IkigaiState } from './types'
+
+interface ContentOperatingPlanProps {
+  value: IkigaiState
+}
+
+const HOOK_FORMATS = [
+  {
+    name: 'Contrarian Take',
+    pattern: '"Everyone says X. I think the opposite — and here is why."',
+    example: '"Everyone says you need a niche. I went broad for 3 years and tripled my income."',
+  },
+  {
+    name: 'Story Open',
+    pattern: '"Last [time], [vivid moment]. Here is what it taught me."',
+    example: '"Last Tuesday, a client paid me to delete code. Here is what it taught me about value."',
+  },
+  {
+    name: 'Counter-Wisdom',
+    pattern: '"The advice is X. The advice is wrong for [audience]."',
+    example: '"\'Build in public\' is wrong for senior consultants. Here is what works instead."',
+  },
+  {
+    name: 'Numbered Breakdown',
+    pattern: '"[N] things I learned [about Y] after [proof of work]."',
+    example: '"6 things I learned about LinkedIn after my post hit 1.2M views."',
+  },
+  {
+    name: 'Vulnerable Confession',
+    pattern: '"I used to [bad pattern]. Here is what changed it."',
+    example: '"I used to post every day and felt empty. Here is what changed it."',
+  },
+] as const
+
+const POST_ARCHETYPES = [
+  {
+    name: 'Insight',
+    weight: 3,
+    purpose: 'Teach a lesson from your zone of expertise. Earns authority.',
+    color: 'violet',
+  },
+  {
+    name: 'Build-in-Public',
+    weight: 2,
+    purpose: 'Show an artifact, a metric, a screenshot. Earns trust.',
+    color: 'amber',
+  },
+  {
+    name: 'Connection',
+    weight: 1,
+    purpose: 'Amplify someone. Make an intro. Tag a thinker. Earns reach.',
+    color: 'emerald',
+  },
+] as const
+
+const CHANNEL_MATRIX = [
+  {
+    channel: 'LinkedIn',
+    role: 'Authority + business gravity',
+    cadence: '4–5 posts / week',
+    format: 'Insight posts (60%) + Build-in-Public (30%) + Connection (10%)',
+  },
+  {
+    channel: 'Threads / X',
+    role: 'Raw thinking, fast feedback',
+    cadence: 'Daily, 1–3 posts',
+    format: 'Half-formed ideas you would not post on LinkedIn yet',
+  },
+  {
+    channel: 'Newsletter',
+    role: 'Consolidation, owned audience',
+    cadence: 'Weekly, Sunday',
+    format: 'This week\'s top post expanded + 3 links you actually read',
+  },
+  {
+    channel: 'YouTube Shorts',
+    role: 'Visualize the 3 pillars',
+    cadence: '2–3 per week',
+    format: '45–90s talking head, 1 idea each, captions on',
+  },
+] as const
+
+function extractPillarHints(value: IkigaiState): string[] {
+  // Heuristic: derive 3 pillar candidates from the wizard answers
+  const sources = [value.good, value.needs, value.pays].map((s) =>
+    s.split(/[.\n,]/)[0]?.trim() || ''
+  )
+  return sources.filter(Boolean).slice(0, 3)
+}
+
+function build30DayCalendar(pillars: string[]): Array<{ week: number; days: string[] }> {
+  const archetypes = ['Insight', 'Insight', 'Build-in-Public', 'Insight', 'Build-in-Public', 'Connection', 'Rest']
+  const safePillars = pillars.length === 3 ? pillars : ['Pillar 1', 'Pillar 2', 'Pillar 3']
+  return [1, 2, 3, 4].map((week) => ({
+    week,
+    days: archetypes.map((archetype, i) => {
+      if (archetype === 'Rest') return 'Rest / consolidate'
+      const pillar = safePillars[(week + i) % 3]
+      return `${archetype} · ${pillar}`
+    }),
+  }))
+}
+
+export function ContentOperatingPlan({ value }: ContentOperatingPlanProps) {
+  const [copied, setCopied] = useState<string | null>(null)
+  const pillarHints = useMemo(() => extractPillarHints(value), [value])
+  const calendar = useMemo(() => build30DayCalendar(pillarHints), [pillarHints])
+  const hasInputs = pillarHints.length > 0
+
+  function downloadCsv() {
+    const header = 'Week,Day,Pillar,Archetype,Channel\n'
+    const rows = calendar
+      .flatMap((week) =>
+        week.days.map((slot, i) => {
+          const [archetype, pillar] = slot.split(' · ')
+          const day = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][i]
+          const channel = i % 2 === 0 ? 'LinkedIn' : 'Threads'
+          return `${week.week},${day},"${pillar || 'Rest'}","${archetype || 'Rest'}",${channel}`
+        }),
+      )
+      .join('\n')
+    const blob = new Blob([header + rows], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `30-day-content-plan-${new Date().toISOString().split('T')[0]}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function copyPattern(name: string, text: string) {
+    navigator.clipboard.writeText(text)
+    setCopied(name)
+    setTimeout(() => setCopied(null), 1800)
+  }
+
+  return (
+    <div id="content-plan" className="space-y-8">
+      {/* LinkedIn Top Voice Playbook */}
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 sm:p-8">
+        <div className="mb-6">
+          <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2 flex items-center gap-1.5">
+            <TrendingUp className="w-3.5 h-3.5" />
+            LinkedIn Top Voice playbook
+          </p>
+          <h3 className="text-xl sm:text-2xl font-semibold text-white tracking-tight">
+            Five hook formats that earn attention without selling out
+          </h3>
+          <p className="text-sm text-zinc-400 mt-2">
+            Pattern over creativity. Rotate these five so you never stare at a blank page.
+          </p>
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-3">
+          {HOOK_FORMATS.map((h) => (
+            <div
+              key={h.name}
+              className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4 space-y-2"
+            >
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold text-white">{h.name}</h4>
+                <button
+                  onClick={() => copyPattern(h.name, h.pattern)}
+                  className="text-zinc-500 hover:text-violet-300 transition-colors"
+                  aria-label={`Copy ${h.name} pattern`}
+                >
+                  {copied === h.name ? (
+                    <Check className="w-4 h-4 text-emerald-400" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+              <p className="text-xs text-zinc-400 italic leading-relaxed">{h.pattern}</p>
+              <p className="text-xs text-zinc-500 leading-relaxed">{h.example}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Post archetypes — weekly rhythm */}
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 sm:p-8">
+        <div className="mb-5">
+          <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2 flex items-center gap-1.5">
+            <Repeat className="w-3.5 h-3.5" />
+            Weekly rhythm
+          </p>
+          <h3 className="text-xl sm:text-2xl font-semibold text-white tracking-tight">
+            3 Insight · 2 Build-in-Public · 1 Connection · 1 Rest
+          </h3>
+          <p className="text-sm text-zinc-400 mt-2">
+            Seven slots. Mix the archetypes. Rest day is non-negotiable — the algorithm rewards consistency, not exhaustion.
+          </p>
+        </div>
+
+        <div className="grid sm:grid-cols-3 gap-3">
+          {POST_ARCHETYPES.map((a) => (
+            <div
+              key={a.name}
+              className={`rounded-2xl border bg-white/[0.02] p-4 space-y-2 ${
+                a.color === 'violet'
+                  ? 'border-violet-500/20'
+                  : a.color === 'amber'
+                    ? 'border-amber-500/20'
+                    : 'border-emerald-500/20'
+              }`}
+            >
+              <div className="flex items-baseline justify-between">
+                <h4 className="text-sm font-semibold text-white">{a.name}</h4>
+                <span className="text-xs text-zinc-500">×{a.weight}/wk</span>
+              </div>
+              <p className="text-xs text-zinc-400 leading-relaxed">{a.purpose}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Multi-channel matrix */}
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 sm:p-8">
+        <div className="mb-5">
+          <p className="text-xs font-medium uppercase tracking-wider text-emerald-400 mb-2 flex items-center gap-1.5">
+            <Layers className="w-3.5 h-3.5" />
+            Channel matrix
+          </p>
+          <h3 className="text-xl sm:text-2xl font-semibold text-white tracking-tight">
+            One thesis, four channels, four roles
+          </h3>
+          <p className="text-sm text-zinc-400 mt-2">
+            Stop reposting the same thing four times. Each channel has a different job.
+          </p>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-white/[0.06]">
+          <table className="w-full text-sm">
+            <thead className="bg-white/[0.03]">
+              <tr className="text-left">
+                <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-zinc-500">Channel</th>
+                <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-zinc-500">Role</th>
+                <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-zinc-500">Cadence</th>
+                <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-zinc-500">Format</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/[0.04]">
+              {CHANNEL_MATRIX.map((row) => (
+                <tr key={row.channel}>
+                  <td className="px-4 py-3 font-medium text-white">{row.channel}</td>
+                  <td className="px-4 py-3 text-zinc-400">{row.role}</td>
+                  <td className="px-4 py-3 text-zinc-400">{row.cadence}</td>
+                  <td className="px-4 py-3 text-zinc-500 text-xs">{row.format}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* 30-day calendar */}
+      <div className="rounded-3xl border border-violet-500/20 bg-gradient-to-br from-violet-500/[0.04] to-amber-500/[0.04] p-6 sm:p-8">
+        <div className="mb-5">
+          <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2 flex items-center gap-1.5">
+            <Calendar className="w-3.5 h-3.5" />
+            Your 30-day calendar
+          </p>
+          <h3 className="text-xl sm:text-2xl font-semibold text-white tracking-tight">
+            Generated from your pillars
+          </h3>
+          {!hasInputs && (
+            <p className="text-sm text-amber-300/80 mt-2">
+              Complete the wizard first — your three pillars will populate this calendar automatically.
+            </p>
+          )}
+          {hasInputs && (
+            <p className="text-sm text-zinc-400 mt-2">
+              Anchored to: {pillarHints.map((p, i) => (
+                <span key={i}>
+                  <span className="text-violet-300">{p}</span>
+                  {i < pillarHints.length - 1 ? ' · ' : ''}
+                </span>
+              ))}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          {calendar.map((week) => (
+            <div key={week.week} className="rounded-2xl border border-white/[0.06] bg-[#0a0a0b]/40 p-3">
+              <div className="flex items-center gap-3 mb-2">
+                <span className="text-xs font-medium text-zinc-500 uppercase tracking-wider min-w-[3.5rem]">
+                  Week {week.week}
+                </span>
+                <div className="flex-1 h-px bg-white/[0.04]" />
+              </div>
+              <div className="grid grid-cols-7 gap-1.5 text-[10px] sm:text-xs">
+                {week.days.map((slot, i) => {
+                  const [archetype] = slot.split(' · ')
+                  const dayLabel = ['M', 'T', 'W', 'T', 'F', 'S', 'S'][i]
+                  const isRest = archetype === 'Rest'
+                  return (
+                    <div
+                      key={i}
+                      className={`rounded-lg border p-2 ${
+                        isRest
+                          ? 'border-white/[0.04] bg-white/[0.01] text-zinc-600'
+                          : 'border-white/[0.06] bg-white/[0.02] text-zinc-300'
+                      }`}
+                    >
+                      <div className="font-medium text-zinc-500 mb-0.5">{dayLabel}</div>
+                      <div className="leading-tight">{slot}</div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Export buttons */}
+        <div className="mt-6 flex flex-wrap items-center gap-2">
+          <a
+            href="/go/ikigai-notion-template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-lg text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-violet-600 hover:from-violet-400 hover:to-violet-500 transition-colors shadow-lg shadow-violet-500/20"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Duplicate Notion template
+          </a>
+          <a
+            href="/go/ikigai-sheet-template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-lg text-sm font-medium text-zinc-200 bg-white/[0.06] border border-white/[0.10] hover:bg-white/[0.10] transition-colors"
+          >
+            <FileSpreadsheet className="w-4 h-4" />
+            Copy Google Sheet
+          </a>
+          <button
+            onClick={downloadCsv}
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-lg text-sm font-medium text-zinc-200 bg-white/[0.06] border border-white/[0.10] hover:bg-white/[0.10] transition-colors"
+          >
+            <Download className="w-4 h-4" />
+            Download CSV
+          </button>
+          <button
+            onClick={() => window.print()}
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-lg text-sm font-medium text-zinc-200 bg-white/[0.06] border border-white/[0.10] hover:bg-white/[0.10] transition-colors"
+          >
+            <FileText className="w-4 h-4" />
+            Print to PDF
+          </button>
+        </div>
+
+        <p className="text-xs text-zinc-500 mt-3 flex items-start gap-1.5">
+          <Sparkles className="w-3 h-3 mt-0.5 flex-shrink-0 text-violet-300" />
+          <span>
+            Pro tip: Block 60 minutes on Sunday to batch the week’s posts. Schedule with Buffer or Typefully.
+            Real attention compounds — fake batches do not.
+          </span>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/workshops/ikigai/GenCreatorStack.tsx
+++ b/components/workshops/ikigai/GenCreatorStack.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import {
+  Mic,
+  Brain,
+  Wand2,
+  Send,
+  BarChart3,
+  ArrowUpRight,
+} from 'lucide-react'
+
+interface StackTool {
+  name: string
+  why: string
+  href: string
+  badge?: 'free' | 'paid' | 'mcp' | 'core'
+}
+
+interface StackCategory {
+  title: string
+  icon: typeof Mic
+  color: 'violet' | 'amber' | 'emerald' | 'sky' | 'rose'
+  intent: string
+  tools: StackTool[]
+}
+
+const CATEGORIES: StackCategory[] = [
+  {
+    title: 'Capture',
+    icon: Mic,
+    color: 'violet',
+    intent: 'Catch raw inputs before they evaporate. Voice → text. Browser → notes. Phone → inbox.',
+    tools: [
+      {
+        name: 'Loom',
+        why: 'Chrome extension. Record screen + face + auto-transcript. Free tier is enough.',
+        href: 'https://www.loom.com',
+        badge: 'free',
+      },
+      {
+        name: 'Voice Memos',
+        why: 'Native on phone. Whisper transcribes anything. Walk and think.',
+        href: 'https://support.apple.com/voice-memos',
+        badge: 'free',
+      },
+      {
+        name: 'Notion Web Clipper',
+        why: 'Send articles to a single inbox. Tag later, batch-process Sunday.',
+        href: 'https://www.notion.so/web-clipper',
+        badge: 'free',
+      },
+      {
+        name: 'Granola',
+        why: 'AI meeting notes that do not record. Outputs structured action items.',
+        href: 'https://www.granola.ai',
+        badge: 'paid',
+      },
+    ],
+  },
+  {
+    title: 'Think',
+    icon: Brain,
+    color: 'sky',
+    intent: 'The wedge between half-formed idea and clear thesis. Pair with AI, not behind it.',
+    tools: [
+      {
+        name: 'Claude Cowork',
+        why: 'Two windows side by side. You type. Claude reasons. Faster than any solo draft.',
+        href: 'https://claude.ai',
+        badge: 'core',
+      },
+      {
+        name: 'ChatGPT Projects',
+        why: 'Persistent context across chats. Drop your brand voice once, reuse forever.',
+        href: 'https://chat.openai.com',
+        badge: 'paid',
+      },
+      {
+        name: 'NotebookLM',
+        why: 'Drop 10 sources. Get audio overviews. Best for research synthesis.',
+        href: 'https://notebooklm.google.com',
+        badge: 'free',
+      },
+      {
+        name: 'Cursor',
+        why: 'If you build: AI-native IDE. Composer mode replaces 70% of solo coding.',
+        href: 'https://www.cursor.com',
+        badge: 'paid',
+      },
+    ],
+  },
+  {
+    title: 'Make',
+    icon: Wand2,
+    color: 'amber',
+    intent: 'Turn idea into artifact. Image, audio, video, code. Preserve voice — never delegate the soul.',
+    tools: [
+      {
+        name: 'Suno AI',
+        why: 'Music generation that respects taste. 12 genre styles in one prompt.',
+        href: 'https://suno.com',
+        badge: 'paid',
+      },
+      {
+        name: 'Nano Banana 2',
+        why: 'Gemini 3.1 Flash Image. Photo-realistic generation with text-rendering that actually works.',
+        href: 'https://aistudio.google.com',
+        badge: 'core',
+      },
+      {
+        name: 'Higgsfield',
+        why: 'Soul Character training for face-consistent video. Product photoshoots, UGC, ads.',
+        href: 'https://higgsfield.ai',
+        badge: 'mcp',
+      },
+      {
+        name: 'HyperFrames',
+        why: 'Code-first video composition. Deterministic, version-controlled, no Adobe.',
+        href: 'https://hyperframes.dev',
+        badge: 'free',
+      },
+    ],
+  },
+  {
+    title: 'Ship',
+    icon: Send,
+    color: 'emerald',
+    intent: 'Move the artifact into the world on schedule. Distribution is the second draft.',
+    tools: [
+      {
+        name: 'Buffer',
+        why: 'Multi-platform scheduling. Free for 3 channels. Best for LinkedIn + Threads + X.',
+        href: 'https://buffer.com',
+        badge: 'free',
+      },
+      {
+        name: 'Typefully',
+        why: 'Thread composer + analytics. Pairs cleanly with the LinkedIn Top Voice playbook.',
+        href: 'https://typefully.com',
+        badge: 'paid',
+      },
+      {
+        name: 'Beehiiv',
+        why: 'Newsletter with native referral loops + paid tier when ready. Better than Substack for monetization.',
+        href: 'https://www.beehiiv.com',
+        badge: 'free',
+      },
+      {
+        name: 'Lemon Squeezy',
+        why: 'EU-friendly merchant of record. Sell digital products without VAT pain.',
+        href: 'https://www.lemonsqueezy.com',
+        badge: 'paid',
+      },
+    ],
+  },
+  {
+    title: 'Measure',
+    icon: BarChart3,
+    color: 'rose',
+    intent: 'What gets measured improves. What does not, drifts. Pick three metrics, not thirty.',
+    tools: [
+      {
+        name: 'Plausible',
+        why: 'Cookie-free, GDPR-clean web analytics. One number per page, no dashboards-of-dashboards.',
+        href: 'https://plausible.io',
+        badge: 'paid',
+      },
+      {
+        name: 'Shield Analytics',
+        why: 'LinkedIn-native. Tracks impressions, engagement velocity, top hooks.',
+        href: 'https://shieldapp.ai',
+        badge: 'paid',
+      },
+      {
+        name: 'Vercel Analytics',
+        why: 'If you host on Vercel: Web Vitals + audience built in. Free tier covers small sites.',
+        href: 'https://vercel.com/analytics',
+        badge: 'free',
+      },
+      {
+        name: 'A simple notebook',
+        why: 'Once a month, write what worked. The pattern is the metric. Beats every dashboard.',
+        href: '#',
+        badge: 'free',
+      },
+    ],
+  },
+]
+
+const COLOR_MAP = {
+  violet: {
+    bg: 'bg-violet-500/10',
+    border: 'border-violet-500/20',
+    text: 'text-violet-300',
+  },
+  amber: {
+    bg: 'bg-amber-500/10',
+    border: 'border-amber-500/20',
+    text: 'text-amber-300',
+  },
+  emerald: {
+    bg: 'bg-emerald-500/10',
+    border: 'border-emerald-500/20',
+    text: 'text-emerald-300',
+  },
+  sky: {
+    bg: 'bg-sky-500/10',
+    border: 'border-sky-500/20',
+    text: 'text-sky-300',
+  },
+  rose: {
+    bg: 'bg-rose-500/10',
+    border: 'border-rose-500/20',
+    text: 'text-rose-300',
+  },
+} as const
+
+const BADGE_MAP = {
+  free: { label: 'Free', class: 'text-emerald-300 bg-emerald-500/10 border-emerald-500/20' },
+  paid: { label: 'Paid', class: 'text-zinc-400 bg-white/[0.04] border-white/[0.08]' },
+  mcp: { label: 'MCP', class: 'text-violet-300 bg-violet-500/10 border-violet-500/20' },
+  core: { label: 'Core', class: 'text-amber-300 bg-amber-500/10 border-amber-500/20' },
+} as const
+
+export function GenCreatorStack() {
+  return (
+    <div id="gencreator-stack" className="space-y-6">
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 sm:p-8">
+        <p className="text-sm text-zinc-400 leading-relaxed">
+          Five jobs every creator runs: <span className="text-white">Capture · Think · Make · Ship · Measure</span>.
+          The stack below is opinionated, not exhaustive. Pick one tool per job, master it, then expand.
+          The goal is leverage, not toolbelt envy.
+        </p>
+      </div>
+
+      <div className="grid lg:grid-cols-2 gap-4">
+        {CATEGORIES.map((cat) => {
+          const colors = COLOR_MAP[cat.color]
+          const Icon = cat.icon
+          return (
+            <div
+              key={cat.title}
+              className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-5 sm:p-6"
+            >
+              <div className="flex items-start gap-3 mb-4">
+                <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${colors.bg} border ${colors.border}`}>
+                  <Icon className={`w-5 h-5 ${colors.text}`} />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-base font-semibold text-white">{cat.title}</h3>
+                  <p className="text-xs text-zinc-500 mt-0.5">{cat.intent}</p>
+                </div>
+              </div>
+
+              <ul className="space-y-2.5">
+                {cat.tools.map((tool) => {
+                  const badge = tool.badge ? BADGE_MAP[tool.badge] : null
+                  return (
+                    <li key={tool.name}>
+                      <a
+                        href={tool.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group block rounded-xl border border-white/[0.04] bg-white/[0.01] hover:bg-white/[0.04] hover:border-white/[0.08] p-3 transition-colors"
+                      >
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-sm font-medium text-white group-hover:text-violet-200 transition-colors">
+                            {tool.name}
+                          </span>
+                          {badge && (
+                            <span className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border ${badge.class}`}>
+                              {badge.label}
+                            </span>
+                          )}
+                          <ArrowUpRight className="w-3.5 h-3.5 text-zinc-600 group-hover:text-violet-300 transition-colors ml-auto" />
+                        </div>
+                        <p className="text-xs text-zinc-500 leading-relaxed">{tool.why}</p>
+                      </a>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-5 sm:p-6">
+        <p className="text-sm text-emerald-200 leading-relaxed">
+          <span className="font-semibold">The discipline:</span> add a tool only when an existing tool fails you twice.
+          Most creators have 30+ subscriptions and 3 they actually use. Be the second kind.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/workshops/ikigai/LiveArtifact.tsx
+++ b/components/workshops/ikigai/LiveArtifact.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { Play, ExternalLink, Sparkles } from 'lucide-react'
+
+interface LiveArtifactProps {
+  /** Loom or YouTube URL. When empty, shows the placeholder state. */
+  embedUrl?: string
+  /** Static poster image while waiting for click-to-play. */
+  posterSrc?: string
+}
+
+export function LiveArtifact({ embedUrl, posterSrc }: LiveArtifactProps) {
+  const hasVideo = Boolean(embedUrl)
+
+  return (
+    <div id="live-artifact" className="space-y-6">
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] overflow-hidden">
+        <div className="p-6 sm:p-8 pb-4">
+          <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2 flex items-center gap-1.5">
+            <Sparkles className="w-3.5 h-3.5" />
+            The artifact
+          </p>
+          <h3 className="text-xl sm:text-2xl font-semibold text-white tracking-tight">
+            Watch the post get written
+          </h3>
+          <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+            Theory is cheap. Here is 90 seconds of me co-writing a LinkedIn post with Claude Cowork —
+            using one of the five hook formats, anchored to a real pillar, preserving voice.
+          </p>
+        </div>
+
+        {/* Video slot */}
+        <div className="relative aspect-video bg-[#050507] border-y border-white/[0.04] overflow-hidden">
+          {hasVideo ? (
+            <iframe
+              src={embedUrl}
+              title="Claude Cowork demo — writing a LinkedIn post"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="absolute inset-0 w-full h-full"
+            />
+          ) : (
+            <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-6">
+              <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.04] via-amber-500/[0.03] to-transparent" />
+              {posterSrc && (
+                <img
+                  src={posterSrc}
+                  alt=""
+                  aria-hidden="true"
+                  className="absolute inset-0 w-full h-full object-cover opacity-30"
+                />
+              )}
+              <div className="relative w-16 h-16 rounded-full bg-white/[0.06] border border-white/[0.10] flex items-center justify-center mb-4">
+                <Play className="w-7 h-7 text-zinc-500 ml-0.5" fill="currentColor" />
+              </div>
+              <p className="relative text-sm font-medium text-zinc-400 mb-1">
+                Live demo lands here
+              </p>
+              <p className="relative text-xs text-zinc-600 max-w-xs">
+                Frank is recording a 90-second Loom of co-writing a post with Claude Cowork.
+                Subscribe below to be notified when it lands.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="p-6 sm:p-8 pt-5">
+          <div className="grid sm:grid-cols-3 gap-3 text-xs">
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-3">
+              <p className="font-medium text-violet-300 mb-1">What you will see</p>
+              <p className="text-zinc-500">A blank doc become a publishable LinkedIn post in 90 seconds.</p>
+            </div>
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-3">
+              <p className="font-medium text-amber-300 mb-1">What you will hear</p>
+              <p className="text-zinc-500">Why each prompt — and which Claude responses I rejected and why.</p>
+            </div>
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-3">
+              <p className="font-medium text-emerald-300 mb-1">What you will keep</p>
+              <p className="text-zinc-500">The exact prompt scaffold, downloadable below.</p>
+            </div>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center gap-2">
+            <a
+              href="/go/claude-cowork"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-violet-300 hover:text-violet-200 transition-colors"
+            >
+              Try Claude Cowork
+              <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+            <span className="text-zinc-700">·</span>
+            <a
+              href="/go/ikigai-prompt-scaffold"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+            >
+              Download the prompt scaffold
+              <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/workshops/ikigai/PresenterOverlay.tsx
+++ b/components/workshops/ikigai/PresenterOverlay.tsx
@@ -1,0 +1,343 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ChevronUp,
+  ChevronDown,
+  Pause,
+  Play,
+  RotateCcw,
+  StickyNote,
+  X,
+  Maximize2,
+} from 'lucide-react'
+
+/**
+ * Speaker notes per section. Keys must match section element ids on the page.
+ * Keep notes tight — these display in a small drawer, not a long manuscript.
+ */
+const SPEAKER_NOTES: Record<string, { title: string; minutes: number; notes: string[] }> = {
+  intro: {
+    title: 'Welcome + Outcomes',
+    minutes: 5,
+    notes: [
+      'Open with the 3Cs hook: "Skills that compound when paired with AI."',
+      'Set the deliverable: by the end you will have a purpose statement + 30-day plan.',
+      'Ask: "Raise a hand if you have ever written a LinkedIn bio and felt nothing." Pause.',
+    ],
+  },
+  'three-cs': {
+    title: 'The 3Cs framework',
+    minutes: 6,
+    notes: [
+      'Collaboration = your pair with AI. Communication = how you make outputs land. Creation = shipping small.',
+      'Bridge: "Your Ikigai points at WHAT. The 3Cs are HOW."',
+      'Avoid: do not get pulled into AI tooling questions yet — bookmark for Module 5.',
+    ],
+  },
+  'module-1': {
+    title: 'Module 1 · Ikigai Map (15 min)',
+    minutes: 15,
+    notes: [
+      'Run the wizard live on screen. Spend 3 min per circle.',
+      'Coach prompt: "External evidence only. Other people\'s words."',
+      'If someone stalls on "what pays" — point at courses + agencies + SaaS in their space.',
+    ],
+  },
+  synthesis: {
+    title: 'Module 2 · Purpose Statement (10 min)',
+    minutes: 10,
+    notes: [
+      'Show the draft auto-generator. Then have them write their own — drafts beat templates.',
+      'Quality check: "If a direct competitor could say this sentence verbatim, sharpen it."',
+      'Export to markdown live so they see it works.',
+    ],
+  },
+  'brand-bridge': {
+    title: 'Module 3 · Brand Bridge (10 min)',
+    minutes: 10,
+    notes: [
+      'Three exercises: Positioning · Audience-of-One · 3 Pillars. They all anchor to Module 2 statement.',
+      'Audience-of-One is the hardest. Force a single name + situation.',
+      'Pillars: each must survive 12 months of weekly posts without repeating.',
+    ],
+  },
+  'content-plan': {
+    title: 'Module 4 · Content Operating Plan (12 min)',
+    minutes: 12,
+    notes: [
+      'Show the 5 hook formats. Have them pick one and draft a post during the workshop.',
+      '3+2+1+1 rhythm. Insight is the engine. Build-in-Public is the trust loop. Connection is the reach loop.',
+      'Channel matrix: stop reposting the same thing 4×. Each channel has a different job.',
+    ],
+  },
+  'gencreator-stack': {
+    title: 'Module 5 · GenCreator Stack (5 min)',
+    minutes: 5,
+    notes: [
+      'Speed-run the 5 categories. Do not let them ask about every tool.',
+      'Discipline: add a tool only when an existing tool fails you twice.',
+      '"Toolbelt envy is not leverage" — repeat the line.',
+    ],
+  },
+  'live-artifact': {
+    title: 'Module 6 · Live Artifact (5 min)',
+    minutes: 5,
+    notes: [
+      'Play the Loom OR demo live (Claude Cowork open in second window).',
+      'Narrate: "Notice I rejected the first 2 hooks. Specificity beats template."',
+      'End on: "AI-assisted. Voice-preserved. Ship today."',
+    ],
+  },
+  activation: {
+    title: 'Module 7 · Activation + CTA (4 min)',
+    minutes: 4,
+    notes: [
+      '4 visible artifacts in 30 days. Public commitment increases follow-through 3×.',
+      'Hand the QR for Coach GPT. Promise the Resource Pack email lands tonight.',
+      'Day-7 check-in is the secret weapon. Show one.',
+    ],
+  },
+}
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+function formatTime(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`
+}
+
+interface PresenterOverlayProps {
+  /** Ordered section ids the presenter will navigate through. */
+  sectionIds: string[]
+  /** When true, render the HUD. Page passes searchParams.present === '1'. */
+  active: boolean
+}
+
+export function PresenterOverlay({ sectionIds, active }: PresenterOverlayProps) {
+  const [currentId, setCurrentId] = useState<string>(sectionIds[0] ?? '')
+  const [notesOpen, setNotesOpen] = useState(false)
+  const [running, setRunning] = useState(true)
+  const [elapsed, setElapsed] = useState(0)
+  const tickRef = useRef<number | null>(null)
+  const startRef = useRef<number>(Date.now())
+
+  // Timer
+  useEffect(() => {
+    if (!active || !running) return
+    tickRef.current = window.setInterval(() => {
+      setElapsed(Date.now() - startRef.current)
+    }, 250) as unknown as number
+    return () => {
+      if (tickRef.current) window.clearInterval(tickRef.current)
+    }
+  }, [active, running])
+
+  // Section detection via IntersectionObserver
+  useEffect(() => {
+    if (!active) return
+    const observers: IntersectionObserver[] = []
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id)
+      if (!el) return
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting && entry.intersectionRatio > 0.3) {
+              setCurrentId(id)
+            }
+          })
+        },
+        { threshold: [0.3, 0.5, 0.7] },
+      )
+      observer.observe(el)
+      observers.push(observer)
+    })
+    return () => observers.forEach((o) => o.disconnect())
+  }, [active, sectionIds])
+
+  const currentIndex = useMemo(
+    () => Math.max(0, sectionIds.indexOf(currentId)),
+    [currentId, sectionIds],
+  )
+
+  const goTo = useCallback(
+    (index: number) => {
+      const id = sectionIds[index]
+      if (!id) return
+      const el = document.getElementById(id)
+      if (!el) return
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    },
+    [sectionIds],
+  )
+
+  const next = useCallback(() => goTo(currentIndex + 1), [currentIndex, goTo])
+  const prev = useCallback(() => goTo(currentIndex - 1), [currentIndex, goTo])
+
+  const reset = useCallback(() => {
+    startRef.current = Date.now()
+    setElapsed(0)
+  }, [])
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    if (!active) return
+    function onKey(e: KeyboardEvent) {
+      // Ignore when typing in inputs
+      const target = e.target as HTMLElement
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
+      if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') {
+        e.preventDefault()
+        next()
+      } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+        e.preventDefault()
+        prev()
+      } else if (e.key === 'n' || e.key === 'N') {
+        setNotesOpen((v) => !v)
+      } else if (e.key === 'r' || e.key === 'R') {
+        reset()
+      } else if (e.key === 'p' || e.key === 'P') {
+        setRunning((v) => !v)
+      } else if (e.key === 'f' || e.key === 'F') {
+        if (!document.fullscreenElement) {
+          document.documentElement.requestFullscreen().catch(() => {})
+        } else {
+          document.exitFullscreen().catch(() => {})
+        }
+      } else if (e.key === 'Escape') {
+        setNotesOpen(false)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, next, prev, reset])
+
+  if (!active) return null
+
+  const note = SPEAKER_NOTES[currentId]
+  const sectionLabel = note?.title ?? currentId
+  const sectionMinutes = note?.minutes
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 pointer-events-none print:hidden">
+      {/* Notes drawer */}
+      {notesOpen && note && (
+        <div className="pointer-events-auto mx-auto max-w-3xl mb-2 px-4">
+          <div className="rounded-2xl border border-white/[0.10] bg-[#0a0a0b]/95 backdrop-blur-xl shadow-2xl shadow-black/60 p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <StickyNote className="w-4 h-4 text-amber-300" />
+                <p className="text-sm font-semibold text-white">{note.title}</p>
+                <span className="text-xs text-zinc-500">· suggested {note.minutes} min</span>
+              </div>
+              <button
+                onClick={() => setNotesOpen(false)}
+                className="text-zinc-500 hover:text-zinc-200"
+                aria-label="Close speaker notes"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <ul className="space-y-1.5">
+              {note.notes.map((n, i) => (
+                <li key={i} className="text-sm text-zinc-300 flex items-start gap-2 leading-relaxed">
+                  <span className="text-amber-300/60 mt-0.5">›</span>
+                  <span>{n}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* HUD */}
+      <div className="pointer-events-auto mx-auto max-w-3xl mb-4 px-4">
+        <div className="rounded-2xl border border-white/[0.10] bg-[#0a0a0b]/90 backdrop-blur-xl shadow-2xl shadow-black/60 px-4 py-2.5 flex items-center gap-3">
+          {/* Section info */}
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <span className="text-[10px] font-medium text-zinc-500 uppercase tracking-wider">
+              {currentIndex + 1}/{sectionIds.length}
+            </span>
+            <span className="text-sm font-medium text-white truncate">{sectionLabel}</span>
+            {sectionMinutes && (
+              <span className="hidden sm:inline text-xs text-zinc-500">· {sectionMinutes}m</span>
+            )}
+          </div>
+
+          {/* Timer */}
+          <div className="flex items-center gap-1.5 text-sm font-mono">
+            <span className={running ? 'text-emerald-300' : 'text-zinc-500'}>
+              {formatTime(elapsed)}
+            </span>
+            <button
+              onClick={() => setRunning((v) => !v)}
+              className="text-zinc-400 hover:text-white"
+              aria-label={running ? 'Pause timer' : 'Start timer'}
+            >
+              {running ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+            </button>
+            <button
+              onClick={reset}
+              className="text-zinc-500 hover:text-white"
+              aria-label="Reset timer"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+            </button>
+          </div>
+
+          {/* Nav */}
+          <div className="flex items-center gap-1">
+            <button
+              onClick={prev}
+              disabled={currentIndex <= 0}
+              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Previous section"
+            >
+              <ChevronUp className="w-4 h-4" />
+            </button>
+            <button
+              onClick={next}
+              disabled={currentIndex >= sectionIds.length - 1}
+              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Next section"
+            >
+              <ChevronDown className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => setNotesOpen((v) => !v)}
+              className={`p-1.5 rounded-md hover:bg-white/[0.06] ${notesOpen ? 'text-amber-300' : 'text-zinc-400 hover:text-white'}`}
+              aria-label="Toggle speaker notes (N)"
+              aria-pressed={notesOpen}
+            >
+              <StickyNote className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => {
+                if (!document.fullscreenElement) {
+                  document.documentElement.requestFullscreen().catch(() => {})
+                } else {
+                  document.exitFullscreen().catch(() => {})
+                }
+              }}
+              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06]"
+              aria-label="Toggle fullscreen (F)"
+            >
+              <Maximize2 className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Keyboard hint */}
+        <p className="hidden sm:block text-center mt-1.5 text-[10px] text-zinc-600">
+          ← → next · N notes · P pause · R reset · F fullscreen
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/data/workshops.ts
+++ b/data/workshops.ts
@@ -19,17 +19,23 @@ export interface Workshop {
   objectives: string[]
   prerequisites: string[]
   modules: WorkshopModule[]
+  /**
+   * When true, the workshop page renders the delivered-format intake form
+   * (`components/workshops/IntakeForm.tsx`) and exposes an #intake anchor.
+   * Omit or set `false` for self-serve / informational workshops.
+   */
+  intakeEnabled?: boolean
 }
 
 export const workshops: Workshop[] = [
   {
     slug: 'ikigai-branding',
     title: 'Ikigai & Branding Workshop',
-    subtitle: 'Find your purpose, then turn it into a brand the world recognizes',
-    duration: '45-75 min',
+    subtitle: 'Find your purpose, turn it into a brand, ship a 30-day content plan',
+    duration: '60-75 min',
     audience: 'Creators, students, professionals reshaping their path',
     difficulty: 'Beginner',
-    moduleCount: 4,
+    moduleCount: 7,
     color: 'violet',
     overview:
       'An interactive, coach-guided workshop. You map your Ikigai through a 4-step wizard (what you love, what you are good at, what the world needs, what pays), synthesize your purpose statement, and immediately translate it into a brand: positioning, audience-of-one, and three content pillars. Pair it with the free Ikigai & Branding Coach GPT for deeper Socratic questioning.',
@@ -77,7 +83,7 @@ export const workshops: Workshop[] = [
           'Positioning = what you are for and what you are not. Force a trade-off. The pillars should be publishable for 12 months straight without repeating yourself. If not, sharpen them.',
         resources: [
           { label: 'Coach GPT (free)', href: '/go/ikigai-coach' },
-          { label: 'Prompt Library: Branding', href: '/prompt-library/marketing' },
+          { label: 'Prompt Library: Branding', href: '/prompt-library?category=create' },
         ],
       },
       {
@@ -177,70 +183,109 @@ export const workshops: Workshop[] = [
   {
     slug: 'build-first-ai-agent',
     title: 'Build Your First AI Agent',
-    subtitle: 'From concept to working prototype in 90 minutes',
+    subtitle: 'One central path in 90 minutes — plus six branches for where you go next',
     duration: '90 min',
-    audience: 'Developers, CS students, technical professionals',
+    audience: 'Developers, CS students, technical professionals, AI-curious builders',
     difficulty: 'Intermediate',
-    moduleCount: 4,
-    color: 'violet',
+    moduleCount: 7,
+    color: 'cyan',
+    intakeEnabled: true,
     overview:
-      'A hands-on technical workshop that takes participants from zero to a working AI agent. Covers the core architecture — tools, memory, and reasoning loops — then builds a functional agent using open-source tooling.',
+      'A hands-on technical workshop. Every participant ships a working AI agent on the Vercel AI SDK — our central path — and leaves with a portable Agent Card (Google A2A) that works across Claude, OpenAI, Google ADK, and no-code stacks. The point is not the framework; the point is the six primitives (model, tool, memory, loop, spec, deploy) that transfer to every agent you will ever build. Six optional branch modules then re-build the same agent on Claude, OpenAI, Google ADK, Oracle ADK, no-code (n8n/Notion/Dify), and AI-builds-AI (Claude Code) stacks.',
     objectives: [
-      'Define the architectural components of an AI agent',
-      'Understand the difference between prompting and agentic workflows',
-      'Build a functional agent with tool use and memory',
-      'Deploy and share an agent prototype',
+      'Name the six primitives of any AI agent — model, tool, memory, loop, spec, deploy',
+      'Ship a working research-assistant agent on the Vercel AI SDK with tool use, memory, and a public URL',
+      'Publish a valid Google A2A Agent Card at /.well-known/agent.json and understand where Oracle Open Agent Specification fits',
+      'Write a 3-case evaluation suite and 2 refusal rails for your agent',
+      'Pick the right branch (Claude / OpenAI / Google ADK / no-code / AI-builds-AI / Oracle) for your next agent based on the transfer matrix',
     ],
     prerequisites: [
-      'Basic programming experience (Python or JavaScript)',
-      'Laptop with Node.js or Python installed',
-      'API key for an LLM provider (OpenAI, Anthropic, or similar)',
+      'Basic JavaScript or TypeScript (Python fine for branches; core is TS)',
+      'Laptop with Node 20+ and pnpm (or npm)',
+      'API key for at least one LLM provider — Anthropic Claude recommended; OpenAI or Google fine',
+      'Optional but recommended: a Vercel account (free tier is plenty) and a GitHub account',
     ],
     modules: [
       {
-        title: 'What Are AI Agents',
-        duration: '15 min',
+        title: 'The hook + the six primitives',
+        duration: '10 min',
         description:
-          'The difference between a chatbot, an assistant, and an agent. Why the agentic paradigm matters. Real-world agent architectures in production.',
+          'A cold open: what actually separates an agent from a chatbot? The reveal — six primitives (model, tool, memory, loop, spec, deploy) that every agent framework is spelling differently. By minute 10, participants have the mental model that will carry every module.',
         instructorNotes:
-          'Start with a comparison: show the same task done via a single prompt vs. an agentic loop. The contrast makes the concept tangible immediately.',
+          'Open by asking the room for 3 definitions of "agent." Reconcile all three with the six primitives on one slide. Keep this under 10 minutes — the hands-on build is the star.',
         resources: [
-          { label: 'Agentic Creator OS', href: '/acos' },
+          { label: 'Agentic Creator OS (mental model)', href: '/acos' },
         ],
       },
       {
-        title: 'Anatomy of an Agent',
-        duration: '25 min',
+        title: 'Models — one SDK, any provider',
+        duration: '10 min',
         description:
-          'Deep dive into the three pillars: tools (what the agent can do), memory (what the agent remembers), and reasoning (how the agent decides). Architecture diagrams and code walkthrough.',
+          'Live demo: a 10-line Vercel AI SDK script that swaps between Claude, GPT, and Gemini by changing one import. Participants type along and swap providers themselves. The portability lesson lands in practice, not in theory.',
         instructorNotes:
-          'Use a whiteboard or slide to draw the agent loop: Observe -> Think -> Act -> Reflect. Map each pillar to a code module participants will build.',
+          'Keep the providers real — use Anthropic as default (best reasoning/$ ratio), then OpenAI and Gemini for the swap. Show cost + capability table while the API calls run.',
         resources: [
-          { label: 'Agentic Creator OS', href: '/acos' },
+          { label: 'Vercel AI SDK docs', href: 'https://sdk.vercel.ai/docs' },
           { label: 'Prompt Library', href: '/prompt-library' },
         ],
       },
       {
-        title: 'Hands-On Build',
-        duration: '35 min',
+        title: 'Tools + structured output',
+        duration: '15 min',
         description:
-          'Build an agent from scratch. Participants implement a simple agent that can search the web, summarize content, and maintain conversation memory. Guided coding with checkpoints.',
+          'Write a typed web_search tool using zod, and a Research structured output schema. Participants learn that a "tool" is just a typed function the agent can call — not magic. The JSON schema becomes the contract that ports across every framework.',
         instructorNotes:
-          'Provide a starter repo with boilerplate already set up. Each checkpoint should produce a working artifact — even if a participant falls behind, they have something functional at each stage.',
+          'Show the schema first, the call site second. Emphasize: "If you can define this tool once in zod, you can call it from Vercel AI SDK, Claude Agent SDK, OpenAI Agents, or Google ADK with near-identical glue."',
         resources: [
-          { label: 'ACOS GitHub Repository', href: 'https://github.com/frankxai/acos' },
           { label: 'Prompt Library', href: '/prompt-library' },
+          { label: 'Starter repo — first-agent-vercel-aisdk', href: 'https://github.com/frankxai/first-agent-vercel-aisdk' },
         ],
       },
       {
-        title: 'Deploy and Share',
+        title: 'The loop + memory — ship the agent',
+        duration: '20 min',
+        description:
+          'Assemble the observe-think-act-reflect loop. Add conversation memory (in-process for workshop, Vercel KV for production). By the end of this module, every participant has a working research-assistant agent. Applause moment.',
+        instructorNotes:
+          'This is the peak of the energy curve. Pair slow participants with fast ones. Keep the demo agent ultra-minimal — a loop around a single tool is enough. Advanced attendees can add a second tool while others catch up.',
+        resources: [
+          { label: 'Starter repo — first-agent-vercel-aisdk', href: 'https://github.com/frankxai/first-agent-vercel-aisdk' },
+        ],
+      },
+      {
+        title: 'Safety rails + evaluation',
+        duration: '10 min',
+        description:
+          'Three eval cases (success, edge case, refusal) and two refusal patterns. Show how to read a trace. Discussion: what does "correct" mean for an LLM? This module is short on purpose — the professor track goes deeper.',
+        instructorNotes:
+          'Use a pre-baked eval harness from the starter repo. The teaching point is the discipline of writing tests for non-deterministic systems, not any specific framework.',
+        resources: [
+          { label: 'Eval harness (starter repo)', href: 'https://github.com/frankxai/first-agent-vercel-aisdk' },
+        ],
+      },
+      {
+        title: 'Agent Card — the portability contract',
         duration: '15 min',
         description:
-          'Deploy the agent to a shareable endpoint. Discussion on production considerations: rate limiting, cost management, safety guardrails.',
+          'Draft a Google A2A Agent Card describing your agent. Validate it. Serve it at /.well-known/agent.json. Ninety seconds on Oracle Open Agent Specification (OAS) for those going enterprise. By the end, your agent has an identity other agents can discover.',
         instructorNotes:
-          'Use Vercel or Replit for quick deployment. End with a gallery walk where participants demo their agents to each other.',
+          'The Agent Card is the artifact that makes the portability lesson concrete. Have a pre-baked template in the starter repo; participants fill fields rather than writing JSON from scratch. Mention BCG\'s enterprise agent playbook uses the same A2A spec — the concept is industry standard, not a toy.',
         resources: [
-          { label: 'Agentic Creator OS', href: '/acos' },
+          { label: 'Google A2A Agent Card spec', href: 'https://a2a-protocol.org/' },
+          { label: 'Oracle Open Agent Specification', href: '/ai-architecture' },
+        ],
+      },
+      {
+        title: 'Deploy + share + pick your next branch',
+        duration: '10 min',
+        description:
+          'vercel --prod. Your agent is public. URLs fly into the group chat. Then a brief look at the six branch modules (Claude, OpenAI, Google ADK, no-code, AI-builds-AI, Oracle) so participants know where to go next. The closing ask: paste your Agent Card URL before you close the laptop.',
+        instructorNotes:
+          'Protect the last 5 minutes for branch sign-ups — this is where the next-session pipeline is built. Do not let Q&A eat the close. Collect URLs in chat for the gallery. Remind participants that /partners exists and affiliate revenue supports the free materials.',
+        resources: [
+          { label: 'Vercel deploy docs', href: 'https://vercel.com/docs' },
+          { label: 'Workshop gallery (coming soon)', href: '/workshops/build-first-ai-agent' },
+          { label: 'Educator / professor track', href: '/workshops/for-educators' },
         ],
       },
     ],
@@ -314,6 +359,324 @@ export const workshops: Workshop[] = [
         ],
       },
     ],
+  },
+  {
+    slug: 'ikigai-content-studio',
+    title: 'Ikigai + AI Content Studio',
+    subtitle:
+      'Find your purpose, then ship your first AI-augmented brand asset in the same session',
+    duration: '3–4 hours',
+    audience: 'Creators, knowledge workers, and operators rebuilding their public presence',
+    difficulty: 'Beginner',
+    moduleCount: 5,
+    color: 'violet',
+    intakeEnabled: true,
+    overview:
+      'A facilitator-led workshop that picks up where the self-serve /workshops/ikigai-branding wizard stops. Attendees map their Ikigai with evidence-backed inputs, distill a two-line purpose statement, translate it into brand positioning plus three content pillars, then use AI tools (ChatGPT, Claude, Suno, Nano Banana) to ship their first visible artifact before leaving the room. Everyone leaves with a 30-day publishing cadence and momentum.',
+    objectives: [
+      'Map your Ikigai with evidence-backed inputs, not vague feelings',
+      'Write a 2-line purpose statement plus a positioning sentence on a single page',
+      'Build an AI-augmented content workflow that fits your real schedule',
+      'Ship one visible artifact (post, short, track, or page) before the session ends',
+      'Leave with a 30-day publishing cadence and a Day-7 check-in',
+    ],
+    prerequisites: [
+      'Laptop, headphones optional',
+      'Free ChatGPT or Claude account',
+      '3–4 hours of focused attention',
+      'Willingness to publish something before leaving the room',
+    ],
+    modules: [
+      {
+        title: 'Ikigai Deep Map',
+        duration: '40 min',
+        description:
+          'Work through the four circles of Ikigai with Socratic prompts and evidence prompts. Specific moments, real skills others named, actual markets you have been paid from. Vague inputs produce vague outputs, so we push for precision.',
+        instructorNotes:
+          'Time-box each circle to 8 minutes. If a participant stalls, pair them with the Coach GPT for 3 minutes, then pull them back. The deliverable is four sharpened paragraphs, not a polished essay.',
+        resources: [
+          { label: 'Self-serve Ikigai Wizard', href: '/workshops/ikigai-branding' },
+          { label: 'Coach GPT (free)', href: '/go/ikigai-coach' },
+        ],
+      },
+      {
+        title: 'Purpose → Positioning Bridge',
+        duration: '30 min',
+        description:
+          'Distill the four circles into one purpose sentence, then translate it into a positioning sentence with a forced trade-off (what you are for, what you are not). Name a precise audience-of-one and three content pillars that can run for twelve months without repetition.',
+        instructorNotes:
+          'The fastest improvement is naming the audience precisely. "Early-career data analysts at mid-sized SaaS companies" beats "professionals". Force every participant to replace any adjective a competitor could also use.',
+        resources: [
+          { label: 'Prompt Library: Branding', href: '/prompt-library?category=create' },
+        ],
+      },
+      {
+        title: 'AI Content Studio Setup',
+        duration: '40 min',
+        description:
+          'Hands-on session where attendees configure their content stack: one writing assistant (Claude or ChatGPT), one visual tool (Nano Banana or equivalent), one audio tool (Suno if relevant), and one publishing surface. We set up reusable prompt templates tied to the three pillars.',
+        instructorNotes:
+          'Walk the room. Most friction happens at authentication and API key setup, not at prompting. Have backup accounts ready. Demonstrate a full pillar-prompt template with one attendee on-screen before turning the room loose.',
+        resources: [
+          { label: 'Prompt Library', href: '/prompt-library' },
+          { label: 'GenCreator Principles', href: '/gencreator/principles' },
+        ],
+      },
+      {
+        title: 'Ship Your First Artifact',
+        duration: '60 min',
+        description:
+          'Every attendee produces and publishes one artifact: a LinkedIn post, a short-form video, a Suno track, a landing page draft, or a newsletter. We iterate in three passes: rough, sharpened, shipped. Publication happens in-room.',
+        instructorNotes:
+          'Resist the urge to coach toward perfection. Two weeks of visible output teaches more than two months of planning. Track completion on the whiteboard — peer momentum is the lever. Celebrate publishes out loud.',
+        resources: [
+          { label: 'GenCreator Principles', href: '/gencreator/principles' },
+          { label: 'Creator Economy Guide', href: '/for/creators' },
+        ],
+      },
+      {
+        title: '30-Day Cadence + Amplification',
+        duration: '30 min',
+        description:
+          'Commit to a 30-day publishing cadence with four artifacts per week across the three pillars. Subscribe to the Resource Pack for templates, a Day-7 check-in, and an amplification loop where Frank reposts the strongest attendee work.',
+        instructorNotes:
+          'End with a commitment round: each attendee says out loud what they will ship in the next seven days. Public commitment doubles follow-through. Collect links so amplification can start within 48 hours.',
+        resources: [
+          { label: 'Coach GPT (free)', href: '/go/ikigai-coach' },
+          { label: 'Creator Economy Guide', href: '/for/creators' },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'sovereign-leadership',
+    title: 'Sovereign Leadership: Human-Centric AI',
+    subtitle: 'AI leadership as a sovereignty practice, not a technology decision',
+    duration: '2 hours',
+    audience: 'Senior executives, board members, and founders deciding how AI fits their company',
+    difficulty: 'Intermediate',
+    moduleCount: 4,
+    color: 'cyan',
+    intakeEnabled: true,
+    overview:
+      'A boardroom-format workshop for leaders who are tired of outsourcing AI strategy to vendors and frameworks they did not choose. The session adapts the 6-pillar AI Center of Excellence framework Frank builds for Fortune 500 clients at Oracle (Strategy, Governance, Talent, Technology, Data, Ethics) to the attendee’s actual company. Every participant leaves having identified one AI decision they have been over-delegating and committing to re-own it this quarter.',
+    objectives: [
+      'Distinguish AI decisions you should own, delegate, or avoid entirely',
+      'Apply the 6-Pillar AI CoE framework (Strategy, Governance, Talent, Technology, Data, Ethics) to your real context',
+      'Complete a Personal AI Sovereignty Assessment',
+      'Commit to one specific re-ownership move this quarter',
+    ],
+    prerequisites: [
+      'Decision-making authority in your organization',
+      '2 hours of focused, uninterrupted attention',
+      'Willingness to name real trade-offs out loud — this is a working session, not a briefing',
+    ],
+    modules: [
+      {
+        title: 'What AI Leadership Actually Is',
+        duration: '20 min',
+        description:
+          'The difference between AI sponsorship, AI delegation, and AI sovereignty. Why the third matters most. Patterns from Fortune 500 deployments where leaders over-delegated the framing decisions and lived with the consequences.',
+        instructorNotes:
+          'Open with two short, anonymized case studies — one where a CEO owned the framing, one where it was outsourced to a vendor. Contrast the 18-month outcomes. Keep it concrete and operational, never philosophical.',
+        resources: [
+          { label: 'ACOS — the personal CoE', href: '/acos' },
+          { label: 'For Founders', href: '/for/founders' },
+        ],
+      },
+      {
+        title: 'The 6-Pillar CoE Framework',
+        duration: '25 min',
+        description:
+          'Walk through each pillar as it operates in a real enterprise AI CoE: Strategy (what we will and will not do with AI), Governance (who decides), Talent (capability build vs. buy), Technology (stack choices), Data (rights and leverage), Ethics (tested, not declared). Each pillar includes one board-level question the leader must own.',
+        instructorNotes:
+          'Draw the 6 pillars as a single diagram on the whiteboard. Ask each attendee to mark which pillar they currently own, which they delegate, and which they avoid. Silence on a pillar is a signal — probe it.',
+        resources: [
+          { label: 'ACOS — the personal CoE', href: '/acos' },
+        ],
+      },
+      {
+        title: 'Personal AI Sovereignty Assessment',
+        duration: '20 min',
+        description:
+          'Hands-on. Each leader scores their current sovereignty across the 6 pillars on a 1–5 scale and identifies the lowest-scoring pillar. The assessment is private; only the commitment is shared. Output: one named gap plus a one-line remedy.',
+        instructorNotes:
+          'Keep scoring private. Loudly name the lowest score in the room only with permission. The point is self-honesty, not peer comparison. Have printed assessment cards ready — paper outperforms a laptop here.',
+        resources: [
+          { label: 'For Founders', href: '/for/founders' },
+        ],
+      },
+      {
+        title: 'The First Move — Commitment Round',
+        duration: '15 min',
+        description:
+          'Each attendee names one specific AI decision they will re-own this quarter, with a date and a named owner (usually themselves). Q&A is built into this module; the commitment is the output. Frank follows up at 30 days.',
+        instructorNotes:
+          'Public commitment doubles follow-through. Write every commitment on a shared flipchart. Note the dates. Send a templated 30-day check-in email the day after the workshop with the commitments attached.',
+        resources: [
+          { label: 'ACOS — the personal CoE', href: '/acos' },
+          { label: 'For Founders', href: '/for/founders' },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'personal-ai-coe',
+    title: 'Build Your Personal AI Center of Excellence',
+    subtitle:
+      'The enterprise CoE framework, scaled to one person. Leave with your AI operating system running.',
+    duration: '90 minutes',
+    audience: 'Operators, creators, and technical professionals building a personal AI stack',
+    difficulty: 'Intermediate',
+    moduleCount: 4,
+    color: 'amber',
+    intakeEnabled: true,
+    overview:
+      'A hands-on 90-minute workshop that treats the participant as a 1-person Fortune 500. Frank walks through how he builds AI Centers of Excellence for Oracle enterprise clients — six pillars, roughly €500k typical budget, 6–12 month rollout — then shows the mirror-image personal version: same architecture, 1/5000th the cost. By end of session, every attendee has a working personal AI CoE: a strategy doc, a tool policy, a prompt library, a memory system, and a weekly review cadence.',
+    objectives: [
+      'Understand the 6-pillar enterprise CoE Frank ships to Oracle clients',
+      'Map each pillar to a personal equivalent without losing the architecture',
+      'Deploy a working Personal AI CoE one-pager and tool stack during the session',
+      'Leave with a weekly review cadence and the CLI and config that support it',
+    ],
+    prerequisites: [
+      'Laptop with a working terminal',
+      'Comfort with the command line or willingness to learn in real time',
+      'Free Claude account or ChatGPT Plus subscription',
+    ],
+    modules: [
+      {
+        title: 'The Enterprise CoE',
+        duration: '20 min',
+        description:
+          'How an enterprise AI Center of Excellence actually works: the 6 pillars, the typical budget, the common failure modes. A short, grounded tour of what Frank ships at Oracle before we mirror it at personal scale.',
+        instructorNotes:
+          'Show one real (anonymized) CoE deliverable on screen — a pillar scorecard or a governance brief. Seeing the artifact collapses the abstraction. Skip slide-heavy storytelling; the personal build needs the time.',
+        resources: [
+          { label: 'ACOS — the personal CoE', href: '/acos' },
+        ],
+      },
+      {
+        title: 'The Personal Mirror',
+        duration: '15 min',
+        description:
+          'Map each of the 6 pillars to a personal equivalent. Enterprise Strategy becomes your AI charter. Enterprise Governance becomes your tool policy. Enterprise Talent becomes your skill-build plan. The architecture holds; the scale changes.',
+        instructorNotes:
+          'Use the same diagram you drew for the enterprise CoE, then redraw it at personal scale side-by-side. The visual parallel is the teaching point. Reuse the participant\'s real context — their actual role, their actual tools.',
+        resources: [
+          { label: 'Prompt Library', href: '/prompt-library' },
+        ],
+      },
+      {
+        title: 'Hands-on Build',
+        duration: '40 min',
+        description:
+          'Real deployment. Each attendee builds their one-pager charter, installs a starter tool policy, configures a prompt library, and stands up a minimal memory system (a markdown file plus a convention). Guided checkpoints every ten minutes.',
+        instructorNotes:
+          'Walk the room continuously. The first ten minutes always surface environment issues — have backup cloud setups ready. Aim for every attendee to hit each checkpoint, even if imperfect. Working beats polished.',
+        resources: [
+          { label: 'ACOS — the personal CoE', href: '/acos' },
+          { label: 'Prompt Library', href: '/prompt-library' },
+        ],
+      },
+      {
+        title: 'Operating Cadence',
+        duration: '15 min',
+        description:
+          'The weekly 20-minute review that keeps the Personal AI CoE alive: what I shipped, what I learned, what to sharpen. Each attendee schedules the first review before leaving and writes the recurring calendar block in-room.',
+        instructorNotes:
+          'The review is the whole game. Without a cadence, the CoE decays in two weeks. Make the calendar block concrete and recurring, same day, same time. Share Frank\'s own review template as a starting point.',
+        resources: [
+          { label: 'ACOS — the personal CoE', href: '/acos' },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'build-hackathon',
+    title: 'Build Hackathon: Ship an AI Agent in 4 Hours',
+    subtitle: 'Half-day hackathon where every team leaves with a working AI agent shipped to the web',
+    duration: '4 hours',
+    audience: 'Mixed teams of 3-5: builders, operators, and domain experts',
+    difficulty: 'Intermediate',
+    moduleCount: 5,
+    color: 'cyan',
+    overview:
+      'A half-day hackathon format. Teams of 3-5 take one real problem from their work, decompose it into an agentic workflow, build with Claude Code (or a comparable agent CLI), and ship a working prototype to a live URL. The facilitator role shifts from teacher to co-pilot — Frank pairs with each team during the build, unblocks blockers, and pushes for shipped-over-polished. By the close, every team has a live link they can share.',
+    objectives: [
+      'Pick one real problem from the team\'s work that AI can materially help with',
+      'Decompose it into agent tools + memory + reasoning in a shared whiteboard',
+      'Build a functional prototype with Claude Code or equivalent',
+      'Deploy to a live URL (Vercel preview, Cloudflare Pages, or Railway)',
+      'Demo in a 4-minute slot to the room with a working link',
+    ],
+    prerequisites: [
+      'Each team has one real problem to attack — bring a real use case, not a toy',
+      'Laptop with Node.js 18+ and a git account',
+      'API keys or cloud credits for at least one LLM (Claude, OpenAI, or Gemini)',
+      'Comfort with terminal OR willingness to pair with a team member who is',
+    ],
+    modules: [
+      {
+        title: 'Problem decomposition (60 min)',
+        duration: '60 min',
+        description:
+          'Teams map their problem into the agent primitives: what tools does the agent need, what memory does it keep, what reasoning loop does it run. Facilitator circulates with the 6-pillar CoE framework as a quick sanity check on governance and data.',
+        instructorNotes:
+          'The hardest part is picking ONE problem narrow enough to ship in 3 hours. Push teams to cut scope aggressively — "solve for a single user in a single context" beats "build a platform." Use the whiteboard template: Tools | Memory | Loop | Output.',
+        resources: [
+          { label: 'Personal AI CoE framework', href: '/workshops/personal-ai-coe' },
+          { label: 'ACOS agent patterns', href: '/acos' },
+        ],
+      },
+      {
+        title: 'Stack kickoff (30 min)',
+        duration: '30 min',
+        description:
+          'Each team scaffolds with Claude Code or equivalent, chooses deployment target, and sets up their LLM keys. Facilitator drops in for any team stuck on setup — usually auth or API keys.',
+        instructorNotes:
+          'Provide a starter repo that handles the deploy plumbing (Vercel + Claude Code template). Teams that insist on from-scratch setup usually burn 45 min before they realize they should have used the template. Enforce the template for all teams.',
+        resources: [
+          { label: 'workshop-os public starter', href: 'https://github.com/frankxai/workshop-os' },
+          { label: 'Claude Code docs', href: 'https://docs.claude.com/en/docs/claude-code' },
+        ],
+      },
+      {
+        title: 'Build sprint (120 min)',
+        duration: '120 min',
+        description:
+          'Heads-down. Teams build. Facilitator floats between teams, unblocks on demand, pushes against perfectionism. Mid-sprint checkpoint at 60 min — each team shows a working seam, not a finished product.',
+        instructorNotes:
+          'The mid-sprint checkpoint is the single most important moment. Teams that can\'t show a working seam by 60 min are over-engineering — intervene and push to mock whatever isn\'t working. Done beats perfect by a mile here.',
+        resources: [
+          { label: 'Prompt library', href: '/prompt-library' },
+          { label: 'Agentic orchestration patterns', href: '/acos' },
+        ],
+      },
+      {
+        title: 'Ship + document (30 min)',
+        duration: '30 min',
+        description:
+          'Each team deploys to a live URL and writes a 5-line README describing the problem, the approach, and the live link. Shipping discipline — if it\'s not deployed, it doesn\'t count.',
+        instructorNotes:
+          'Have a Vercel team already set up so teams can invite their builders in a click. Enforce the 5-line README — teams that skip it during the hackathon skip it forever. The README is the amplification artifact.',
+        resources: [
+          { label: 'Vercel quick deploy', href: 'https://vercel.com/templates' },
+        ],
+      },
+      {
+        title: 'Demos + amplification (40 min)',
+        duration: '40 min',
+        description:
+          '4 minutes per team. Show the problem, the live link, the one thing that surprised you. Audience votes on most-shippable prototype. Winning team gets a dedicated post on Frank\'s channels amplifying their build.',
+        instructorNotes:
+          'The amplification prize is the real carrot. Sponsors of the event often love this because a winning team posts a "we built X at Frank Riemer\'s hackathon with Company Y" — that\'s the sponsor\'s ROI. Be generous with reposts for every team that shipped, not just the winner.',
+        resources: [
+          { label: 'Crosspost checklist', href: '/workshops' },
+        ],
+      },
+    ],
+    intakeEnabled: true,
   },
 ]
 


### PR DESCRIPTION
## Summary
Doubles the Ikigai & Branding workshop from a 4-module marketing page into a full delivery system, backing Frank's NL Digital (2026-05-19) and Madrid (2026-05-27) workshop deliveries.

- **New route** `/workshops/ikigai-branding/present` — 14-slide fullscreen deck with keyboard nav (← → N P R F 0-9), speaker notes drawer per slide, timer, progress dots, print-to-PDF
- **3 new modules** on the main page — Content Operating Plan (LinkedIn Top Voice playbook + 3·2·1·1 weekly rhythm + 30-day calendar from wizard pillars + CSV download), GenCreator Stack (20 tools across Capture/Think/Make/Ship/Measure), Live Artifact slot (Loom embed for Claude Cowork demo)
- **On-page presenter HUD** — activated via `?present=1` or hero toggle, IntersectionObserver tracks section-in-view, speaker notes per section
- **Course JSON-LD** updated: timeRequired PT55M → PT75M, modules 4 → 7

## Files
8 files, +2079 / -19. See commit `327e6579` for the full diff.

## Test plan
- [ ] Vercel preview URL renders `/workshops/ikigai-branding` with 7 modules + presenter buttons in hero
- [ ] `/workshops/ikigai-branding/present` loads, keyboard nav works (← → between slides)
- [ ] `?present=1` on main page shows on-page HUD with timer + section tracker
- [ ] Frank's trial-run via Loom catches any wording / pacing issues

## Followups (after this merges)
- Wire real Notion + Google Sheet template hrefs (placeholder hrefs ship now under `/go/ikigai-notion-template` + `/go/ikigai-sheet-template`)
- Frank records the 90s Claude Cowork demo, populate `LiveArtifact` `embedUrl`
- Playwright E2E once MCP picks up on next Claude Code session restart

🤖 Source: `frankxai/FrankX/feature/ikigai-presenter-and-modules` commit `1ba141ef`