### PR TITLE
feat(workshops/ikigai): UX polish — path orientation, progress rail, when-to-use AI guidance

### DIFF
--- a/app/workshops/ikigai-branding/page.tsx
+++ b/app/workshops/ikigai-branding/page.tsx
@@ -31,6 +31,8 @@ import { AICompanions } from '@/components/workshops/ikigai/AICompanions'
 import { CommonTraps } from '@/components/workshops/ikigai/CommonTraps'
 import { PromptStack } from '@/components/workshops/ikigai/PromptStack'
 import { AIConnectors } from '@/components/workshops/ikigai/AIConnectors'
+import { WorkshopPath } from '@/components/workshops/ikigai/WorkshopPath'
+import { WorkshopProgressRail } from '@/components/workshops/ikigai/WorkshopProgressRail'
 import { WORKSHOP_PROMPTS } from '@/lib/workshop-prompts'
 import { emptyIkigai, type IkigaiState } from '@/components/workshops/ikigai/types'
 import { getWorkshopBySlug } from '@/data/workshops'
@@ -126,6 +128,7 @@ export default function IkigaiBrandingWorkshopPage() {
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
       <CourseSchema />
+      <WorkshopProgressRail />
 
       {/* Hero */}
       <section id="intro" className="relative pt-28 pb-12 overflow-hidden scroll-mt-24">
@@ -171,7 +174,7 @@ export default function IkigaiBrandingWorkshopPage() {
                 Workshop
               </span>
             </h1>
-            <p className="text-lg text-zinc-400 mb-6 max-w-2xl">
+            <p className="text-lg text-zinc-400 mb-6 max-w-2xl leading-relaxed">
               {workshop.subtitle}.
             </p>
 
@@ -179,29 +182,59 @@ export default function IkigaiBrandingWorkshopPage() {
               {workshop.overview}
             </p>
 
-            <div className="mt-8 max-w-xl">
-              <CoachGPTCard />
+            {/* Primary CTA — for individuals */}
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Link
+                href="#start"
+                className="inline-flex items-center gap-2 px-5 py-3 rounded-lg text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-violet-600 hover:from-violet-400 hover:to-violet-500 transition-colors shadow-lg shadow-violet-500/20 cursor-pointer"
+              >
+                Start the workshop
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+              <a
+                href="/go/ikigai-coach"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 px-4 py-3 rounded-lg text-sm font-medium text-zinc-200 bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.08] hover:text-white transition-colors cursor-pointer"
+              >
+                Prefer a chat? Open Coach GPT
+              </a>
             </div>
 
-            {/* Presenter tools — visible to anyone, useful for facilitators */}
-            <div className="mt-4 flex flex-wrap items-center gap-2">
+            {/* Facilitator tools — small, secondary, separated */}
+            <div className="mt-5 pt-5 border-t border-white/[0.04] flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-zinc-500">
+              <span>Facilitating?</span>
               <Link
                 href="/workshops/ikigai-branding/present"
-                className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-xs font-medium text-zinc-300 bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.08] hover:text-white transition-colors"
+                className="inline-flex items-center gap-1.5 text-zinc-300 hover:text-violet-200 transition-colors cursor-pointer"
               >
                 <Presentation className="w-3.5 h-3.5" />
                 Open presenter mode
               </Link>
+              <span className="text-zinc-700">·</span>
               <button
                 onClick={() => setPresenterActive((v) => !v)}
-                className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-xs font-medium text-zinc-400 bg-white/[0.02] border border-white/[0.06] hover:bg-white/[0.06] hover:text-zinc-200 transition-colors"
+                className="text-zinc-400 hover:text-zinc-200 transition-colors cursor-pointer"
               >
                 {presenterActive ? 'Hide' : 'Show'} on-page HUD
               </button>
+              <span className="text-zinc-700">·</span>
+              <Link
+                href="/workshops/ikigai-branding/present/speaker"
+                target="_blank"
+                className="text-zinc-400 hover:text-zinc-200 transition-colors cursor-pointer"
+              >
+                Speaker view
+              </Link>
             </div>
           </motion.div>
         </div>
       </section>
+
+      {/* Path-selector — orient the three user types */}
+      <div id="start" className="scroll-mt-24">
+        <WorkshopPath />
+      </div>
 
       {/* Ikigai Venn — visual anchor */}
       <section className="pb-12">
@@ -254,7 +287,7 @@ export default function IkigaiBrandingWorkshopPage() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">
-              Module 1 · The Ikigai Map
+              Module 1 · The Ikigai Map · ~15 min
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight flex items-center gap-2">
               <Compass className="w-6 h-6 text-violet-300" />
@@ -295,7 +328,7 @@ export default function IkigaiBrandingWorkshopPage() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-amber-400 mb-2">
-              Module 2 · Purpose Statement
+              Module 2 · Purpose Statement · ~10 min
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
               Write the sentence
@@ -367,14 +400,14 @@ export default function IkigaiBrandingWorkshopPage() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">
-              Module 4 · Content Operating Plan
+              Module 4 · Content Operating Plan · ~12 min
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
               From positioning to publishing
             </h2>
-            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
-              The pillars tell you what to write about. This module gives you the patterns, the rhythm,
-              and the calendar so blank-page mornings end. Anchored to your three pillars from Module 3.
+            <p className="text-sm text-zinc-400 mt-2 max-w-2xl leading-relaxed">
+              Pillars tell you what to write. This module gives you the rhythm, the formats, and
+              the 30-day calendar — anchored to your Module 3 pillars. Monday&apos;s post written by Sunday night.
             </p>
           </div>
           <div className="mb-5">
@@ -412,14 +445,14 @@ export default function IkigaiBrandingWorkshopPage() {
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mb-6">
             <p className="text-xs font-medium uppercase tracking-wider text-sky-300 mb-2">
-              Module 5 · The Operating Stack
+              Module 5 · The Operating Stack · ~8 min
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
               Your AI companion. Then the 5-job stack.
             </h2>
-            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
-              Two layers. First the AI brain you actually think with. Then the four other jobs you run
-              every week. Opinionated, picked from the field, built to compound — not sprawl.
+            <p className="text-sm text-zinc-400 mt-2 max-w-2xl leading-relaxed">
+              First the AI you think with daily. Then the four other jobs every creator runs.
+              Opinionated, picked from the field, built to compound — not sprawl.
             </p>
           </div>
           <div className="mb-5">
@@ -468,7 +501,7 @@ export default function IkigaiBrandingWorkshopPage() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
           <div className="mb-2">
             <p className="text-xs font-medium uppercase tracking-wider text-emerald-400 mb-2">
-              Module 7 · Activation
+              Module 7 · Activation · ~5 min
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
               Ship the brand into reality

--- a/app/workshops/ikigai-branding/present/page.tsx
+++ b/app/workshops/ikigai-branding/present/page.tsx
@@ -438,6 +438,18 @@ export default function IkigaiPresentPage() {
       </AnimatePresence>
 
       <style jsx global>{`
+        html, body {
+          /* Prevent pull-to-refresh and bounce on mobile while in presenter mode */
+          overscroll-behavior: contain;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          /* Respect users who request reduced motion */
+          * {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0.01ms !important;
+          }
+        }
         @media print {
           html, body { background: white !important; color: black !important; }
           .fixed { position: static !important; }

--- a/components/workshops/ikigai/PromptCard.tsx
+++ b/components/workshops/ikigai/PromptCard.tsx
@@ -136,7 +136,7 @@ export function PromptCard({ prompt }: PromptCardProps) {
                 href={t.href(prompt.body)}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium border ${ACCENT_MAP[t.accent]} transition-colors`}
+                className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium border cursor-pointer ${ACCENT_MAP[t.accent]} transition-colors`}
                 title={t.note ? `Opens new chat — paste the copied prompt` : `Opens with prompt pre-filled`}
               >
                 <span className={`flex items-center justify-center w-6 h-6 rounded border ${ACCENT_MAP[t.accent]} font-bold text-[11px]`}>
@@ -147,6 +147,19 @@ export function PromptCard({ prompt }: PromptCardProps) {
                 <ExternalLink className="w-3 h-3 opacity-60 ml-0.5" />
               </a>
             ))}
+          </div>
+
+          {/* When-to-use-which guidance */}
+          <div className="mt-3 pt-3 border-t border-white/[0.04] grid grid-cols-1 sm:grid-cols-3 gap-x-3 gap-y-1.5 text-[11px] leading-snug">
+            <p className="text-zinc-400">
+              <span className="text-emerald-300 font-medium">ChatGPT</span> — opens with prompt prefilled. Best if you use Memory.
+            </p>
+            <p className="text-zinc-400">
+              <span className="text-amber-300 font-medium">Claude</span> — paste after open. Best for long, careful reasoning.
+            </p>
+            <p className="text-zinc-400">
+              <span className="text-sky-300 font-medium">Gemini</span> — paste after open. Best if you live in Google Workspace.
+            </p>
           </div>
         </div>
       </div>

--- a/components/workshops/ikigai/WorkshopPath.tsx
+++ b/components/workshops/ikigai/WorkshopPath.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import Link from 'next/link'
+import { Sparkles, Users, BookOpen, ArrowRight } from 'lucide-react'
+
+interface PathOption {
+  id: string
+  badge: string
+  title: string
+  subtitle: string
+  audience: string
+  cta: string
+  href: string
+  primary?: boolean
+  icon: typeof Sparkles
+  color: 'violet' | 'amber' | 'zinc'
+}
+
+const PATHS: PathOption[] = [
+  {
+    id: 'ai-native',
+    badge: 'Recommended',
+    title: 'Run it yourself with AI',
+    subtitle: 'Six prompts. Your favorite AI assistant. Forty-five focused minutes.',
+    audience: 'For self-serve attendees — paste each prompt into ChatGPT, Claude, or Gemini and ship.',
+    cta: 'Start the workshop',
+    href: '#module-1',
+    primary: true,
+    icon: Sparkles,
+    color: 'violet',
+  },
+  {
+    id: 'live-attendee',
+    badge: 'Live workshop',
+    title: 'Follow along with Frank',
+    subtitle: 'A facilitator runs the deck. You follow along on your phone.',
+    audience: 'For workshop attendees — open the prompts here, follow Frank\'s pace.',
+    cta: 'View the prompt library',
+    href: '#module-1',
+    icon: Users,
+    color: 'amber',
+  },
+  {
+    id: 'manual',
+    badge: 'No AI needed',
+    title: 'Use the manual wizards',
+    subtitle: 'Browser-based wizard for each module. Saves to your device.',
+    audience: 'For attendees without an AI subscription — every module has a manual fallback.',
+    cta: 'Open the wizards',
+    href: '#module-1',
+    icon: BookOpen,
+    color: 'zinc',
+  },
+]
+
+const COLOR_MAP = {
+  violet: {
+    border: 'border-violet-500/30',
+    bg: 'bg-gradient-to-br from-violet-500/[0.08] via-white/[0.02] to-amber-500/[0.04]',
+    badge: 'text-violet-300 bg-violet-500/[0.12] border-violet-500/30',
+    icon: 'text-violet-300 bg-violet-500/10 border-violet-500/30',
+    cta: 'bg-gradient-to-r from-violet-500 to-violet-600 hover:from-violet-400 hover:to-violet-500 text-white shadow-lg shadow-violet-500/20',
+  },
+  amber: {
+    border: 'border-amber-500/20',
+    bg: 'bg-white/[0.02]',
+    badge: 'text-amber-300 bg-amber-500/[0.08] border-amber-500/20',
+    icon: 'text-amber-300 bg-amber-500/10 border-amber-500/20',
+    cta: 'bg-white/[0.06] border border-white/[0.10] hover:bg-white/[0.10] text-zinc-200',
+  },
+  zinc: {
+    border: 'border-white/[0.08]',
+    bg: 'bg-white/[0.015]',
+    badge: 'text-zinc-400 bg-white/[0.04] border-white/[0.08]',
+    icon: 'text-zinc-300 bg-white/[0.04] border-white/[0.08]',
+    cta: 'bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.08] text-zinc-300',
+  },
+} as const
+
+/**
+ * Path-selector for the three user types that land on the workshop:
+ *   - Individual doing it self-serve with AI (default / recommended)
+ *   - Attendee at a live workshop following along
+ *   - Person without an AI subscription using manual wizards
+ *
+ * Lives right after the hero so visitors aren't dumped into a 7-module
+ * page without orientation. Each card anchor-links to #module-1 — the
+ * downstream sections serve all three audiences.
+ */
+export function WorkshopPath() {
+  return (
+    <section className="pb-12">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-violet-300 mb-1.5">
+            Pick your path
+          </p>
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
+            Three ways to run this workshop
+          </h2>
+          <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+            All three paths use the same prompt library below. Pick the one that matches how you want to work.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-4">
+          {PATHS.map((p) => {
+            const c = COLOR_MAP[p.color]
+            const Icon = p.icon
+            return (
+              <Link
+                key={p.id}
+                href={p.href}
+                className={`group block rounded-3xl border ${c.border} ${c.bg} p-6 cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-xl ${
+                  p.primary ? 'hover:shadow-violet-500/[0.15]' : 'hover:shadow-black/40'
+                }`}
+              >
+                <div className="flex items-center justify-between mb-4">
+                  <div className={`w-11 h-11 rounded-xl border flex items-center justify-center ${c.icon}`}>
+                    <Icon className="w-5 h-5" strokeWidth={2} />
+                  </div>
+                  <span className={`text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded border ${c.badge}`}>
+                    {p.badge}
+                  </span>
+                </div>
+                <h3 className="text-lg font-semibold text-white tracking-tight mb-2 leading-snug">
+                  {p.title}
+                </h3>
+                <p className="text-sm text-zinc-400 leading-relaxed mb-3">{p.subtitle}</p>
+                <p className="text-xs text-zinc-500 leading-relaxed mb-5">{p.audience}</p>
+                <div
+                  className={`inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-semibold transition-colors ${c.cta}`}
+                >
+                  {p.cta}
+                  <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/workshops/ikigai/WorkshopProgressRail.tsx
+++ b/components/workshops/ikigai/WorkshopProgressRail.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowRight, Sparkles } from 'lucide-react'
+
+interface ProgressSection {
+  id: string
+  label: string
+  minutes: number
+}
+
+const SECTIONS: ProgressSection[] = [
+  { id: 'module-1', label: 'Map', minutes: 15 },
+  { id: 'synthesis', label: 'Statement', minutes: 10 },
+  { id: 'brand-bridge', label: 'Brand', minutes: 10 },
+  { id: 'content-plan', label: 'Plan', minutes: 12 },
+  { id: 'gencreator-stack', label: 'Stack', minutes: 8 },
+  { id: 'activation', label: 'Ship', minutes: 5 },
+]
+
+/**
+ * Sticky progress rail that tracks which module the user is currently
+ * viewing. Activates after scrolling past the hero. Hides on print.
+ *
+ * UX intent: a 7-module page feels long. The rail makes progress
+ * legible — attendees see "you are on Map · 4 of 6 sections left" and
+ * the workshop feels finite instead of endless.
+ */
+export function WorkshopProgressRail() {
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    // Hide when hero is in view; show once scrolled past
+    const hero = document.getElementById('intro')
+    const heroObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => setVisible(!e.isIntersecting))
+      },
+      { threshold: 0.1 },
+    )
+    if (hero) heroObserver.observe(hero)
+
+    // Section tracking
+    const observers: IntersectionObserver[] = []
+    SECTIONS.forEach((s) => {
+      const el = document.getElementById(s.id)
+      if (!el) return
+      const o = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting && entry.intersectionRatio > 0.25) {
+              setActiveId(s.id)
+            }
+          })
+        },
+        { threshold: [0.25, 0.5] },
+      )
+      o.observe(el)
+      observers.push(o)
+    })
+
+    return () => {
+      heroObserver.disconnect()
+      observers.forEach((o) => o.disconnect())
+    }
+  }, [])
+
+  if (!visible) return null
+
+  const activeIndex = SECTIONS.findIndex((s) => s.id === activeId)
+  const safeIndex = activeIndex < 0 ? 0 : activeIndex
+  const progress = ((safeIndex + 1) / SECTIONS.length) * 100
+
+  return (
+    <div className="fixed top-4 inset-x-4 z-40 flex justify-center pointer-events-none print:hidden">
+      <div className="pointer-events-auto inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-white/[0.10] bg-[#0a0a0b]/85 backdrop-blur-xl shadow-2xl shadow-black/40">
+        <Sparkles className="w-3.5 h-3.5 text-violet-300 flex-shrink-0" />
+        <span className="text-xs font-medium text-white whitespace-nowrap">
+          {SECTIONS[safeIndex]?.label || 'Start'}
+        </span>
+        <span className="text-[10px] text-zinc-500 tabular-nums whitespace-nowrap">
+          · {safeIndex + 1}/{SECTIONS.length}
+        </span>
+        <div className="w-12 sm:w-20 h-1 rounded-full bg-white/[0.08] overflow-hidden flex-shrink-0">
+          <div
+            className="h-full bg-gradient-to-r from-violet-400 to-amber-400 transition-[width] duration-500"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <Link
+          href="#activation"
+          className="hidden sm:inline-flex items-center gap-1 text-[10px] font-medium text-zinc-400 hover:text-white transition-colors px-1.5 py-0.5"
+        >
+          Skip to ship
+          <ArrowRight className="w-2.5 h-2.5" />
+        </Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Final human-UX pass before NL Digital + Madrid. Restraint discipline — orient users, reduce decisions, polish copy.

**Adds:**
- `WorkshopPath` — 3 path cards after hero (individual self-serve · live attendee · manual fallback). Routes each user type without forcing a single funnel.
- `WorkshopProgressRail` — sticky pill once user scrolls past hero. Module label + N/6 progress. Hides on print. IntersectionObserver-driven.
- `PromptCard` 'when to use which AI' footer — 3-column 11px guide under the AI buttons. Removes the silent 'wait which one do I pick' question.

**Refactors:**
- Hero CTAs: primary 'Start the workshop' anchor-link. Facilitator tools (presenter mode, on-page HUD, speaker view) demoted to small border-top row with 'Facilitating?' prefix.
- Module headings: time badges inline (`~15 min`, `~10 min`, etc.). Sets expectations.
- Module 4 + 5 copy: tightened. Ends on concrete action.
- All clickable elements gained `cursor-pointer`.

**`/present` a11y + mobile:**
- `overscroll-behavior: contain` — prevents pull-to-refresh on iOS Safari
- `@media (prefers-reduced-motion)` — animations clamped for users requesting reduced motion

5 files. Ready for trial run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress rail to track workshop completion status
  * Introduced "Pick your path" navigation guide with multiple workshop options
  * Added AI assistant usage guidance showing when to use ChatGPT, Claude, or Gemini
  * Module sections now display estimated completion times

* **Improvements**
  * Enhanced presenter mode mobile experience
  * Improved accessibility support for reduced motion preferences
  * Refreshed Ikigai & Branding workshop page layout and messaging
  * Updated visual styling for prompt cards and CTAs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankxai/frankx.ai-vercel-website/pull/69)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->