### PR TITLE
feat(workshops/ikigai): mobile presenter UX + browser-agent surface

### DIFF
--- a/app/api/workshops/ikigai-branding/prompts.json/route.ts
+++ b/app/api/workshops/ikigai-branding/prompts.json/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Public JSON endpoint exposing the Ikigai workshop prompt library.
+ *
+ * Designed for browser agents (Perplexity Comet, OpenAI Operator,
+ * Anthropic Computer Use, Arc Search "Browse for me") and any other
+ * automation that wants to run the workshop programmatically.
+ *
+ * Discovery:
+ *   GET https://frankx.ai/api/workshops/ikigai-branding/prompts.json
+ *
+ * Returns:
+ *   - Workshop metadata (title, url, facilitator)
+ *   - All 6 prompts with full body + chain instructions
+ *   - Connector setup paths (ChatGPT native / Claude MCP / CSV)
+ *   - License: CC BY 4.0
+ */
+
+import { WORKSHOP_PROMPTS, CONNECTOR_PATHS } from '@/lib/workshop-prompts'
+import { FRANK_CREDENTIALS, FRANK_RECEIPTS } from '@/lib/workshop-citations'
+
+// Static — regenerated at build time, served from CDN edge.
+export const dynamic = 'force-static'
+
+export function GET() {
+  return Response.json(
+    {
+      schemaVersion: '1',
+      workshop: {
+        slug: 'ikigai-branding',
+        title: 'Ikigai & Branding Workshop',
+        subtitle:
+          'Find your purpose, turn it into a brand, ship a 30-day content plan.',
+        url: 'https://frankx.ai/workshops/ikigai-branding',
+        presentUrl: 'https://frankx.ai/workshops/ikigai-branding/present',
+        durationMinutes: 75,
+        difficulty: 'Beginner',
+      },
+      facilitator: {
+        name: 'Frank Riemer',
+        role: FRANK_CREDENTIALS.role,
+        org: FRANK_CREDENTIALS.org,
+        site: 'https://frankx.ai',
+        receipts: FRANK_RECEIPTS,
+      },
+      prompts: WORKSHOP_PROMPTS.map((p) => ({
+        id: p.id,
+        module: p.module,
+        title: p.title,
+        subtitle: p.subtitle,
+        body: p.body,
+        bestIn: p.bestIn,
+        outputHandling: p.outputHandling,
+        // Direct ChatGPT prefill URL — agents can deep-link here
+        chatgptUrl: `https://chatgpt.com/?q=${encodeURIComponent(p.body)}`,
+      })),
+      connectorPaths: CONNECTOR_PATHS,
+      license: 'CC BY 4.0',
+      attribution: 'Frank Riemer · frankx.ai · 2026',
+      contact: 'https://frankx.ai/contact',
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=300, s-maxage=3600',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      },
+    },
+  )
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Max-Age': '86400',
+    },
+  })
+}

--- a/app/workshops/ikigai-branding/page.tsx
+++ b/app/workshops/ikigai-branding/page.tsx
@@ -35,6 +35,7 @@ import { WORKSHOP_PROMPTS } from '@/lib/workshop-prompts'
 import { emptyIkigai, type IkigaiState } from '@/components/workshops/ikigai/types'
 import { getWorkshopBySlug } from '@/data/workshops'
 import { MODULE_4_CITATIONS, MODULE_5_CITATIONS } from '@/lib/workshop-citations'
+import { WORKSHOP_PROMPTS as ALL_PROMPTS } from '@/lib/workshop-prompts'
 
 // Update this when Frank records the Claude Cowork demo. When empty, the
 // Module 6 section is hidden entirely (no empty placeholder on a public page).
@@ -54,26 +55,58 @@ const PRESENTER_SECTIONS = [
 function CourseSchema() {
   const ld = JSON.stringify({
     '@context': 'https://schema.org',
-    '@type': 'Course',
-    name: 'Ikigai & Branding Workshop',
-    description:
-      'Interactive, coach-guided workshop. Map your Ikigai, write your purpose statement, translate it into a brand positioning, and ship a 30-day content plan across LinkedIn + newsletter + video.',
-    url: 'https://frankx.ai/workshops/ikigai-branding',
-    provider: {
-      '@type': 'Person',
-      name: 'Frank Riemer',
-      url: 'https://frankx.ai',
-      jobTitle: 'AI Architect',
-    },
-    educationalLevel: 'Beginner',
-    timeRequired: 'PT75M',
-    numberOfCredits: 7,
-    isAccessibleForFree: true,
-    hasCourseInstance: {
-      '@type': 'CourseInstance',
-      courseMode: 'online',
-      courseWorkload: 'PT75M',
-    },
+    '@graph': [
+      {
+        '@type': 'Course',
+        '@id': 'https://frankx.ai/workshops/ikigai-branding#course',
+        name: 'Ikigai & Branding Workshop',
+        description:
+          'Interactive, coach-guided workshop. Map your Ikigai, write your purpose statement, translate it into a brand positioning, and ship a 30-day content plan across LinkedIn + newsletter + video.',
+        url: 'https://frankx.ai/workshops/ikigai-branding',
+        provider: {
+          '@type': 'Person',
+          name: 'Frank Riemer',
+          url: 'https://frankx.ai',
+          jobTitle: 'AI Architect',
+        },
+        educationalLevel: 'Beginner',
+        timeRequired: 'PT75M',
+        numberOfCredits: 7,
+        isAccessibleForFree: true,
+        hasCourseInstance: {
+          '@type': 'CourseInstance',
+          courseMode: 'online',
+          courseWorkload: 'PT75M',
+        },
+      },
+      {
+        // HowTo schema — agent-readable instructions for running the
+        // workshop programmatically. Browser agents (Comet, Operator)
+        // can parse this to execute the workshop on the user's behalf.
+        '@type': 'HowTo',
+        '@id': 'https://frankx.ai/workshops/ikigai-branding#howto',
+        name: 'Run the Ikigai & Branding Workshop',
+        description:
+          'Six prompts, paste-and-run, that turn an attendee from cold open to shipped 30-day plan. Each prompt works in ChatGPT, Claude, or Gemini.',
+        totalTime: 'PT75M',
+        tool: ['ChatGPT', 'Claude', 'Gemini'],
+        supply: [
+          { '@type': 'HowToSupply', name: 'A favorite AI assistant account' },
+          { '@type': 'HowToSupply', name: 'Notion, Google Sheets, or a CSV-capable tool' },
+        ],
+        step: ALL_PROMPTS.map((p, i) => ({
+          '@type': 'HowToStep',
+          position: i + 1,
+          name: `Module ${p.module}: ${p.title}`,
+          text: p.subtitle,
+          url: `https://frankx.ai/workshops/ikigai-branding#prompt-${p.id}`,
+          itemListElement: {
+            '@type': 'HowToDirection',
+            text: p.body.slice(0, 280) + '…',
+          },
+        })),
+      },
+    ],
   })
   return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ld }} />
 }

--- a/app/workshops/ikigai-branding/present/page.tsx
+++ b/app/workshops/ikigai-branding/present/page.tsx
@@ -42,6 +42,8 @@ export default function IkigaiPresentPage() {
   const startRef = useRef<number>(Date.now())
   const tickRef = useRef<number | null>(null)
   const chromeTimerRef = useRef<number | null>(null)
+  const touchStartXRef = useRef<number | null>(null)
+  const touchStartYRef = useRef<number | null>(null)
 
   const slide = SLIDES[index] ?? SLIDES[0]
   const total = SLIDES.length
@@ -149,11 +151,37 @@ export default function IkigaiPresentPage() {
 
   const progress = useMemo(() => ((index + 1) / total) * 100, [index, total])
 
+  // Touch handlers — mobile swipe navigation
+  function onTouchStart(e: React.TouchEvent) {
+    const t = e.touches[0]
+    touchStartXRef.current = t.clientX
+    touchStartYRef.current = t.clientY
+  }
+
+  function onTouchEnd(e: React.TouchEvent) {
+    if (touchStartXRef.current === null || touchStartYRef.current === null) return
+    const t = e.changedTouches[0]
+    const dx = t.clientX - touchStartXRef.current
+    const dy = t.clientY - touchStartYRef.current
+    touchStartXRef.current = null
+    touchStartYRef.current = null
+    // Ignore short or vertical-dominant swipes (so scrolling still works)
+    if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return
+    if (dx < 0) next()
+    else prev()
+  }
+
   return (
     <div
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
       className={`fixed inset-0 bg-[#0a0a0b] text-white overflow-hidden ${
         isFullscreen ? 'cursor-none' : ''
       } ${chromeVisible ? '!cursor-default' : ''}`}
+      data-workshop-deck="ikigai-branding"
+      data-slide-index={index}
+      data-slide-id={slide.id}
+      data-slide-total={total}
     >
       {/* Backdrop gradients */}
       <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.04] via-transparent to-amber-500/[0.03] pointer-events-none" />
@@ -217,7 +245,28 @@ export default function IkigaiPresentPage() {
         </AnimatePresence>
 
         {/* Slide content */}
-        <div className="flex-1 flex items-center justify-center px-8 py-8 overflow-hidden">
+        <div className="flex-1 flex items-center justify-center px-4 sm:px-6 lg:px-8 py-8 overflow-hidden relative">
+          {/* Mobile tap zones — visible only when chrome hidden (fullscreen).
+              On windowed mode the footer buttons handle navigation. */}
+          {isFullscreen && !chromeVisible && (
+            <>
+              <button
+                onClick={prev}
+                aria-label="Previous slide"
+                className="absolute inset-y-0 left-0 w-1/3 z-10 cursor-default"
+              />
+              <button
+                onClick={next}
+                aria-label="Next slide"
+                className="absolute inset-y-0 right-0 w-1/3 z-10 cursor-default"
+              />
+              <button
+                onClick={() => setChromeVisible(true)}
+                aria-label="Show controls"
+                className="absolute inset-y-0 left-1/3 right-1/3 z-10 cursor-default"
+              />
+            </>
+          )}
           <AnimatePresence mode="wait">
             <motion.div
               key={slide.id}
@@ -225,7 +274,7 @@ export default function IkigaiPresentPage() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -16 }}
               transition={{ duration: 0.3 }}
-              className="w-full max-w-6xl mx-auto"
+              className="w-full max-w-6xl mx-auto relative z-20 pointer-events-none [&_a]:pointer-events-auto [&_button]:pointer-events-auto [&_iframe]:pointer-events-auto"
             >
               {slide.eyebrow && (
                 <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-3">
@@ -233,7 +282,7 @@ export default function IkigaiPresentPage() {
                 </p>
               )}
               {slide.id !== 'cover' && (
-                <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white tracking-tight mb-10 max-w-4xl">
+                <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-white tracking-tight mb-6 sm:mb-10 max-w-4xl">
                   {slide.title}
                 </h2>
               )}

--- a/app/workshops/ikigai-branding/present/slides.tsx
+++ b/app/workshops/ikigai-branding/present/slides.tsx
@@ -69,14 +69,14 @@ export const SLIDES: SlideDef[] = [
       'BRIDGE · "Before we start — why this room, why this hour. Three minutes."',
     ],
     body: () => (
-      <div className="text-center space-y-10 max-w-5xl mx-auto">
+      <div className="text-center space-y-6 sm:space-y-10 max-w-5xl mx-auto px-2">
         <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border border-violet-500/20 bg-violet-500/[0.06] text-[10px] font-medium text-violet-300 uppercase tracking-[0.18em]">
           <Compass className="w-3 h-3" />
           A 75-minute workshop
         </div>
         <div className="space-y-2">
           <h1
-            className="text-7xl sm:text-8xl lg:text-9xl font-bold tracking-tighter leading-[0.95]"
+            className="text-5xl sm:text-7xl lg:text-8xl xl:text-9xl font-bold tracking-tighter leading-[0.95]"
             style={{ fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif' }}
           >
             <span className="text-white">Ikigai </span>
@@ -86,11 +86,11 @@ export const SLIDES: SlideDef[] = [
             </span>
           </h1>
         </div>
-        <p className="text-xl sm:text-2xl text-zinc-400 max-w-3xl mx-auto leading-relaxed font-light">
+        <p className="text-base sm:text-xl lg:text-2xl text-zinc-400 max-w-3xl mx-auto leading-relaxed font-light">
           Find what makes time disappear. Translate it into a brand the world remembers.
           Ship the plan before you leave the room.
         </p>
-        <div className="pt-12 text-sm text-zinc-500 tracking-wide flex items-center justify-center gap-3 flex-wrap">
+        <div className="pt-6 sm:pt-12 text-xs sm:text-sm text-zinc-500 tracking-wide flex items-center justify-center gap-2 sm:gap-3 flex-wrap">
           <span className="text-zinc-300 font-medium">Frank Riemer</span>
           <span className="text-zinc-700">·</span>
           <span>{FRANK_CREDENTIALS.role}, {FRANK_CREDENTIALS.org}</span>
@@ -698,7 +698,7 @@ export const SLIDES: SlideDef[] = [
           If you remember nothing else, remember this
         </p>
         <h2
-          className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white leading-tight tracking-tight"
+          className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight tracking-tight"
           style={{ fontFamily: '"Source Serif 4", "Source Serif Pro", Georgia, serif' }}
         >
           Your purpose is not in your head.

--- a/components/workshops/ikigai/PromptCard.tsx
+++ b/components/workshops/ikigai/PromptCard.tsx
@@ -70,7 +70,12 @@ export function PromptCard({ prompt }: PromptCardProps) {
   }
 
   return (
-    <div className="rounded-3xl border border-violet-500/20 bg-gradient-to-br from-violet-500/[0.04] via-white/[0.02] to-amber-500/[0.03] overflow-hidden">
+    <div
+      className="rounded-3xl border border-violet-500/20 bg-gradient-to-br from-violet-500/[0.04] via-white/[0.02] to-amber-500/[0.03] overflow-hidden"
+      data-workshop-prompt={prompt.id}
+      data-workshop-module={prompt.module}
+      data-workshop-prompt-title={prompt.title}
+    >
       {/* Header */}
       <div className="px-5 sm:px-6 pt-5 sm:pt-6 pb-4 border-b border-white/[0.04]">
         <div className="flex items-center gap-2 mb-2">
@@ -85,10 +90,15 @@ export function PromptCard({ prompt }: PromptCardProps) {
         <p className="text-sm text-zinc-400 leading-relaxed">{prompt.subtitle}</p>
       </div>
 
-      {/* Prompt body — scrollable, mono, readable on mobile */}
+      {/* Prompt body — scrollable, mono, readable on mobile. The
+          data-workshop-prompt-body attribute exposes the prompt text
+          to browser agents (Comet, Operator, Computer Use). */}
       <div className="relative">
         <div className="max-h-64 sm:max-h-72 overflow-y-auto p-4 sm:p-5 bg-[#0a0a0b]/40">
-          <pre className="text-[11px] sm:text-[13px] text-zinc-300 leading-relaxed font-mono whitespace-pre-wrap break-words">
+          <pre
+            data-workshop-prompt-body={prompt.id}
+            className="text-[11px] sm:text-[13px] text-zinc-300 leading-relaxed font-mono whitespace-pre-wrap break-words"
+          >
             {prompt.body}
           </pre>
         </div>


### PR DESCRIPTION
## Summary
Two upgrades, one PR.

### Mobile presenter UX
- **Swipe gestures** on /present — left/right navigates, 60px threshold, horizontal-dominant so vertical scroll still works
- **Tap zones** in fullscreen + chrome-hidden mode — left third = prev, right third = next, middle = show chrome. Slide-content links/buttons still work via `pointer-events-auto` whitelist
- **Responsive typography** — cover slide scales text-5xl → text-7xl → text-8xl → text-9xl across breakpoints; Why-Listen and Remember-this titles also scaled

### Browser-agent surface
- **Public JSON endpoint** at `/api/workshops/ikigai-branding/prompts.json` — workshop metadata + 6 prompts + connector paths + license. CORS enabled. Designed for Perplexity Comet, OpenAI Operator, Anthropic Computer Use, Arc "Browse for me"
- **HowTo schema.org JSON-LD** alongside existing Course schema — each prompt is a HowToStep with deep-link anchor
- **data-* attributes** on PromptCard: `data-workshop-prompt` + `data-workshop-module` + `data-workshop-prompt-body` so agents can `document.querySelector('[data-workshop-prompt="generate-30-day-csv"]')`
- **data-workshop-deck** + `data-slide-index` + `data-slide-id` on /present root — agents can read deck state

## Why this matters
Browser agents are the emerging surface. When attendees use Comet, Operator, or Computer Use, the workshop page needs to be *legible to the agent*, not just to the human. Structured JSON + HowTo + targetable attributes mean an agent can delegate "go run the Ikigai workshop for me" successfully.

## Test plan
- [ ] `curl https://frankx.ai/api/workshops/ikigai-branding/prompts.json` returns valid JSON with 6 prompts
- [ ] View-source on `/workshops/ikigai-branding` shows HowTo @graph entry alongside Course
- [ ] DevTools → Elements → search `data-workshop-prompt` finds 6 entries
- [ ] Mobile: swipe left/right on /present advances slides
- [ ] Mobile: fullscreen + idle → tap left third = prev, right third = next
- [ ] Mobile: cover slide text fits without horizontal overflow

🤖 Ships on top of #67 (already merged to main)