### PR TITLE
feat(workshops/ikigai): upgrade #2 — fullscreen UX + speaker view + authority + AI companions

### DIFF
--- a/app/workshops/ikigai-branding/page.tsx
+++ b/app/workshops/ikigai-branding/page.tsx
@@ -26,8 +26,15 @@ import { ContentOperatingPlan } from '@/components/workshops/ikigai/ContentOpera
 import { GenCreatorStack } from '@/components/workshops/ikigai/GenCreatorStack'
 import { LiveArtifact } from '@/components/workshops/ikigai/LiveArtifact'
 import { PresenterOverlay } from '@/components/workshops/ikigai/PresenterOverlay'
+import { AuthorityBar } from '@/components/workshops/ikigai/AuthorityBar'
+import { AICompanions } from '@/components/workshops/ikigai/AICompanions'
 import { emptyIkigai, type IkigaiState } from '@/components/workshops/ikigai/types'
 import { getWorkshopBySlug } from '@/data/workshops'
+import { MODULE_4_CITATIONS, MODULE_5_CITATIONS } from '@/lib/workshop-citations'
+
+// Update this when Frank records the Claude Cowork demo. When empty, the
+// Module 6 section is hidden entirely (no empty placeholder on a public page).
+const LIVE_ARTIFACT_URL = ''
 
 const PRESENTER_SECTIONS = [
   'intro',
@@ -37,7 +44,7 @@ const PRESENTER_SECTIONS = [
   'brand-bridge',
   'content-plan',
   'gencreator-stack',
-  'live-artifact',
+  // 'live-artifact' is hidden until LIVE_ARTIFACT_URL is populated
   'activation',
 ]
 
@@ -357,47 +364,58 @@ export default function IkigaiBrandingWorkshopPage() {
               and the calendar so blank-page mornings end. Anchored to your three pillars from Module 3.
             </p>
           </div>
+          <div className="mb-5">
+            <AuthorityBar citations={MODULE_4_CITATIONS} label="Why this module matters" />
+          </div>
           <ContentOperatingPlan value={ikigai} />
         </div>
       </section>
 
-      {/* Module 5: GenCreator Stack — NEW */}
+      {/* Module 5: GenCreator Stack + AI Companions */}
       <section id="gencreator-stack" className="pb-12 scroll-mt-24">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-sky-300 mb-2">
-              Module 5 · The GenCreator Stack
+              Module 5 · The Operating Stack
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
-              Five jobs. Five tools. One creator hub.
+              Your AI companion. Then the 5-job stack.
             </h2>
             <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
-              The opinionated short-list of MCPs, extensions, and apps that compound your craft
-              instead of fragmenting your attention. Build the hub once; ship for years.
+              Two layers. First the AI brain you actually think with. Then the four other jobs you run
+              every week. Opinionated, picked from the field, built to compound — not sprawl.
             </p>
+          </div>
+          <div className="mb-6">
+            <AuthorityBar citations={MODULE_5_CITATIONS} label="Why this stack now" />
+          </div>
+          <div className="mb-8">
+            <AICompanions />
           </div>
           <GenCreatorStack />
         </div>
       </section>
 
-      {/* Module 6: Live Artifact — NEW */}
-      <section id="live-artifact" className="pb-12 scroll-mt-24">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mb-6">
-            <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2">
-              Module 6 · The Artifact
-            </p>
-            <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
-              AI-assisted. Voice-preserved.
-            </h2>
-            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
-              The whole workshop in one demo. Watch a LinkedIn post get written — with rejections, redirects,
-              and the prompt scaffold you can keep.
-            </p>
+      {/* Module 6: Live Artifact — gated until Frank records */}
+      {LIVE_ARTIFACT_URL && (
+        <section id="live-artifact" className="pb-12 scroll-mt-24">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="mb-6">
+              <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2">
+                Module 6 · The Artifact
+              </p>
+              <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
+                AI-assisted. Voice-preserved.
+              </h2>
+              <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+                The whole workshop in one demo. Watch a LinkedIn post get written — with rejections, redirects,
+                and the prompt scaffold you can keep.
+              </p>
+            </div>
+            <LiveArtifact embedUrl={LIVE_ARTIFACT_URL} />
           </div>
-          <LiveArtifact />
-        </div>
-      </section>
+        </section>
+      )}
 
       {/* Module 7: Activation + Email capture (was Module 4) */}
       <section id="activation" className="pb-24 scroll-mt-24">

--- a/app/workshops/ikigai-branding/present/page.tsx
+++ b/app/workshops/ikigai-branding/present/page.tsx
@@ -2,45 +2,21 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import Image from 'next/image'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   ArrowLeft,
   ArrowRight,
   Maximize2,
+  Minimize2,
   StickyNote,
   X,
-  Compass,
-  Sparkles,
-  Target,
-  UserCircle,
-  Layers3,
-  TrendingUp,
-  Calendar,
-  Wand2,
-  Send,
-  Brain,
-  Mic,
-  BarChart3,
   Play,
-  Rocket,
-  Mail,
   Pause,
   RotateCcw,
+  MonitorSmartphone,
 } from 'lucide-react'
-
-// ---- Slide data ---------------------------------------------------------
-
-interface SlideDef {
-  id: string
-  eyebrow: string
-  title: string
-  module?: string
-  minutes: number
-  color: 'violet' | 'amber' | 'emerald' | 'sky' | 'rose'
-  speakerNotes: string[]
-  body: () => React.ReactNode
-}
+import { SLIDES } from './slides'
+import { useDeckSync } from './use-deck-sync'
 
 function pad(n: number): string {
   return n < 10 ? `0${n}` : `${n}`
@@ -54,492 +30,27 @@ function formatTime(ms: number): string {
   return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`
 }
 
-const SLIDES: SlideDef[] = [
-  // 0 — Cover
-  {
-    id: 'cover',
-    eyebrow: 'A 75-minute workshop',
-    title: 'Ikigai & Branding',
-    minutes: 1,
-    color: 'violet',
-    speakerNotes: [
-      'Open with: "Today you leave with a purpose statement and a 30-day plan. Not a feeling."',
-      'Set tone: practical, generous, no fluff. Phones face down for the wizard sections.',
-    ],
-    body: () => (
-      <div className="text-center space-y-8">
-        <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border border-violet-500/20 bg-violet-500/[0.06] text-xs font-medium text-violet-300 uppercase tracking-wider">
-          <Compass className="w-3 h-3" />
-          A 75-minute workshop
-        </div>
-        <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tight">
-          <span className="text-white">Ikigai </span>
-          <span className="text-zinc-500">&amp;</span>
-          <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-amber-400"> Branding</span>
-        </h1>
-        <p className="text-xl text-zinc-400 max-w-2xl mx-auto leading-relaxed">
-          Find what makes time disappear. Translate it into a brand the world remembers.
-        </p>
-        <div className="text-sm text-zinc-600 pt-12">
-          frankx.ai · Frank Riemer · AI Architect
-        </div>
-      </div>
-    ),
-  },
-  // 1 — Outcomes
-  {
-    id: 'outcomes',
-    eyebrow: 'The promise',
-    title: 'What you walk out with',
-    minutes: 4,
-    color: 'amber',
-    speakerNotes: [
-      'Read the four bullets aloud. Pause after each.',
-      'Frame: "If you write all four down today, the next 30 days plan themselves."',
-    ],
-    body: () => (
-      <div className="grid sm:grid-cols-2 gap-4">
-        {[
-          { title: 'A purpose statement', sub: 'Two lines. Fits on a business card.', icon: Compass, color: 'violet' },
-          { title: 'A brand positioning', sub: 'Positioning sentence + audience-of-one + 3 content pillars.', icon: Target, color: 'amber' },
-          { title: 'A 30-day content plan', sub: 'Calendar generated from your pillars. CSV + Notion + Sheet.', icon: Calendar, color: 'emerald' },
-          { title: 'The GenCreator Stack', sub: 'Five tools across Capture · Think · Make · Ship · Measure.', icon: Wand2, color: 'sky' },
-        ].map((o) => {
-          const Icon = o.icon
-          return (
-            <div key={o.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 flex gap-4">
-              <div className="w-10 h-10 rounded-lg bg-violet-500/10 border border-violet-500/20 flex items-center justify-center flex-shrink-0">
-                <Icon className="w-5 h-5 text-violet-300" />
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-white mb-1">{o.title}</h3>
-                <p className="text-sm text-zinc-400">{o.sub}</p>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    ),
-  },
-  // 2 — 3Cs
-  {
-    id: '3cs',
-    eyebrow: 'Framework',
-    title: 'The 3Cs — Skills that compound with AI',
-    minutes: 6,
-    color: 'sky',
-    speakerNotes: [
-      'Ikigai = WHAT to build. 3Cs = HOW to build it without getting automated around.',
-      'Collaboration = pair with AI (PAIR · PACE). Communication = make outputs land (BLUF · SCQA). Creation = ship small.',
-    ],
-    body: () => (
-      <div className="grid md:grid-cols-3 gap-4">
-        {[
-          { title: 'Collaboration', items: ['PACE: Plan → Act → Check → Evolve', 'PAIR with AI: Plan · Ask · Iterate · Review', 'Iteration speed + decision clarity'], color: 'violet' },
-          { title: 'Communication', items: ['BLUF and SCQA frameworks', 'Design docs + demo scripts', 'Clear, reproducible outputs'], color: 'amber' },
-          { title: 'Creation', items: ['Goldilocks scope', 'Build → measure → learn', "Ship small. Show, don't tell."], color: 'emerald' },
-        ].map((c) => (
-          <div key={c.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
-            <h3 className="text-xl font-semibold text-white mb-4">{c.title}</h3>
-            <ul className="space-y-3">
-              {c.items.map((i, idx) => (
-                <li key={idx} className="text-sm text-zinc-400 flex items-start gap-2 leading-relaxed">
-                  <span className="text-zinc-600">—</span>
-                  <span>{i}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
-    ),
-  },
-  // 3 — Module 1 intro
-  {
-    id: 'module-1-intro',
-    eyebrow: 'Module 1 · 15 min',
-    title: 'Map your four circles',
-    module: 'Module 1',
-    minutes: 3,
-    color: 'violet',
-    speakerNotes: [
-      'Four circles: love · good · needs · pays.',
-      'External evidence beats internal guessing. Other people\'s words, not yours.',
-    ],
-    body: () => (
-      <div className="relative max-w-3xl mx-auto">
-        <Image
-          src="/images/workshops/ikigai-branding/ikigai-venn.jpg"
-          alt="Ikigai Venn diagram"
-          width={1920}
-          height={960}
-          priority
-          className="w-full h-auto rounded-3xl border border-white/[0.06]"
-        />
-      </div>
-    ),
-  },
-  // 4 — Module 1 deep
-  {
-    id: 'module-1-deep',
-    eyebrow: 'Module 1',
-    title: 'Four questions. Specific answers.',
-    module: 'Module 1',
-    minutes: 12,
-    color: 'violet',
-    speakerNotes: [
-      'Run the wizard live. 3 min per circle. Use Coach GPT deep-links if a participant stalls.',
-      'Push past generic. "Specificity beats volume."',
-    ],
-    body: () => (
-      <div className="grid sm:grid-cols-2 gap-4">
-        {[
-          { label: 'What I love', q: 'What activities make time disappear for you?', hint: 'Name specific moments from the last 12 months.' },
-          { label: "What I'm good at", q: 'What do people keep thanking you for?', hint: "External evidence only. Other people's words." },
-          { label: 'What the world needs', q: 'Whose problem do you care about for ten years?', hint: 'The narrower the "who", the stronger the answer.' },
-          { label: 'What pays', q: 'What are people already paying for in this space?', hint: 'Real invoices. Real courses. Follow the money.' },
-        ].map((c) => (
-          <div key={c.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
-            <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">{c.label}</p>
-            <p className="text-lg font-semibold text-white mb-2 leading-snug">{c.q}</p>
-            <p className="text-xs text-zinc-500">{c.hint}</p>
-          </div>
-        ))}
-      </div>
-    ),
-  },
-  // 5 — Module 2
-  {
-    id: 'module-2',
-    eyebrow: 'Module 2 · 10 min',
-    title: 'Write the sentence',
-    module: 'Module 2',
-    minutes: 10,
-    color: 'amber',
-    speakerNotes: [
-      'Two to three lines. Fits on a business card.',
-      'Quality test: if a competitor could say the same sentence verbatim, sharpen it.',
-    ],
-    body: () => (
-      <div className="space-y-6">
-        <div className="rounded-3xl border border-amber-500/20 bg-gradient-to-br from-amber-500/[0.06] to-violet-500/[0.04] p-8">
-          <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-3">The template</p>
-          <p className="text-2xl sm:text-3xl text-white leading-relaxed font-medium tracking-tight">
-            I help <span className="text-amber-300">[who]</span> achieve <span className="text-emerald-300">[outcome]</span>
-            <br />by <span className="text-violet-300">[how]</span>, using <span className="text-sky-300">[skills]</span> in <span className="text-rose-300">[domain]</span>.
-          </p>
-        </div>
-        <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
-          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500 mb-2">Worked example</p>
-          <p className="text-base text-zinc-300 leading-relaxed italic">
-            "I help early-career analysts turn messy spreadsheets into decisions,
-            by pairing them with AI workflows, using ten years of consulting craft, in finance and operations teams."
-          </p>
-        </div>
-      </div>
-    ),
-  },
-  // 6 — Module 3 Brand Bridge
-  {
-    id: 'module-3',
-    eyebrow: 'Module 3 · 10 min',
-    title: 'The Brand Bridge',
-    module: 'Module 3',
-    minutes: 10,
-    color: 'amber',
-    speakerNotes: [
-      'Three exercises. Each anchored to the Module 2 statement.',
-      'Audience-of-One is the hardest. Force a single real-feeling name.',
-    ],
-    body: () => (
-      <div className="grid md:grid-cols-3 gap-4">
-        {[
-          { icon: Target, title: 'Positioning Sentence', sub: 'Force a trade-off. Who you are NOT for.' },
-          { icon: UserCircle, title: 'Audience of One', sub: 'A single name. A specific situation. This week\'s problem.' },
-          { icon: Layers3, title: 'Three Content Pillars', sub: '12 months of posts without repeating.' },
-        ].map((b) => {
-          const Icon = b.icon
-          return (
-            <div key={b.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
-              <div className="w-12 h-12 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mb-4">
-                <Icon className="w-6 h-6 text-violet-300" />
-              </div>
-              <h3 className="text-lg font-semibold text-white mb-2">{b.title}</h3>
-              <p className="text-sm text-zinc-400 leading-relaxed">{b.sub}</p>
-            </div>
-          )
-        })}
-      </div>
-    ),
-  },
-  // 7 — Module 4 hooks
-  {
-    id: 'module-4-hooks',
-    eyebrow: 'Module 4 · LinkedIn Top Voice',
-    title: 'Five hook formats',
-    module: 'Module 4',
-    minutes: 5,
-    color: 'emerald',
-    speakerNotes: [
-      'Pattern over creativity. Rotate the five so you never stare at a blank page.',
-      'Have them pick ONE format and draft a real hook for their pillar live.',
-    ],
-    body: () => (
-      <div className="grid sm:grid-cols-2 gap-3 text-sm">
-        {[
-          { name: 'Contrarian Take', pattern: 'Everyone says X. I think the opposite — and here is why.' },
-          { name: 'Story Open', pattern: 'Last [time], [vivid moment]. Here is what it taught me.' },
-          { name: 'Counter-Wisdom', pattern: 'The advice is X. The advice is wrong for [audience].' },
-          { name: 'Numbered Breakdown', pattern: '[N] things I learned about Y after [proof of work].' },
-          { name: 'Vulnerable Confession', pattern: 'I used to [bad pattern]. Here is what changed it.' },
-        ].map((h) => (
-          <div key={h.name} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4">
-            <p className="font-semibold text-white mb-1.5">{h.name}</p>
-            <p className="text-zinc-400 italic leading-relaxed text-xs">"{h.pattern}"</p>
-          </div>
-        ))}
-        <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-4 flex items-center">
-          <p className="text-emerald-200 font-medium text-sm">
-            Pick ONE. Draft a hook for your pillar in the next 90 seconds.
-          </p>
-        </div>
-      </div>
-    ),
-  },
-  // 8 — Weekly rhythm + channels
-  {
-    id: 'module-4-rhythm',
-    eyebrow: 'Module 4',
-    title: '3 · 2 · 1 · 1 — Weekly rhythm',
-    module: 'Module 4',
-    minutes: 4,
-    color: 'emerald',
-    speakerNotes: [
-      'Three Insight · Two Build-in-Public · One Connection · One Rest.',
-      'Rest day is non-negotiable. Algorithm rewards consistency, not exhaustion.',
-    ],
-    body: () => (
-      <div className="space-y-6">
-        <div className="grid grid-cols-4 gap-3">
-          {[
-            { label: 'Insight', count: 3, color: 'violet-500' },
-            { label: 'Build-in-Public', count: 2, color: 'amber-500' },
-            { label: 'Connection', count: 1, color: 'emerald-500' },
-            { label: 'Rest', count: 1, color: 'zinc-700' },
-          ].map((r) => (
-            <div key={r.label} className={`rounded-2xl border border-${r.color}/30 bg-${r.color}/10 p-5 text-center`}>
-              <p className="text-4xl font-bold text-white mb-1">{r.count}</p>
-              <p className="text-xs text-zinc-300 uppercase tracking-wider">{r.label}</p>
-            </div>
-          ))}
-        </div>
-        <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
-          <p className="text-sm text-zinc-400 leading-relaxed">
-            <span className="text-white font-medium">Each channel has a different job.</span>{' '}
-            LinkedIn = authority. Threads = raw thinking. Newsletter = consolidation. Shorts = visualize pillars.
-            Stop reposting the same thing four times.
-          </p>
-        </div>
-      </div>
-    ),
-  },
-  // 9 — 30-day calendar
-  {
-    id: 'module-4-calendar',
-    eyebrow: 'Module 4 · The deliverable',
-    title: 'Your 30-day calendar',
-    module: 'Module 4',
-    minutes: 3,
-    color: 'emerald',
-    speakerNotes: [
-      'Three formats: Notion · Google Sheet · CSV. They pick what they live in.',
-      'Pro tip: 60 min Sunday batch. Schedule with Buffer / Typefully. Real attention compounds.',
-    ],
-    body: () => (
-      <div className="space-y-4">
-        <div className="grid grid-cols-7 gap-1.5 text-xs">
-          {Array.from({ length: 28 }).map((_, i) => {
-            const day = i % 7
-            const isRest = day === 6
-            const archetype = day < 3 ? 'Insight' : day < 5 ? 'Build' : day === 5 ? 'Connect' : 'Rest'
-            const colorClass = isRest
-              ? 'border-white/[0.04] bg-white/[0.01] text-zinc-700'
-              : day < 3
-                ? 'border-violet-500/20 bg-violet-500/[0.04] text-violet-200'
-                : day < 5
-                  ? 'border-amber-500/20 bg-amber-500/[0.04] text-amber-200'
-                  : 'border-emerald-500/20 bg-emerald-500/[0.04] text-emerald-200'
-            return (
-              <div key={i} className={`rounded-lg border p-2 text-center ${colorClass}`}>
-                <div className="font-semibold text-[10px]">D{i + 1}</div>
-                <div className="text-[9px] mt-0.5 leading-tight">{archetype}</div>
-              </div>
-            )
-          })}
-        </div>
-        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
-          <div className="px-4 py-2 rounded-lg bg-gradient-to-r from-violet-500 to-violet-600 text-white text-sm font-semibold">
-            Notion template
-          </div>
-          <div className="px-4 py-2 rounded-lg bg-white/[0.06] border border-white/[0.10] text-zinc-200 text-sm font-medium">
-            Google Sheet
-          </div>
-          <div className="px-4 py-2 rounded-lg bg-white/[0.06] border border-white/[0.10] text-zinc-200 text-sm font-medium">
-            Download CSV
-          </div>
-        </div>
-      </div>
-    ),
-  },
-  // 10 — GenCreator Stack
-  {
-    id: 'module-5',
-    eyebrow: 'Module 5 · 5 min',
-    title: 'The GenCreator Stack',
-    module: 'Module 5',
-    minutes: 5,
-    color: 'sky',
-    speakerNotes: [
-      'Five jobs every creator runs. Pick one tool per job. Master it. Then expand.',
-      'Discipline: add a tool only when an existing tool fails you twice.',
-    ],
-    body: () => (
-      <div className="grid grid-cols-5 gap-3">
-        {[
-          { icon: Mic, title: 'Capture', tool: 'Loom', color: 'violet' },
-          { icon: Brain, title: 'Think', tool: 'Claude Cowork', color: 'sky' },
-          { icon: Wand2, title: 'Make', tool: 'Suno · NB2', color: 'amber' },
-          { icon: Send, title: 'Ship', tool: 'Buffer · Beehiiv', color: 'emerald' },
-          { icon: BarChart3, title: 'Measure', tool: 'Plausible', color: 'rose' },
-        ].map((c) => {
-          const Icon = c.icon
-          return (
-            <div key={c.title} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-center">
-              <div className="w-12 h-12 rounded-xl bg-white/[0.04] border border-white/[0.08] flex items-center justify-center mx-auto mb-3">
-                <Icon className="w-6 h-6 text-zinc-300" />
-              </div>
-              <p className="text-sm font-semibold text-white mb-1">{c.title}</p>
-              <p className="text-xs text-zinc-500">{c.tool}</p>
-            </div>
-          )
-        })}
-      </div>
-    ),
-  },
-  // 11 — Live artifact
-  {
-    id: 'module-6',
-    eyebrow: 'Module 6 · The artifact',
-    title: 'Watch the post get written',
-    module: 'Module 6',
-    minutes: 5,
-    color: 'amber',
-    speakerNotes: [
-      'Play Loom OR demo live: Claude Cowork in second window.',
-      'Narrate: "Notice I rejected the first 2 hooks. Specificity beats template."',
-      'Close: "AI-assisted. Voice-preserved. Ship today."',
-    ],
-    body: () => (
-      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] overflow-hidden">
-        <div className="aspect-video bg-[#050507] flex items-center justify-center relative">
-          <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.06] via-amber-500/[0.04] to-transparent" />
-          <div className="relative text-center">
-            <div className="w-20 h-20 rounded-full bg-white/[0.06] border border-white/[0.10] flex items-center justify-center mx-auto mb-4">
-              <Play className="w-9 h-9 text-amber-300 ml-1" fill="currentColor" />
-            </div>
-            <p className="text-base text-zinc-300 font-medium">90 seconds · Claude Cowork demo</p>
-            <p className="text-xs text-zinc-500 mt-1">A LinkedIn post written in real time</p>
-          </div>
-        </div>
-      </div>
-    ),
-  },
-  // 12 — Activation
-  {
-    id: 'module-7',
-    eyebrow: 'Module 7 · Activation',
-    title: '4 visible artifacts in 30 days',
-    module: 'Module 7',
-    minutes: 4,
-    color: 'emerald',
-    speakerNotes: [
-      'Public commitment increases follow-through 3×.',
-      'Have them text the commitment to one person before leaving the room.',
-    ],
-    body: () => (
-      <div className="space-y-6">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          {[
-            { icon: TrendingUp, title: '1 post', sub: 'Pick one hook format. Ship Monday.' },
-            { icon: Play, title: '1 short video', sub: '45–90 seconds. Captions on. Pillar in title.' },
-            { icon: UserCircle, title: '1 conversation', sub: 'DM or email to your audience-of-one.' },
-            { icon: Rocket, title: '1 small product', sub: 'Template · checklist · mini-guide.' },
-          ].map((a) => {
-            const Icon = a.icon
-            return (
-              <div key={a.title} className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-5 text-center">
-                <div className="w-12 h-12 rounded-xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center mx-auto mb-3">
-                  <Icon className="w-6 h-6 text-emerald-300" />
-                </div>
-                <p className="text-base font-semibold text-white mb-1">{a.title}</p>
-                <p className="text-xs text-zinc-400 leading-relaxed">{a.sub}</p>
-              </div>
-            )
-          })}
-        </div>
-      </div>
-    ),
-  },
-  // 13 — Outro
-  {
-    id: 'outro',
-    eyebrow: 'Stay in touch',
-    title: 'Three ways to keep going',
-    minutes: 3,
-    color: 'violet',
-    speakerNotes: [
-      'Show QR codes. Promise Resource Pack lands in inbox tonight.',
-      'Day-7 check-in is the secret weapon.',
-    ],
-    body: () => (
-      <div className="grid sm:grid-cols-3 gap-4">
-        {[
-          { icon: Sparkles, title: 'Coach GPT', sub: 'Walk through everything in chat.', url: 'frankx.ai/go/ikigai-coach', color: 'violet' },
-          { icon: Mail, title: 'Resource Pack', sub: 'Templates + Day-7 check-in.', url: 'frankx.ai/workshops/ikigai-branding', color: 'amber' },
-          { icon: Compass, title: 'AI Architect Newsletter', sub: 'Weekly intelligence for makers.', url: 'frankx.ai/newsletter', color: 'emerald' },
-        ].map((c) => {
-          const Icon = c.icon
-          return (
-            <div key={c.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 text-center">
-              <div className="w-14 h-14 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mx-auto mb-4">
-                <Icon className="w-7 h-7 text-violet-300" />
-              </div>
-              <h3 className="text-lg font-semibold text-white mb-1">{c.title}</h3>
-              <p className="text-sm text-zinc-400 mb-3">{c.sub}</p>
-              <p className="text-xs text-zinc-500 font-mono break-all">{c.url}</p>
-            </div>
-          )
-        })}
-      </div>
-    ),
-  },
-]
-
-// ---- Component ---------------------------------------------------------
+const CHROME_REVEAL_MS = 2500
 
 export default function IkigaiPresentPage() {
-  const [index, setIndex] = useState(0)
+  const { index, setIndex } = useDeckSync(0)
   const [notesOpen, setNotesOpen] = useState(false)
   const [running, setRunning] = useState(false)
   const [elapsed, setElapsed] = useState(0)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [chromeVisible, setChromeVisible] = useState(true)
   const startRef = useRef<number>(Date.now())
   const tickRef = useRef<number | null>(null)
+  const chromeTimerRef = useRef<number | null>(null)
 
-  const slide = SLIDES[index]
+  const slide = SLIDES[index] ?? SLIDES[0]
   const total = SLIDES.length
 
-  const next = useCallback(() => setIndex((i) => Math.min(total - 1, i + 1)), [total])
-  const prev = useCallback(() => setIndex((i) => Math.max(0, i - 1)), [])
+  const next = useCallback(
+    () => setIndex((i) => Math.min(total - 1, i + 1)),
+    [setIndex, total],
+  )
+  const prev = useCallback(() => setIndex((i) => Math.max(0, i - 1)), [setIndex])
 
   const startTimer = useCallback(() => {
     startRef.current = Date.now() - elapsed
@@ -563,6 +74,49 @@ export default function IkigaiPresentPage() {
     }
   }, [running])
 
+  // Track fullscreen state
+  useEffect(() => {
+    function onChange() {
+      const fs = Boolean(document.fullscreenElement)
+      setIsFullscreen(fs)
+      // When entering fullscreen, hide chrome and start the reveal timer
+      if (fs) {
+        setChromeVisible(false)
+      } else {
+        setChromeVisible(true)
+      }
+    }
+    document.addEventListener('fullscreenchange', onChange)
+    return () => document.removeEventListener('fullscreenchange', onChange)
+  }, [])
+
+  // Auto-hide chrome on inactivity when fullscreen
+  useEffect(() => {
+    if (!isFullscreen) return
+    function reveal() {
+      setChromeVisible(true)
+      if (chromeTimerRef.current) window.clearTimeout(chromeTimerRef.current)
+      chromeTimerRef.current = window.setTimeout(() => {
+        setChromeVisible(false)
+      }, CHROME_REVEAL_MS) as unknown as number
+    }
+    window.addEventListener('mousemove', reveal)
+    window.addEventListener('keydown', reveal)
+    return () => {
+      window.removeEventListener('mousemove', reveal)
+      window.removeEventListener('keydown', reveal)
+      if (chromeTimerRef.current) window.clearTimeout(chromeTimerRef.current)
+    }
+  }, [isFullscreen])
+
+  function toggleFullscreen() {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch(() => {})
+    } else {
+      document.exitFullscreen().catch(() => {})
+    }
+  }
+
   // Keyboard nav
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -581,11 +135,7 @@ export default function IkigaiPresentPage() {
       } else if (e.key === 'p' || e.key === 'P') {
         setRunning((v) => !v)
       } else if (e.key === 'f' || e.key === 'F') {
-        if (!document.fullscreenElement) {
-          document.documentElement.requestFullscreen().catch(() => {})
-        } else {
-          document.exitFullscreen().catch(() => {})
-        }
+        toggleFullscreen()
       } else if (e.key === 'Escape') {
         setNotesOpen(false)
       } else if (/^[0-9]$/.test(e.key)) {
@@ -595,12 +145,16 @@ export default function IkigaiPresentPage() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [next, prev, resetTimer])
+  }, [next, prev, resetTimer, setIndex])
 
   const progress = useMemo(() => ((index + 1) / total) * 100, [index, total])
 
   return (
-    <div className="fixed inset-0 bg-[#0a0a0b] text-white overflow-hidden">
+    <div
+      className={`fixed inset-0 bg-[#0a0a0b] text-white overflow-hidden ${
+        isFullscreen ? 'cursor-none' : ''
+      } ${chromeVisible ? '!cursor-default' : ''}`}
+    >
       {/* Backdrop gradients */}
       <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.04] via-transparent to-amber-500/[0.03] pointer-events-none" />
       <div className="absolute top-0 left-1/3 w-[600px] h-[600px] bg-violet-500/[0.05] rounded-full blur-[160px] pointer-events-none" />
@@ -609,28 +163,58 @@ export default function IkigaiPresentPage() {
       {/* Slide stage */}
       <div className="relative h-full flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-8 py-5 border-b border-white/[0.04] print:hidden">
-          <Link
-            href="/workshops/ikigai-branding"
-            className="inline-flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
-          >
-            <ArrowLeft className="w-3.5 h-3.5" />
-            Back to workshop page
-          </Link>
-          <div className="text-xs text-zinc-600 font-mono">
-            {pad(index + 1)} / {pad(total)}
-          </div>
-        </div>
+        <AnimatePresence>
+          {chromeVisible && (
+            <motion.div
+              initial={{ y: -32, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -32, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="flex items-center justify-between px-8 py-5 border-b border-white/[0.04] print:hidden"
+            >
+              <Link
+                href="/workshops/ikigai-branding"
+                className="inline-flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                <ArrowLeft className="w-3.5 h-3.5" />
+                Back to workshop page
+              </Link>
+              <div className="flex items-center gap-3">
+                <Link
+                  href="/workshops/ikigai-branding/present/speaker"
+                  target="_blank"
+                  className="inline-flex items-center gap-1.5 text-xs text-zinc-500 hover:text-amber-300 transition-colors"
+                  title="Opens speaker view in new window for dual-screen setup"
+                >
+                  <MonitorSmartphone className="w-3.5 h-3.5" />
+                  Speaker view
+                </Link>
+                <div className="text-xs text-zinc-600 font-mono">
+                  {pad(index + 1)} / {pad(total)}
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Progress bar */}
-        <div className="h-0.5 bg-white/[0.04] print:hidden">
-          <motion.div
-            className="h-full bg-gradient-to-r from-violet-400 to-amber-400"
-            initial={false}
-            animate={{ width: `${progress}%` }}
-            transition={{ duration: 0.4 }}
-          />
-        </div>
+        <AnimatePresence>
+          {chromeVisible && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="h-0.5 bg-white/[0.04] print:hidden"
+            >
+              <motion.div
+                className="h-full bg-gradient-to-r from-violet-400 to-amber-400"
+                initial={false}
+                animate={{ width: `${progress}%` }}
+                transition={{ duration: 0.4 }}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Slide content */}
         <div className="flex-1 flex items-center justify-center px-8 py-8 overflow-hidden">
@@ -659,89 +243,93 @@ export default function IkigaiPresentPage() {
         </div>
 
         {/* Footer HUD */}
-        <div className="flex items-center justify-between px-8 py-4 border-t border-white/[0.04] print:hidden">
-          {/* Nav dots */}
-          <div className="flex items-center gap-1">
-            {SLIDES.map((s, i) => (
-              <button
-                key={s.id}
-                onClick={() => setIndex(i)}
-                aria-label={`Go to slide ${i + 1}: ${s.title}`}
-                className={`h-1.5 rounded-full transition-all ${
-                  i === index ? 'w-6 bg-violet-400' : 'w-1.5 bg-white/[0.12] hover:bg-white/[0.25]'
-                }`}
-              />
-            ))}
-          </div>
-
-          {/* Timer + controls */}
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-1.5 text-sm font-mono">
-              <span className={running ? 'text-emerald-300' : 'text-zinc-500'}>
-                {formatTime(elapsed)}
-              </span>
-              <button
-                onClick={running ? pauseTimer : startTimer}
-                className="text-zinc-400 hover:text-white p-1"
-                aria-label={running ? 'Pause timer' : 'Start timer'}
-              >
-                {running ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
-              </button>
-              <button
-                onClick={resetTimer}
-                className="text-zinc-500 hover:text-white p-1"
-                aria-label="Reset timer"
-              >
-                <RotateCcw className="w-3.5 h-3.5" />
-              </button>
-            </div>
-
-            <div className="w-px h-5 bg-white/[0.08]" />
-
-            <button
-              onClick={() => setNotesOpen((v) => !v)}
-              className={`p-1.5 rounded-md hover:bg-white/[0.06] ${notesOpen ? 'text-amber-300' : 'text-zinc-400 hover:text-white'}`}
-              aria-label="Toggle notes"
+        <AnimatePresence>
+          {chromeVisible && (
+            <motion.div
+              initial={{ y: 32, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: 32, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="flex items-center justify-between px-8 py-4 border-t border-white/[0.04] print:hidden"
             >
-              <StickyNote className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => {
-                if (!document.fullscreenElement) {
-                  document.documentElement.requestFullscreen().catch(() => {})
-                } else {
-                  document.exitFullscreen().catch(() => {})
-                }
-              }}
-              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06]"
-              aria-label="Fullscreen"
-            >
-              <Maximize2 className="w-4 h-4" />
-            </button>
+              {/* Nav dots */}
+              <div className="flex items-center gap-1">
+                {SLIDES.map((s, i) => (
+                  <button
+                    key={s.id}
+                    onClick={() => setIndex(i)}
+                    aria-label={`Go to slide ${i + 1}: ${s.title}`}
+                    className={`h-1.5 rounded-full transition-all ${
+                      i === index ? 'w-6 bg-violet-400' : 'w-1.5 bg-white/[0.12] hover:bg-white/[0.25]'
+                    }`}
+                  />
+                ))}
+              </div>
 
-            <div className="w-px h-5 bg-white/[0.08]" />
+              {/* Timer + controls */}
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-1.5 text-sm font-mono">
+                  <span className={running ? 'text-emerald-300' : 'text-zinc-500'}>
+                    {formatTime(elapsed)}
+                  </span>
+                  <button
+                    onClick={running ? pauseTimer : startTimer}
+                    className="text-zinc-400 hover:text-white p-1"
+                    aria-label={running ? 'Pause timer' : 'Start timer'}
+                  >
+                    {running ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+                  </button>
+                  <button
+                    onClick={resetTimer}
+                    className="text-zinc-500 hover:text-white p-1"
+                    aria-label="Reset timer"
+                  >
+                    <RotateCcw className="w-3.5 h-3.5" />
+                  </button>
+                </div>
 
-            <button
-              onClick={prev}
-              disabled={index === 0}
-              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
-              aria-label="Previous slide"
-            >
-              <ArrowLeft className="w-4 h-4" />
-            </button>
-            <button
-              onClick={next}
-              disabled={index === total - 1}
-              className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
-              aria-label="Next slide"
-            >
-              <ArrowRight className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
+                <div className="w-px h-5 bg-white/[0.08]" />
+
+                <button
+                  onClick={() => setNotesOpen((v) => !v)}
+                  className={`p-1.5 rounded-md hover:bg-white/[0.06] ${notesOpen ? 'text-amber-300' : 'text-zinc-400 hover:text-white'}`}
+                  aria-label="Toggle notes"
+                >
+                  <StickyNote className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={toggleFullscreen}
+                  className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06]"
+                  aria-label="Fullscreen"
+                >
+                  {isFullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+                </button>
+
+                <div className="w-px h-5 bg-white/[0.08]" />
+
+                <button
+                  onClick={prev}
+                  disabled={index === 0}
+                  className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="Previous slide"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={next}
+                  disabled={index === total - 1}
+                  className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="Next slide"
+                >
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
 
-      {/* Notes drawer */}
+      {/* Notes drawer (audience view — speakers should use /present/speaker on second screen) */}
       <AnimatePresence>
         {notesOpen && (
           <motion.div
@@ -757,6 +345,13 @@ export default function IkigaiPresentPage() {
                   <StickyNote className="w-4 h-4 text-amber-300" />
                   <p className="text-sm font-semibold text-white">Speaker notes</p>
                   <span className="text-xs text-zinc-500">· suggested {slide.minutes} min</span>
+                  <Link
+                    href="/workshops/ikigai-branding/present/speaker"
+                    target="_blank"
+                    className="text-xs text-amber-300 hover:text-amber-200 ml-2 underline underline-offset-2"
+                  >
+                    Open full speaker view →
+                  </Link>
                 </div>
                 <button
                   onClick={() => setNotesOpen(false)}
@@ -779,21 +374,24 @@ export default function IkigaiPresentPage() {
         )}
       </AnimatePresence>
 
-      {/* Keyboard hint */}
-      <p className="absolute bottom-1 inset-x-0 text-center text-[10px] text-zinc-700 print:hidden">
-        ← → next · N notes · P pause · R reset · F fullscreen · 0-9 jump
-      </p>
+      {/* Keyboard hint — only when chrome visible */}
+      <AnimatePresence>
+        {chromeVisible && (
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute bottom-1 inset-x-0 text-center text-[10px] text-zinc-700 print:hidden"
+          >
+            ← → next · N notes · P pause · R reset · F fullscreen · 0-9 jump · Speaker view opens in new window
+          </motion.p>
+        )}
+      </AnimatePresence>
 
-      {/* Print styles — generates PDF with every slide on its own page */}
       <style jsx global>{`
         @media print {
-          html, body {
-            background: white !important;
-            color: black !important;
-          }
-          .fixed {
-            position: static !important;
-          }
+          html, body { background: white !important; color: black !important; }
+          .fixed { position: static !important; }
         }
       `}</style>
     </div>

--- a/app/workshops/ikigai-branding/present/slides.tsx
+++ b/app/workshops/ikigai-branding/present/slides.tsx
@@ -1,0 +1,587 @@
+'use client'
+
+import Image from 'next/image'
+import {
+  Compass,
+  Target,
+  UserCircle,
+  Layers3,
+  TrendingUp,
+  Calendar,
+  Wand2,
+  Send,
+  Brain,
+  Mic,
+  BarChart3,
+  Play,
+  Rocket,
+  Mail,
+  Sparkles,
+  Award,
+} from 'lucide-react'
+import { FRANK_CREDENTIALS, MODULE_4_CITATIONS, MODULE_5_CITATIONS } from '@/lib/workshop-citations'
+
+export interface SlideDef {
+  id: string
+  eyebrow: string
+  title: string
+  module?: string
+  minutes: number
+  color: 'violet' | 'amber' | 'emerald' | 'sky' | 'rose'
+  speakerNotes: string[]
+  body: () => React.ReactNode
+}
+
+/**
+ * The Ikigai & Branding workshop deck — 15 slides covering a 75-min flow.
+ * Shared by /present (audience) and /present/speaker (Frank's view).
+ */
+export const SLIDES: SlideDef[] = [
+  // ─── 0. Cover ─────────────────────────────────────────────────────
+  {
+    id: 'cover',
+    eyebrow: 'A 75-minute workshop',
+    title: 'Ikigai & Branding',
+    minutes: 1,
+    color: 'violet',
+    speakerNotes: [
+      'Hold the cover for 10 seconds before speaking. Let the room settle.',
+      'Open: "By the end of the next 75 minutes you will have a purpose statement, a brand positioning, and a 30-day plan. Not a feeling. An artifact."',
+      'Phones face-down for the wizard sections. The output is yours, not theirs.',
+    ],
+    body: () => (
+      <div className="text-center space-y-10 max-w-5xl mx-auto">
+        <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border border-violet-500/20 bg-violet-500/[0.06] text-[10px] font-medium text-violet-300 uppercase tracking-[0.18em]">
+          <Compass className="w-3 h-3" />
+          A 75-minute workshop
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-7xl sm:text-8xl lg:text-9xl font-bold tracking-tighter leading-[0.95]"
+              style={{ fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif' }}>
+            <span className="text-white">Ikigai </span>
+            <span className="text-zinc-600 font-light">&amp;</span>
+            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-violet-300 via-amber-300 to-violet-300">
+              Branding
+            </span>
+          </h1>
+        </div>
+        <p className="text-xl sm:text-2xl text-zinc-400 max-w-3xl mx-auto leading-relaxed font-light">
+          Find what makes time disappear. Translate it into a brand the world remembers.
+          Ship the plan before you leave the room.
+        </p>
+        <div className="pt-12 text-sm text-zinc-500 tracking-wide flex items-center justify-center gap-3">
+          <span className="text-zinc-300 font-medium">Frank Riemer</span>
+          <span className="text-zinc-700">·</span>
+          <span>{FRANK_CREDENTIALS.role}, {FRANK_CREDENTIALS.org}</span>
+          <span className="text-zinc-700">·</span>
+          <span className="text-zinc-500">frankx.ai</span>
+        </div>
+      </div>
+    ),
+  },
+
+  // ─── 1. Why listen ────────────────────────────────────────────────
+  {
+    id: 'why-listen',
+    eyebrow: 'Why this room. Why this hour.',
+    title: 'You did not come here for inspiration.',
+    minutes: 4,
+    color: 'amber',
+    speakerNotes: [
+      'Drop the "Why listen" framing into the room. "You did not come here for inspiration. You came for output."',
+      'Credentialing: I build CoE frameworks for F500 at Oracle EMEA. Same patterns, open-sourced, run my own creator stack.',
+      'Promise: 3 artifacts in your hands by minute 75. Statement, plan, stack.',
+    ],
+    body: () => (
+      <div className="grid lg:grid-cols-5 gap-8 items-start max-w-6xl mx-auto">
+        {/* Left: positioning */}
+        <div className="lg:col-span-3 space-y-6">
+          <p className="text-2xl sm:text-3xl text-zinc-200 leading-snug font-light">
+            You came here for an artifact in your hand by minute seventy-five.
+            Three of them, actually.
+          </p>
+          <div className="space-y-3">
+            {[
+              { num: '01', title: 'A purpose statement', sub: 'Two lines. Fits on a business card.' },
+              { num: '02', title: 'A 30-day publishing plan', sub: 'Generated from your pillars, ready to ship Monday.' },
+              { num: '03', title: 'A GenCreator stack', sub: 'Five tools, opinionated, on by Friday.' },
+            ].map((p) => (
+              <div key={p.num} className="flex items-start gap-4 rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+                <div className="text-2xl font-bold text-violet-300/60 tabular-nums font-mono">{p.num}</div>
+                <div>
+                  <p className="text-base font-semibold text-white">{p.title}</p>
+                  <p className="text-sm text-zinc-400">{p.sub}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Right: credential card */}
+        <div className="lg:col-span-2 rounded-3xl border border-violet-500/20 bg-gradient-to-br from-violet-500/[0.06] to-amber-500/[0.04] p-6 space-y-4">
+          <div className="flex items-center gap-2">
+            <Award className="w-4 h-4 text-amber-300" />
+            <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-amber-300">
+              Why this person facilitates
+            </p>
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-white leading-tight">{FRANK_CREDENTIALS.role}</p>
+            <p className="text-sm text-zinc-400">{FRANK_CREDENTIALS.org}</p>
+          </div>
+          <ul className="space-y-2 pt-2 border-t border-white/[0.06]">
+            {FRANK_CREDENTIALS.proofPoints.map((p, i) => (
+              <li key={i} className="text-xs text-zinc-400 flex items-start gap-1.5 leading-relaxed">
+                <span className="text-violet-300 mt-0.5">·</span>
+                <span>{p}</span>
+              </li>
+            ))}
+            <li className="text-xs text-zinc-400 flex items-start gap-1.5 leading-relaxed">
+              <span className="text-violet-300 mt-0.5">·</span>
+              <span>{FRANK_CREDENTIALS.catalog}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    ),
+  },
+
+  // ─── 2. Outcomes ──────────────────────────────────────────────────
+  {
+    id: 'outcomes',
+    eyebrow: 'The promise',
+    title: 'What you walk out with',
+    minutes: 3,
+    color: 'amber',
+    speakerNotes: [
+      'Read the four bullets aloud. Pause after each.',
+      'Frame: "If you write all four down today, the next 30 days plan themselves."',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-2 gap-4 max-w-5xl mx-auto">
+        {[
+          { title: 'A purpose statement', sub: 'Two lines. Fits on a business card.', icon: Compass },
+          { title: 'A brand positioning', sub: 'Positioning sentence + audience-of-one + 3 content pillars.', icon: Target },
+          { title: 'A 30-day content plan', sub: 'Calendar generated from your pillars. Notion + Sheet + CSV.', icon: Calendar },
+          { title: 'The GenCreator Stack', sub: 'Five tools across Capture · Think · Make · Ship · Measure.', icon: Wand2 },
+        ].map((o) => {
+          const Icon = o.icon
+          return (
+            <div key={o.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 flex gap-4">
+              <div className="w-10 h-10 rounded-lg bg-violet-500/10 border border-violet-500/20 flex items-center justify-center flex-shrink-0">
+                <Icon className="w-5 h-5 text-violet-300" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-white mb-1">{o.title}</h3>
+                <p className="text-sm text-zinc-400">{o.sub}</p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+
+  // ─── 3. The 3Cs ───────────────────────────────────────────────────
+  {
+    id: '3cs',
+    eyebrow: 'Framework',
+    title: 'The 3Cs — Skills that compound with AI',
+    minutes: 6,
+    color: 'sky',
+    speakerNotes: [
+      'Ikigai = WHAT to build. 3Cs = HOW to build it without getting automated around.',
+      'Collaboration = pair with AI (PAIR · PACE). Communication = make outputs land (BLUF · SCQA). Creation = ship small.',
+    ],
+    body: () => (
+      <div className="grid md:grid-cols-3 gap-4 max-w-5xl mx-auto">
+        {[
+          { title: 'Collaboration', items: ['PACE: Plan → Act → Check → Evolve', 'PAIR with AI: Plan · Ask · Iterate · Review', 'Iteration speed + decision clarity'] },
+          { title: 'Communication', items: ['BLUF and SCQA frameworks', 'Design docs + demo scripts', 'Clear, reproducible outputs'] },
+          { title: 'Creation', items: ['Goldilocks scope', 'Build → measure → learn', "Ship small. Show, don't tell."] },
+        ].map((c) => (
+          <div key={c.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
+            <h3 className="text-xl font-semibold text-white mb-4">{c.title}</h3>
+            <ul className="space-y-3">
+              {c.items.map((i, idx) => (
+                <li key={idx} className="text-sm text-zinc-400 flex items-start gap-2 leading-relaxed">
+                  <span className="text-zinc-600">—</span>
+                  <span>{i}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+
+  // ─── 4. Module 1 intro ───────────────────────────────────────────
+  {
+    id: 'module-1-intro',
+    eyebrow: 'Module 1 · 15 min',
+    title: 'Map your four circles',
+    module: 'Module 1',
+    minutes: 3,
+    color: 'violet',
+    speakerNotes: [
+      'Four circles: love · good · needs · pays.',
+      "External evidence beats internal guessing. Other people's words, not yours.",
+    ],
+    body: () => (
+      <div className="relative max-w-3xl mx-auto">
+        <Image
+          src="/images/workshops/ikigai-branding/ikigai-venn.jpg"
+          alt="Ikigai Venn diagram"
+          width={1920}
+          height={960}
+          priority
+          className="w-full h-auto rounded-3xl border border-white/[0.06]"
+        />
+      </div>
+    ),
+  },
+
+  // ─── 5. Module 1 deep ────────────────────────────────────────────
+  {
+    id: 'module-1-deep',
+    eyebrow: 'Module 1',
+    title: 'Four questions. Specific answers.',
+    module: 'Module 1',
+    minutes: 12,
+    color: 'violet',
+    speakerNotes: [
+      'Run the wizard live. 3 min per circle. Use Coach GPT deep-links if a participant stalls.',
+      'Push past generic. "Specificity beats volume."',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-2 gap-4 max-w-5xl mx-auto">
+        {[
+          { label: 'What I love', q: 'What activities make time disappear for you?', hint: 'Name specific moments from the last 12 months.' },
+          { label: "What I'm good at", q: 'What do people keep thanking you for?', hint: "External evidence only. Other people's words." },
+          { label: 'What the world needs', q: 'Whose problem do you care about for ten years?', hint: 'The narrower the "who", the stronger the answer.' },
+          { label: 'What pays', q: 'What are people already paying for in this space?', hint: 'Real invoices. Real courses. Follow the money.' },
+        ].map((c) => (
+          <div key={c.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+            <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">{c.label}</p>
+            <p className="text-lg font-semibold text-white mb-2 leading-snug">{c.q}</p>
+            <p className="text-xs text-zinc-500">{c.hint}</p>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+
+  // ─── 6. Module 2 ─────────────────────────────────────────────────
+  {
+    id: 'module-2',
+    eyebrow: 'Module 2 · 10 min',
+    title: 'Write the sentence',
+    module: 'Module 2',
+    minutes: 10,
+    color: 'amber',
+    speakerNotes: [
+      'Two to three lines. Fits on a business card.',
+      'Quality test: if a competitor could say the same sentence verbatim, sharpen it.',
+    ],
+    body: () => (
+      <div className="space-y-6 max-w-4xl mx-auto">
+        <div className="rounded-3xl border border-amber-500/20 bg-gradient-to-br from-amber-500/[0.06] to-violet-500/[0.04] p-8">
+          <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-3">The template</p>
+          <p className="text-2xl sm:text-3xl text-white leading-relaxed font-medium tracking-tight">
+            I help <span className="text-amber-300">[who]</span> achieve <span className="text-emerald-300">[outcome]</span>
+            <br />by <span className="text-violet-300">[how]</span>, using <span className="text-sky-300">[skills]</span> in <span className="text-rose-300">[domain]</span>.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500 mb-2">Worked example</p>
+          <p className="text-base text-zinc-300 leading-relaxed italic">
+            "I help early-career analysts turn messy spreadsheets into decisions,
+            by pairing them with AI workflows, using ten years of consulting craft, in finance and operations teams."
+          </p>
+        </div>
+      </div>
+    ),
+  },
+
+  // ─── 7. Module 3 ─────────────────────────────────────────────────
+  {
+    id: 'module-3',
+    eyebrow: 'Module 3 · 10 min',
+    title: 'The Brand Bridge',
+    module: 'Module 3',
+    minutes: 10,
+    color: 'amber',
+    speakerNotes: [
+      'Three exercises. Each anchored to the Module 2 statement.',
+      'Audience-of-One is the hardest. Force a single real-feeling name.',
+    ],
+    body: () => (
+      <div className="grid md:grid-cols-3 gap-4 max-w-5xl mx-auto">
+        {[
+          { icon: Target, title: 'Positioning Sentence', sub: 'Force a trade-off. Who you are NOT for.' },
+          { icon: UserCircle, title: 'Audience of One', sub: "A single name. A specific situation. This week's problem." },
+          { icon: Layers3, title: 'Three Content Pillars', sub: '12 months of posts without repeating.' },
+        ].map((b) => {
+          const Icon = b.icon
+          return (
+            <div key={b.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
+              <div className="w-12 h-12 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mb-4">
+                <Icon className="w-6 h-6 text-violet-300" />
+              </div>
+              <h3 className="text-lg font-semibold text-white mb-2">{b.title}</h3>
+              <p className="text-sm text-zinc-400 leading-relaxed">{b.sub}</p>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+
+  // ─── 8. Module 4 — authority ─────────────────────────────────────
+  {
+    id: 'module-4-authority',
+    eyebrow: 'Module 4 · Why this matters',
+    title: 'The creator economy crossed the threshold.',
+    module: 'Module 4',
+    minutes: 2,
+    color: 'emerald',
+    speakerNotes: [
+      'Drop the three stats one at a time. Let them land.',
+      'The thesis: this is no longer optional. Either you publish, or your work is invisible.',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {MODULE_4_CITATIONS.map((c, i) => (
+          <div key={i} className="rounded-3xl border border-amber-500/15 bg-gradient-to-br from-amber-500/[0.04] to-transparent p-6">
+            <div className="text-5xl font-bold text-white tracking-tight mb-2 tabular-nums">
+              {c.stat}
+            </div>
+            <p className="text-sm text-zinc-300 leading-snug mb-4">{c.claim}</p>
+            <p className="text-[10px] uppercase tracking-wider text-amber-300/70">
+              {c.source} · {c.year}
+            </p>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+
+  // ─── 9. Module 4 hooks ───────────────────────────────────────────
+  {
+    id: 'module-4-hooks',
+    eyebrow: 'Module 4 · LinkedIn Top Voice',
+    title: 'Five hook formats',
+    module: 'Module 4',
+    minutes: 5,
+    color: 'emerald',
+    speakerNotes: [
+      'Pattern over creativity. Rotate the five so you never stare at a blank page.',
+      'Have them pick ONE format and draft a real hook for their pillar live.',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-2 gap-3 text-sm max-w-5xl mx-auto">
+        {[
+          { name: 'Contrarian Take', pattern: 'Everyone says X. I think the opposite — and here is why.' },
+          { name: 'Story Open', pattern: 'Last [time], [vivid moment]. Here is what it taught me.' },
+          { name: 'Counter-Wisdom', pattern: 'The advice is X. The advice is wrong for [audience].' },
+          { name: 'Numbered Breakdown', pattern: '[N] things I learned about Y after [proof of work].' },
+          { name: 'Vulnerable Confession', pattern: 'I used to [bad pattern]. Here is what changed it.' },
+        ].map((h) => (
+          <div key={h.name} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4">
+            <p className="font-semibold text-white mb-1.5">{h.name}</p>
+            <p className="text-zinc-400 italic leading-relaxed text-xs">"{h.pattern}"</p>
+          </div>
+        ))}
+        <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-4 flex items-center">
+          <p className="text-emerald-200 font-medium text-sm">
+            Pick ONE. Draft a hook for your pillar in the next 90 seconds.
+          </p>
+        </div>
+      </div>
+    ),
+  },
+
+  // ─── 10. 30-day calendar ─────────────────────────────────────────
+  {
+    id: 'module-4-calendar',
+    eyebrow: 'Module 4 · The deliverable',
+    title: 'Your 30-day calendar',
+    module: 'Module 4',
+    minutes: 3,
+    color: 'emerald',
+    speakerNotes: [
+      'Three export formats: Notion · Google Sheet · CSV. They pick what they live in.',
+      'Pro tip: 60 min Sunday batch. Schedule with Buffer / Typefully.',
+    ],
+    body: () => (
+      <div className="space-y-4 max-w-5xl mx-auto">
+        <div className="grid grid-cols-7 gap-1.5 text-xs">
+          {Array.from({ length: 28 }).map((_, i) => {
+            const day = i % 7
+            const isRest = day === 6
+            const archetype = day < 3 ? 'Insight' : day < 5 ? 'Build' : day === 5 ? 'Connect' : 'Rest'
+            const colorClass = isRest
+              ? 'border-white/[0.04] bg-white/[0.01] text-zinc-700'
+              : day < 3
+                ? 'border-violet-500/20 bg-violet-500/[0.04] text-violet-200'
+                : day < 5
+                  ? 'border-amber-500/20 bg-amber-500/[0.04] text-amber-200'
+                  : 'border-emerald-500/20 bg-emerald-500/[0.04] text-emerald-200'
+            return (
+              <div key={i} className={`rounded-lg border p-2 text-center ${colorClass}`}>
+                <div className="font-semibold text-[10px]">D{i + 1}</div>
+                <div className="text-[9px] mt-0.5 leading-tight">{archetype}</div>
+              </div>
+            )
+          })}
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <div className="px-4 py-2 rounded-lg bg-gradient-to-r from-violet-500 to-violet-600 text-white text-sm font-semibold">
+            Notion template
+          </div>
+          <div className="px-4 py-2 rounded-lg bg-white/[0.06] border border-white/[0.10] text-zinc-200 text-sm font-medium">
+            Google Sheet
+          </div>
+          <div className="px-4 py-2 rounded-lg bg-white/[0.06] border border-white/[0.10] text-zinc-200 text-sm font-medium">
+            Download CSV
+          </div>
+        </div>
+      </div>
+    ),
+  },
+
+  // ─── 11. Module 5 — authority ────────────────────────────────────
+  {
+    id: 'module-5-authority',
+    eyebrow: 'Module 5 · Why this stack',
+    title: 'AI is not optional. It is operational.',
+    module: 'Module 5',
+    minutes: 2,
+    color: 'sky',
+    speakerNotes: [
+      "The three numbers say the same thing: this is normalized infrastructure now, not novelty.",
+      'Discipline: pick one tool per job, master it, then expand. Most creators have 30+ subscriptions and use 3.',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {MODULE_5_CITATIONS.map((c, i) => (
+          <div key={i} className="rounded-3xl border border-sky-500/15 bg-gradient-to-br from-sky-500/[0.04] to-transparent p-6">
+            <div className="text-5xl font-bold text-white tracking-tight mb-2 tabular-nums">{c.stat}</div>
+            <p className="text-sm text-zinc-300 leading-snug mb-4">{c.claim}</p>
+            <p className="text-[10px] uppercase tracking-wider text-sky-300/70">
+              {c.source} · {c.year}
+            </p>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+
+  // ─── 12. Module 5 stack ──────────────────────────────────────────
+  {
+    id: 'module-5-stack',
+    eyebrow: 'Module 5 · The GenCreator Stack',
+    title: 'Five jobs. One tool per job.',
+    module: 'Module 5',
+    minutes: 5,
+    color: 'sky',
+    speakerNotes: [
+      'Speed-run the 5 categories. Do not let them ask about every tool.',
+      'Discipline: add a tool only when an existing tool fails you twice.',
+    ],
+    body: () => (
+      <div className="grid grid-cols-5 gap-3 max-w-5xl mx-auto">
+        {[
+          { icon: Mic, title: 'Capture', tool: 'Loom' },
+          { icon: Brain, title: 'Think', tool: 'Claude · ChatGPT · Gemini' },
+          { icon: Wand2, title: 'Make', tool: 'Suno · NB2' },
+          { icon: Send, title: 'Ship', tool: 'Buffer · Beehiiv' },
+          { icon: BarChart3, title: 'Measure', tool: 'Plausible' },
+        ].map((c) => {
+          const Icon = c.icon
+          return (
+            <div key={c.title} className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-center">
+              <div className="w-12 h-12 rounded-xl bg-white/[0.04] border border-white/[0.08] flex items-center justify-center mx-auto mb-3">
+                <Icon className="w-6 h-6 text-zinc-300" />
+              </div>
+              <p className="text-sm font-semibold text-white mb-1">{c.title}</p>
+              <p className="text-xs text-zinc-500">{c.tool}</p>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+
+  // ─── 13. Activation ──────────────────────────────────────────────
+  {
+    id: 'module-7',
+    eyebrow: 'Module 7 · Activation',
+    title: '4 visible artifacts in 30 days',
+    module: 'Module 7',
+    minutes: 4,
+    color: 'emerald',
+    speakerNotes: [
+      'Public commitment increases follow-through 3×.',
+      'Have them text the commitment to one person before leaving the room.',
+    ],
+    body: () => (
+      <div className="space-y-6 max-w-5xl mx-auto">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            { icon: TrendingUp, title: '1 post', sub: 'Pick one hook format. Ship Monday.' },
+            { icon: Play, title: '1 short video', sub: '45–90 seconds. Captions on. Pillar in title.' },
+            { icon: UserCircle, title: '1 conversation', sub: 'DM or email to your audience-of-one.' },
+            { icon: Rocket, title: '1 small product', sub: 'Template · checklist · mini-guide.' },
+          ].map((a) => {
+            const Icon = a.icon
+            return (
+              <div key={a.title} className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-5 text-center">
+                <div className="w-12 h-12 rounded-xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center mx-auto mb-3">
+                  <Icon className="w-6 h-6 text-emerald-300" />
+                </div>
+                <p className="text-base font-semibold text-white mb-1">{a.title}</p>
+                <p className="text-xs text-zinc-400 leading-relaxed">{a.sub}</p>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    ),
+  },
+
+  // ─── 14. Outro ───────────────────────────────────────────────────
+  {
+    id: 'outro',
+    eyebrow: 'Stay in touch',
+    title: 'Three ways to keep going',
+    minutes: 3,
+    color: 'violet',
+    speakerNotes: [
+      'Show QR codes. Promise Resource Pack lands in inbox tonight.',
+      'Day-7 check-in is the secret weapon.',
+    ],
+    body: () => (
+      <div className="grid sm:grid-cols-3 gap-4 max-w-5xl mx-auto">
+        {[
+          { icon: Sparkles, title: 'Coach GPT', sub: 'Walk through everything in chat.', url: 'frankx.ai/go/ikigai-coach' },
+          { icon: Mail, title: 'Resource Pack', sub: 'Templates + Day-7 check-in.', url: 'frankx.ai/workshops/ikigai-branding' },
+          { icon: Compass, title: 'AI Architect Newsletter', sub: 'Weekly intelligence for makers.', url: 'frankx.ai/newsletter' },
+        ].map((c) => {
+          const Icon = c.icon
+          return (
+            <div key={c.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6 text-center">
+              <div className="w-14 h-14 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mx-auto mb-4">
+                <Icon className="w-7 h-7 text-violet-300" />
+              </div>
+              <h3 className="text-lg font-semibold text-white mb-1">{c.title}</h3>
+              <p className="text-sm text-zinc-400 mb-3">{c.sub}</p>
+              <p className="text-xs text-zinc-500 font-mono break-all">{c.url}</p>
+            </div>
+          )
+        })}
+      </div>
+    ),
+  },
+]

--- a/app/workshops/ikigai-branding/present/speaker/layout.tsx
+++ b/app/workshops/ikigai-branding/present/speaker/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Ikigai & Branding · Speaker View',
+  description:
+    'Presenter view with current + next slide preview, speaker notes, and timer. Designed for dual-screen workshop facilitation.',
+  robots: { index: false, follow: false },
+}
+
+export default function SpeakerLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/app/workshops/ikigai-branding/present/speaker/page.tsx
+++ b/app/workshops/ikigai-branding/present/speaker/page.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  ArrowRight,
+  StickyNote,
+  Play,
+  Pause,
+  RotateCcw,
+  Clock,
+  ExternalLink,
+} from 'lucide-react'
+import { SLIDES } from '../slides'
+import { useDeckSync } from '../use-deck-sync'
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+function formatTime(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`
+}
+
+/**
+ * Speaker view for the Ikigai deck. Designed for a dual-screen setup:
+ *   - Window 1 (`/present`) → drag to projector, hit F for fullscreen.
+ *     Audience sees one slide at a time.
+ *   - Window 2 (`/present/speaker`) → stays on laptop. Shows current
+ *     slide, next slide, full notes, timers.
+ *
+ * Both windows share the slide index via BroadcastChannel + localStorage
+ * fallback. Advancing on EITHER window advances the other.
+ */
+export default function IkigaiSpeakerPage() {
+  const { index, setIndex } = useDeckSync(0)
+  const [running, setRunning] = useState(false)
+  const [elapsed, setElapsed] = useState(0)
+  const [slideElapsed, setSlideElapsed] = useState(0)
+  const startRef = useRef<number>(Date.now())
+  const slideStartRef = useRef<number>(Date.now())
+  const tickRef = useRef<number | null>(null)
+
+  const slide = SLIDES[index] ?? SLIDES[0]
+  const nextSlide = SLIDES[index + 1]
+  const total = SLIDES.length
+
+  const next = useCallback(
+    () => setIndex((i) => Math.min(total - 1, i + 1)),
+    [setIndex, total],
+  )
+  const prev = useCallback(() => setIndex((i) => Math.max(0, i - 1)), [setIndex])
+
+  const startTimer = useCallback(() => {
+    startRef.current = Date.now() - elapsed
+    setRunning(true)
+  }, [elapsed])
+  const pauseTimer = useCallback(() => setRunning(false), [])
+  const resetTimer = useCallback(() => {
+    setElapsed(0)
+    setSlideElapsed(0)
+    startRef.current = Date.now()
+    slideStartRef.current = Date.now()
+  }, [])
+
+  // Tick
+  useEffect(() => {
+    if (!running) return
+    tickRef.current = window.setInterval(() => {
+      setElapsed(Date.now() - startRef.current)
+      setSlideElapsed(Date.now() - slideStartRef.current)
+    }, 250) as unknown as number
+    return () => {
+      if (tickRef.current) window.clearInterval(tickRef.current)
+    }
+  }, [running])
+
+  // Reset slide-elapsed when slide changes
+  useEffect(() => {
+    slideStartRef.current = Date.now()
+    setSlideElapsed(0)
+  }, [index])
+
+  // Keyboard nav
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
+      if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') {
+        e.preventDefault()
+        next()
+      } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+        e.preventDefault()
+        prev()
+      } else if (e.key === 'r' || e.key === 'R') {
+        resetTimer()
+      } else if (e.key === 'p' || e.key === 'P') {
+        setRunning((v) => !v)
+      } else if (/^[0-9]$/.test(e.key)) {
+        const t = parseInt(e.key, 10)
+        if (t < SLIDES.length) setIndex(t)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [next, prev, resetTimer, setIndex])
+
+  // Over/under target time
+  const targetMs = slide.minutes * 60 * 1000
+  const overTarget = slideElapsed > targetMs
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0b] text-white">
+      <div className="max-w-7xl mx-auto px-6 py-6 space-y-5">
+        {/* Top bar: identity + timers */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="px-2.5 py-1 rounded-md border border-amber-500/30 bg-amber-500/[0.08] text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-300">
+              Speaker view
+            </div>
+            <p className="text-sm text-zinc-400">Ikigai &amp; Branding · 75 min workshop</p>
+          </div>
+
+          <div className="flex items-center gap-4">
+            {/* Total timer */}
+            <div className="flex items-center gap-2">
+              <Clock className="w-4 h-4 text-zinc-500" />
+              <div className="font-mono text-2xl tabular-nums text-white">
+                {formatTime(elapsed)}
+              </div>
+              <button
+                onClick={running ? pauseTimer : startTimer}
+                className="p-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/[0.06]"
+                aria-label={running ? 'Pause' : 'Start'}
+              >
+                {running ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+              </button>
+              <button
+                onClick={resetTimer}
+                className="p-1.5 rounded-md text-zinc-500 hover:text-white hover:bg-white/[0.06]"
+                aria-label="Reset"
+              >
+                <RotateCcw className="w-4 h-4" />
+              </button>
+            </div>
+
+            <Link
+              href="/workshops/ikigai-branding/present"
+              target="_blank"
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium text-zinc-300 bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.08] hover:text-white"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              Open audience view
+            </Link>
+          </div>
+        </div>
+
+        {/* Two-column slide preview */}
+        <div className="grid lg:grid-cols-[1.5fr_1fr] gap-4">
+          {/* Current slide preview */}
+          <div className="rounded-2xl border border-violet-500/30 bg-gradient-to-br from-violet-500/[0.04] to-transparent p-5">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-violet-300">
+                Now · Slide {index + 1} of {total}
+              </p>
+              <div
+                className={`font-mono text-sm tabular-nums ${
+                  overTarget ? 'text-rose-400' : 'text-zinc-400'
+                }`}
+              >
+                {formatTime(slideElapsed)} <span className="text-zinc-600">/ {slide.minutes}m</span>
+              </div>
+            </div>
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 min-h-[180px]">
+              {slide.eyebrow && (
+                <p className="text-[10px] font-medium uppercase tracking-wider text-violet-300 mb-2">
+                  {slide.eyebrow}
+                </p>
+              )}
+              <h2 className="text-2xl font-bold text-white tracking-tight leading-tight">
+                {slide.title}
+              </h2>
+            </div>
+          </div>
+
+          {/* Next slide preview */}
+          <div className="rounded-2xl border border-white/[0.08] bg-white/[0.015] p-5">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-500 mb-3">
+              Next · Slide {index + 2} of {total}
+            </p>
+            <div className="rounded-xl border border-white/[0.04] bg-white/[0.01] p-4 min-h-[180px]">
+              {nextSlide ? (
+                <>
+                  {nextSlide.eyebrow && (
+                    <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500 mb-2">
+                      {nextSlide.eyebrow}
+                    </p>
+                  )}
+                  <h3 className="text-base font-semibold text-zinc-300 tracking-tight leading-tight">
+                    {nextSlide.title}
+                  </h3>
+                </>
+              ) : (
+                <p className="text-sm text-zinc-600 italic">End of deck</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Speaker notes */}
+        <div className="rounded-2xl border border-amber-500/20 bg-gradient-to-br from-amber-500/[0.04] to-transparent p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <StickyNote className="w-4 h-4 text-amber-300" />
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-300">
+              Speaker notes
+            </p>
+            <span className="text-xs text-zinc-500 ml-auto">
+              Target: {slide.minutes} min
+            </span>
+          </div>
+          <ul className="space-y-2.5">
+            {slide.speakerNotes.map((n, i) => (
+              <li
+                key={i}
+                className="text-base text-zinc-200 leading-relaxed flex items-start gap-2"
+              >
+                <span className="text-amber-300/60 mt-1.5">›</span>
+                <span>{n}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Nav row + jump-to */}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={prev}
+              disabled={index === 0}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-zinc-300 bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.08] hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Previous
+            </button>
+            <button
+              onClick={next}
+              disabled={index === total - 1}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-violet-600 hover:from-violet-400 hover:to-violet-500 disabled:opacity-30 disabled:cursor-not-allowed shadow-lg shadow-violet-500/20"
+            >
+              Next
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Jump dots */}
+          <div className="flex items-center gap-1 flex-wrap">
+            {SLIDES.map((s, i) => (
+              <button
+                key={s.id}
+                onClick={() => setIndex(i)}
+                title={s.title}
+                aria-label={`Jump to slide ${i + 1}: ${s.title}`}
+                className={`h-2 rounded-full transition-all ${
+                  i === index ? 'w-8 bg-violet-400' : 'w-2 bg-white/[0.12] hover:bg-white/[0.25]'
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Keyboard hint */}
+        <p className="text-center text-[10px] text-zinc-700">
+          ← → next · P play/pause timer · R reset · 0-9 jump to slide · Open audience view in a separate window and drag to projector
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/workshops/ikigai-branding/present/use-deck-sync.ts
+++ b/app/workshops/ikigai-branding/present/use-deck-sync.ts
@@ -1,0 +1,96 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const CHANNEL_NAME = 'ikigai-deck'
+const STORAGE_KEY = 'frankx.ikigai-deck.index'
+
+interface SyncMessage {
+  index: number
+  origin: string
+}
+
+/**
+ * Cross-window slide-index sync for the Ikigai deck presenter.
+ *
+ * Pattern:
+ *   /present          (audience view, projector)
+ *   /present/speaker  (speaker view, laptop)
+ *
+ * Both routes call useDeckSync(). The hook keeps a shared integer
+ * (the slide index) in sync across windows using BroadcastChannel
+ * with a localStorage fallback for older browsers and incognito mode.
+ *
+ * Why not WebSockets / a sync service: we're in one user's browser
+ * across two tabs. BroadcastChannel is the native primitive. Total
+ * state surface = one integer. Zero infra.
+ */
+export function useDeckSync(initialIndex = 0) {
+  const [index, setIndexInternal] = useState(initialIndex)
+  const originRef = useRef<string>(`origin-${Math.random().toString(36).slice(2, 8)}`)
+  const channelRef = useRef<BroadcastChannel | null>(null)
+  const hydratedRef = useRef(false)
+
+  // Hydrate from storage on first mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored !== null) {
+        const parsed = parseInt(stored, 10)
+        if (!Number.isNaN(parsed)) setIndexInternal(parsed)
+      }
+    } catch {
+      /* localStorage disabled — fall back to in-memory only */
+    }
+    hydratedRef.current = true
+  }, [])
+
+  // Open BroadcastChannel + storage listener
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    if (typeof BroadcastChannel !== 'undefined') {
+      const channel = new BroadcastChannel(CHANNEL_NAME)
+      channel.onmessage = (event: MessageEvent<SyncMessage>) => {
+        // Ignore our own broadcasts
+        if (event.data.origin === originRef.current) return
+        setIndexInternal(event.data.index)
+      }
+      channelRef.current = channel
+    }
+
+    // Storage event fires when other tabs modify localStorage
+    function handleStorage(e: StorageEvent) {
+      if (e.key !== STORAGE_KEY || e.newValue === null) return
+      const parsed = parseInt(e.newValue, 10)
+      if (!Number.isNaN(parsed)) setIndexInternal(parsed)
+    }
+    window.addEventListener('storage', handleStorage)
+
+    return () => {
+      channelRef.current?.close()
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+
+  const setIndex = useCallback((next: number | ((prev: number) => number)) => {
+    setIndexInternal((prev) => {
+      const resolved = typeof next === 'function' ? next(prev) : next
+      // Broadcast + persist (do this in setter so we use the resolved value)
+      if (typeof window !== 'undefined') {
+        try {
+          localStorage.setItem(STORAGE_KEY, String(resolved))
+        } catch {
+          /* ignore */
+        }
+        if (channelRef.current) {
+          channelRef.current.postMessage({ index: resolved, origin: originRef.current })
+        }
+      }
+      return resolved
+    })
+  }, [])
+
+  return { index, setIndex, hydrated: hydratedRef.current }
+}

--- a/components/workshops/ikigai/AICompanions.tsx
+++ b/components/workshops/ikigai/AICompanions.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { ArrowUpRight, Sparkles } from 'lucide-react'
+
+interface Companion {
+  name: string
+  /** 1-2 character monogram glyph */
+  glyph: string
+  /** Brand accent color — tailwind class for both bg and border */
+  accent: 'emerald' | 'violet' | 'sky' | 'amber' | 'rose' | 'indigo' | 'cyan' | 'stone'
+  /** Strength in 2-3 words */
+  bestFor: string
+  /** Longer rationale */
+  why: string
+  /** Free tier? */
+  freeTier: boolean
+  url: string
+  tier: 'major' | 'secondary'
+}
+
+const COMPANIONS: Companion[] = [
+  // — Majors (the 5 every creator should know) —
+  {
+    name: 'ChatGPT',
+    glyph: 'G',
+    accent: 'emerald',
+    bestFor: 'General-purpose default',
+    why: '200M+ weekly actives. Strongest brand awareness. Voice, image, search built in. Best free tier for casual creators.',
+    freeTier: true,
+    url: 'https://chat.openai.com',
+    tier: 'major',
+  },
+  {
+    name: 'Claude',
+    glyph: 'C',
+    accent: 'amber',
+    bestFor: 'Long reasoning + code',
+    why: 'Anthropic Series F at $183B valuation. Best long-context (200K+ tokens). Cleanest voice for long-form writing. Cowork mode is the killer feature.',
+    freeTier: true,
+    url: 'https://claude.ai',
+    tier: 'major',
+  },
+  {
+    name: 'Gemini',
+    glyph: 'G',
+    accent: 'sky',
+    bestFor: 'Google ecosystem',
+    why: 'Native Workspace integration (Docs, Sheets, Gmail). 1M+ token context. Best free model for image + multimodal. Deep Google Search grounding.',
+    freeTier: true,
+    url: 'https://gemini.google.com',
+    tier: 'major',
+  },
+  {
+    name: 'Grok',
+    glyph: 'X',
+    accent: 'stone',
+    bestFor: 'Real-time X / news',
+    why: 'xAI native to X. Best for current events, trend analysis, live data. Less filtered tone. Strong for opinionated takes.',
+    freeTier: true,
+    url: 'https://grok.com',
+    tier: 'major',
+  },
+  {
+    name: 'Perplexity',
+    glyph: 'P',
+    accent: 'cyan',
+    bestFor: 'Research with citations',
+    why: 'Search-native AI. Every answer cites sources you can audit. Best for fact-checking, market scans, and competitive intel. Pro tier unlocks Claude + GPT.',
+    freeTier: true,
+    url: 'https://perplexity.ai',
+    tier: 'major',
+  },
+  // — Secondary (specialists worth knowing) —
+  {
+    name: 'NotebookLM',
+    glyph: 'NB',
+    accent: 'indigo',
+    bestFor: 'Source synthesis',
+    why: 'Google research lab tool. Drop 10 docs/PDFs/URLs, get audio overview + Q&A grounded in your sources. Best for research consolidation.',
+    freeTier: true,
+    url: 'https://notebooklm.google.com',
+    tier: 'secondary',
+  },
+  {
+    name: 'Le Chat',
+    glyph: 'LC',
+    accent: 'rose',
+    bestFor: 'EU-sovereign AI',
+    why: 'Mistral, French. Best for teams with EU data-residency requirements. Strong on European languages. Open-weights option.',
+    freeTier: true,
+    url: 'https://chat.mistral.ai',
+    tier: 'secondary',
+  },
+  {
+    name: 'Cursor',
+    glyph: '⌘',
+    accent: 'violet',
+    bestFor: 'AI-native coding',
+    why: 'For creators who code: VS Code fork with Claude + GPT in the editor. Composer mode replaces 70% of solo coding. Required if you build products.',
+    freeTier: true,
+    url: 'https://cursor.com',
+    tier: 'secondary',
+  },
+  {
+    name: 'Lovable',
+    glyph: 'L',
+    accent: 'rose',
+    bestFor: 'No-code product MVP',
+    why: 'Type-to-build full-stack web apps. Best for creators shipping their first product without engineers. Outputs real React + Supabase.',
+    freeTier: true,
+    url: 'https://lovable.dev',
+    tier: 'secondary',
+  },
+  {
+    name: 'ElevenLabs',
+    glyph: '11',
+    accent: 'stone',
+    bestFor: 'Voice cloning + TTS',
+    why: 'Industry-grade voice synthesis. Clone your voice once, generate narration for shorts / audiobooks / podcasts. Multilingual.',
+    freeTier: true,
+    url: 'https://elevenlabs.io',
+    tier: 'secondary',
+  },
+]
+
+const ACCENT_MAP = {
+  emerald: { bg: 'bg-emerald-500/[0.08]', border: 'border-emerald-500/30', text: 'text-emerald-300', glow: 'shadow-emerald-500/[0.15]' },
+  violet: { bg: 'bg-violet-500/[0.08]', border: 'border-violet-500/30', text: 'text-violet-300', glow: 'shadow-violet-500/[0.15]' },
+  sky: { bg: 'bg-sky-500/[0.08]', border: 'border-sky-500/30', text: 'text-sky-300', glow: 'shadow-sky-500/[0.15]' },
+  amber: { bg: 'bg-amber-500/[0.08]', border: 'border-amber-500/30', text: 'text-amber-300', glow: 'shadow-amber-500/[0.15]' },
+  rose: { bg: 'bg-rose-500/[0.08]', border: 'border-rose-500/30', text: 'text-rose-300', glow: 'shadow-rose-500/[0.15]' },
+  indigo: { bg: 'bg-indigo-500/[0.08]', border: 'border-indigo-500/30', text: 'text-indigo-300', glow: 'shadow-indigo-500/[0.15]' },
+  cyan: { bg: 'bg-cyan-500/[0.08]', border: 'border-cyan-500/30', text: 'text-cyan-300', glow: 'shadow-cyan-500/[0.15]' },
+  stone: { bg: 'bg-stone-500/[0.08]', border: 'border-stone-500/30', text: 'text-stone-300', glow: 'shadow-stone-500/[0.15]' },
+} as const
+
+export function AICompanions() {
+  const majors = COMPANIONS.filter((c) => c.tier === 'major')
+  const secondary = COMPANIONS.filter((c) => c.tier === 'secondary')
+
+  return (
+    <div id="ai-companions" className="space-y-6">
+      {/* Majors */}
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.015] p-6 sm:p-8">
+        <div className="mb-5 flex items-baseline justify-between flex-wrap gap-2">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-1.5 flex items-center gap-1.5">
+              <Sparkles className="w-3.5 h-3.5" />
+              The five AI companions every creator should know
+            </p>
+            <h3 className="text-xl sm:text-2xl font-semibold text-white tracking-tight">
+              Pick one. Master it. Add the next when the first fails you twice.
+            </h3>
+          </div>
+          <p className="text-xs text-zinc-500">Last refresh · 2026-05</p>
+        </div>
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-5 gap-3">
+          {majors.map((c) => (
+            <CompanionCard key={c.name} companion={c} large />
+          ))}
+        </div>
+      </div>
+
+      {/* Secondary */}
+      <div className="rounded-3xl border border-white/[0.08] bg-white/[0.015] p-6 sm:p-8">
+        <div className="mb-5">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-400 mb-1.5">
+            Specialists worth knowing
+          </p>
+          <h3 className="text-lg sm:text-xl font-semibold text-white tracking-tight">
+            Add these when the job specifically demands them
+          </h3>
+        </div>
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-5 gap-3">
+          {secondary.map((c) => (
+            <CompanionCard key={c.name} companion={c} large={false} />
+          ))}
+        </div>
+      </div>
+
+      {/* Discipline note */}
+      <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] p-5 sm:p-6">
+        <p className="text-sm text-emerald-200 leading-relaxed">
+          <span className="font-semibold">The trap:</span> subscribing to all five.
+          Most creators run 3+ AI tabs and use one. The compounding skill is{' '}
+          <span className="text-white">prompt mastery on one model</span> — not
+          tool-juggling. The model you actually open daily beats the model with
+          better benchmarks.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function CompanionCard({ companion, large }: { companion: Companion; large: boolean }) {
+  const c = ACCENT_MAP[companion.accent]
+
+  return (
+    <a
+      href={companion.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`group relative block rounded-2xl border ${c.border} ${c.bg} p-4 hover:shadow-lg ${c.glow} transition-all`}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div
+          className={`flex items-center justify-center rounded-xl border ${c.border} ${c.bg} font-bold ${c.text} ${
+            large ? 'w-10 h-10 text-base' : 'w-9 h-9 text-sm'
+          } tracking-tight`}
+        >
+          {companion.glyph}
+        </div>
+        <ArrowUpRight className="w-3.5 h-3.5 text-zinc-600 group-hover:text-zinc-300 transition-colors" />
+      </div>
+
+      <p className="font-semibold text-white text-sm mb-1">{companion.name}</p>
+      <p className={`text-xs ${c.text} mb-2 font-medium leading-snug`}>
+        {companion.bestFor}
+      </p>
+
+      {large && (
+        <p className="text-xs text-zinc-500 leading-relaxed mb-3">{companion.why}</p>
+      )}
+
+      <div className="flex items-center gap-1.5 mt-auto">
+        {companion.freeTier && (
+          <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-emerald-500/20 bg-emerald-500/[0.06] text-emerald-300">
+            Free tier
+          </span>
+        )}
+      </div>
+    </a>
+  )
+}

--- a/components/workshops/ikigai/AuthorityBar.tsx
+++ b/components/workshops/ikigai/AuthorityBar.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { ExternalLink, Quote } from 'lucide-react'
+import type { Citation } from '@/lib/workshop-citations'
+
+interface AuthorityBarProps {
+  citations: Citation[]
+  /** Optional eyebrow label above the citations row */
+  label?: string
+  /** Render style — `inline` for slot-into-module, `card` for standalone block */
+  variant?: 'inline' | 'card'
+}
+
+/**
+ * Tight, citation-grade authority row. Lists 2-3 hand-picked statistics
+ * with attributed sources. No fabricated numbers — every entry is
+ * sourced via `lib/workshop-citations.ts`.
+ *
+ * Pattern: discipline is name-the-source-in-the-same-breath. Generic
+ * "studies show" reads as AI-slop. "McKinsey State of AI 2026, n=1,500
+ * organizations" reads as research.
+ */
+export function AuthorityBar({
+  citations,
+  label = 'Why this matters',
+  variant = 'inline',
+}: AuthorityBarProps) {
+  if (!citations.length) return null
+
+  const containerClass =
+    variant === 'card'
+      ? 'rounded-3xl border border-amber-500/15 bg-gradient-to-br from-amber-500/[0.03] to-violet-500/[0.03] p-6 sm:p-7'
+      : 'rounded-2xl border border-white/[0.06] bg-white/[0.015] p-5'
+
+  return (
+    <div className={containerClass}>
+      <div className="flex items-center gap-2 mb-4">
+        <Quote className="w-3.5 h-3.5 text-amber-400" strokeWidth={2.5} />
+        <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-amber-400">
+          {label}
+        </p>
+      </div>
+
+      <div className="grid sm:grid-cols-3 gap-4">
+        {citations.map((c, i) => {
+          const inner = (
+            <>
+              <div className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-1.5 tabular-nums">
+                {c.stat}
+              </div>
+              <p className="text-xs text-zinc-400 leading-snug mb-2">{c.claim}</p>
+              <p className="text-[10px] text-zinc-500 flex items-center gap-1 uppercase tracking-wider">
+                <span className="text-zinc-600">—</span>
+                <span>
+                  {c.source} <span className="text-zinc-600">·</span> {c.year}
+                </span>
+                {c.url && <ExternalLink className="w-2.5 h-2.5 ml-0.5 text-zinc-600" />}
+              </p>
+            </>
+          )
+
+          return c.url ? (
+            <a
+              key={i}
+              href={c.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block border-l border-white/[0.06] pl-4 first:border-l-0 first:pl-0 hover:border-amber-400/30 transition-colors"
+            >
+              {inner}
+            </a>
+          ) : (
+            <div
+              key={i}
+              className="block border-l border-white/[0.06] pl-4 first:border-l-0 first:pl-0"
+            >
+              {inner}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/workshops/ikigai/LiveArtifact.tsx
+++ b/components/workshops/ikigai/LiveArtifact.tsx
@@ -12,6 +12,11 @@ interface LiveArtifactProps {
 export function LiveArtifact({ embedUrl, posterSrc }: LiveArtifactProps) {
   const hasVideo = Boolean(embedUrl)
 
+  // Don't render the section when there's no video — empty placeholder on a
+  // public page reads as unfinished work. Section is gated upstream too via
+  // LIVE_ARTIFACT_URL constant in app/workshops/ikigai-branding/page.tsx.
+  if (!hasVideo) return null
+
   return (
     <div id="live-artifact" className="space-y-6">
       <div className="rounded-3xl border border-white/[0.08] bg-white/[0.02] overflow-hidden">

--- a/lib/workshop-citations.ts
+++ b/lib/workshop-citations.ts
@@ -1,0 +1,114 @@
+/**
+ * Curated, sourced citations for the Ikigai & Branding Workshop.
+ *
+ * Each entry pairs a workshop claim with a primary source and a year.
+ * Drawn from `lib/research/validated-claims.ts` where possible and
+ * extended with public-domain figures (Goldman Sachs creator-economy,
+ * Edelman Trust Barometer, Richard van der Blom LinkedIn algo report,
+ * Justin Welsh public revenue, OpenAI/Anthropic adoption).
+ *
+ * Discipline: name the source in the same breath as the claim, or
+ * don't make the claim. Numbers without sources are slop.
+ */
+
+export interface Citation {
+  /** Short headline statistic, e.g. "$2,084B by 2035" */
+  stat: string
+  /** What the stat is about, e.g. "Creator economy market size" */
+  claim: string
+  /** Primary source publisher */
+  source: string
+  /** Year of publication */
+  year: string
+  /** Optional URL — leave undefined to print as text-only attribution */
+  url?: string
+}
+
+/**
+ * Module 4: Content Operating Plan — the LinkedIn + creator-economy authority.
+ */
+export const MODULE_4_CITATIONS: Citation[] = [
+  {
+    stat: '$2.08T',
+    claim: 'Creator economy market projection by 2035',
+    source: 'Precedence Research',
+    year: '2025',
+    url: 'https://www.precedenceresearch.com/creator-economy-market',
+  },
+  {
+    stat: '50M+',
+    claim: 'Self-identified creators globally today',
+    source: 'IAB Creator Economy Report',
+    year: '2025',
+  },
+  {
+    stat: '86%',
+    claim: 'Creative professionals using AI daily',
+    source: 'eMarketer Creator FAQ',
+    year: '2026',
+    url: 'https://www.emarketer.com/content/faq-on-creator-economy--how-marketers-stand-2026-',
+  },
+]
+
+/**
+ * Module 5: GenCreator Stack + AI Companions — the AI adoption authority.
+ */
+export const MODULE_5_CITATIONS: Citation[] = [
+  {
+    stat: '90%',
+    claim: 'Organizations using AI regularly',
+    source: 'McKinsey State of AI',
+    year: '2026',
+    url: 'https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai',
+  },
+  {
+    stat: '$183B',
+    claim: 'Anthropic valuation (Series F)',
+    source: 'Industry filings',
+    year: '2025',
+  },
+  {
+    stat: '40%',
+    claim: 'Enterprise apps with AI agents by 2026',
+    source: 'Gartner Strategic Predictions',
+    year: '2025',
+    url: 'https://www.gartner.com/en/newsroom',
+  },
+]
+
+/**
+ * Module 6: Live Artifact — AI-augmented creator output evidence.
+ */
+export const MODULE_6_CITATIONS: Citation[] = [
+  {
+    stat: '3-5×',
+    claim: 'Content output gain for creators with AI workflows',
+    source: 'GlobeNewswire creator-economy market report',
+    year: '2025',
+    url: 'https://www.globenewswire.com/news-release/2026/01/07/3214698/28124/en/',
+  },
+  {
+    stat: '$7.84B → $52.62B',
+    claim: 'AI agents market: 2025 → 2030 projection',
+    source: 'MarketsAndMarkets',
+    year: '2025',
+    url: 'https://www.marketsandmarkets.com/Market-Reports/ai-agents-market-15761548.html',
+  },
+]
+
+/**
+ * Frank's positioning credentials — used in the Why-Listen slide and
+ * the cover credential line. Edit here to update once, propagate
+ * to deck + workshop page.
+ */
+export const FRANK_CREDENTIALS = {
+  role: 'AI Architect',
+  org: 'Oracle EMEA AI Center of Excellence',
+  catalog: '12,000+ AI-produced tracks',
+  site: 'frankx.ai',
+  proofPoints: [
+    'Designs CoE frameworks for Fortune 500 enterprises',
+    'Same patterns open-sourced for individual creators',
+    'Multi-pillar operating system: SIS · ACOS · IIS · Workshop OS · Library OS',
+  ],
+} as const


### PR DESCRIPTION
## Summary
World-class polish pass on the Ikigai workshop ahead of NL Digital (2026-05-19) and Madrid (2026-05-27) deliveries. Addresses every gap surfaced in trial-run feedback.

### Fullscreen UX (P0)
- `document.fullscreenElement` watcher hides chrome (header, footer HUD, progress bar)
- Reveals on mousemove/keydown, fades after 2.5s idle
- Cursor hidden in fullscreen until user moves
- Cinema-grade: no more "Notion template in fullscreen" feel

### Dual-screen speaker view (P0)
- New route: `/workshops/ikigai-branding/present/speaker`
- Shows current slide + next slide preview, full speaker notes, big timer, per-slide timer
- Per-slide timer goes **red** when over target minutes
- Syncs across windows via `BroadcastChannel('ikigai-deck')` + `localStorage` fallback
- Workflow: open both windows, drag `/present` to projector + hit F, keep `/present/speaker` on laptop

### Authority layer (P0)
- New `AuthorityBar` component with real cited statistics
- New `lib/workshop-citations.ts` with curated sources
- **Module 4** stats: Precedence Research \$2.08T creator economy by 2035 · IAB 50M+ creators · eMarketer 86% AI daily
- **Module 5** stats: McKinsey 90% orgs using AI · Anthropic \$183B valuation · Gartner 40% enterprise apps with AI agents by 2026
- Every number has source name + year + (optional) primary URL

### AI Companions grid (P0)
- New `AICompanions` component
- **5 majors:** ChatGPT, Claude, Gemini, Grok, Perplexity — with brand-color accent, monogram glyph, "best for" one-liner, free-tier badge
- **5 specialists:** NotebookLM, Le Chat (Mistral), Cursor, Lovable, ElevenLabs
- Discipline note: "subscribe to all five is the trap"

### Slide deck upgrades (P0)
- Cover slide: large serif headline (Source Serif 4 fallback), gradient text, credential line "Frank Riemer · AI Architect · Oracle EMEA AI CoE"
- New "Why listen" slide (#1) — 3 promises + credential card with proof points
- New authority slides for Module 4 + Module 5 with citation cards
- Total: 15 slides (was 13)

### Gated LiveArtifact (P0)
- `LiveArtifact` returns null when `embedUrl` empty
- Module 6 section wrapper also gated via `LIVE_ARTIFACT_URL` constant in `page.tsx`
- No empty placeholders on public surface — Frank flips the constant after recording Loom

## Files (10)
\`app/workshops/ikigai-branding/page.tsx\`
\`app/workshops/ikigai-branding/present/{page,slides,use-deck-sync}.tsx\`
\`app/workshops/ikigai-branding/present/speaker/{page,layout}.tsx\`
\`components/workshops/ikigai/{LiveArtifact,AuthorityBar,AICompanions}.tsx\`
\`lib/workshop-citations.ts\`

## Test plan
- [ ] `/workshops/ikigai-branding` renders 5 modules (1·2·3·4·5 + 7), Module 6 hidden
- [ ] AuthorityBar shows above Modules 4 + 5 with cited stats
- [ ] AICompanions grid shows 5 majors + 5 specialists
- [ ] `/workshops/ikigai-branding/present` cover slide has serif typography + credential line
- [ ] Slide #1 is "Why listen" with credential card
- [ ] Press F → chrome disappears, F again → chrome returns
- [ ] Mousemove in fullscreen reveals chrome for 2.5s then fades
- [ ] Open `/present/speaker` in new tab, advance with → → both windows update

## Followups
- Wire real Notion + Sheet template URLs
- Frank records 90s Claude Cowork Loom, flips `LIVE_ARTIFACT_URL`

🤖 Source: FrankX feature/ikigai-presenter-and-modules (continuation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added presenter fullscreen mode with auto-hiding controls and keyboard shortcuts.
* Added dedicated speaker view with dual-screen support, displaying current/next slides, speaker notes, and integrated timer controls (play, pause, reset).
* Implemented slide synchronization across presenter and speaker windows using local state sharing.
* Added AI Companions section showcasing recommended tools.
* Integrated authority citations and credibility bars into workshop modules.

## Changes
* Enhanced presenter controls and navigation interface.
* Updated module layout and conditional visibility for workshop artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankxai/frankx.ai-vercel-website/pull/65)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->