### PR TITLE
feat(crosslinks): research → workshops → library → os surface Blue Zones + V2/V3/V4

### DIFF
--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -307,6 +307,37 @@ export default function LibraryPage() {
         </div>
       </section>
 
+      {/* Research articles grounded in this collection */}
+      <section className="max-w-4xl mx-auto px-6 pb-16">
+        <div className="rounded-2xl border border-violet-500/[0.16] bg-violet-500/[0.03] p-8">
+          <div className="flex flex-wrap items-baseline justify-between gap-3 mb-3">
+            <h2 className="text-xl font-semibold text-white">Research grounded in this collection</h2>
+            <span className="text-[10px] uppercase tracking-[0.18em] text-violet-200">flagship article</span>
+          </div>
+          <p className="text-sm text-white/60 leading-relaxed mb-5">
+            Some of the books in this library are not just reading recommendations &mdash; they
+            are sources for deep research articles. Where four library books cluster around
+            one idea, you can read the meta-article that synthesises them.
+          </p>
+          <Link
+            href="/research/blue-zones-ikigai-ai-era"
+            className="group block rounded-xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.04] hover:border-white/[0.16] p-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+          >
+            <p className="text-[10px] uppercase tracking-[0.24em] text-white/40 mb-2">
+              Blue Zones &middot; Ikigai &middot; AI Era
+            </p>
+            <h3 className="text-base font-semibold text-white mb-2">
+              The four library books behind one Japanese word
+            </h3>
+            <p className="text-sm text-white/60 leading-relaxed">
+              Kamiya (1966), Buettner (2005), Garc&iacute;a &amp; Miralles (2016), Mogi (2017) &mdash; the
+              lineage of ikigai from psychiatric foundation to global bestseller, with an
+              honest reckoning of the 2014 Western Venn. 12-minute read.
+            </p>
+          </Link>
+        </div>
+      </section>
+
       {/* Our Books CTA */}
       <section className="max-w-4xl mx-auto px-6 pb-32">
         <div className="rounded-2xl border border-amber-500/10 bg-amber-500/[0.03] p-10 text-center">

--- a/app/os/page.tsx
+++ b/app/os/page.tsx
@@ -389,6 +389,71 @@ export default function OSPage() {
         </div>
       </section>
 
+      {/* Research Hub — the thinking under the modules */}
+      <section className="py-12 border-t border-white/[0.04]">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="rounded-2xl border border-violet-500/[0.16] bg-violet-500/[0.03] p-6 sm:p-8">
+            <div className="flex items-start gap-4 mb-5">
+              <div className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/15">
+                <BookOpen className="h-5 w-5 text-violet-300" aria-hidden="true" />
+              </div>
+              <div className="flex-1">
+                <div className="flex flex-wrap items-baseline justify-between gap-3">
+                  <h2 className="text-xl font-semibold text-zinc-50">Research Hub</h2>
+                  <span className="text-[10px] uppercase tracking-[0.18em] text-violet-200">flagship articles</span>
+                </div>
+                <p className="text-sm text-zinc-400 leading-relaxed max-w-3xl mt-1">
+                  The deep editorial thinking under the modules. Where the prompts come from,
+                  why the architecture is built the way it is, what the longevity research
+                  actually says about meaning.
+                </p>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <Link
+                href="/research/blue-zones-ikigai-ai-era"
+                className="group block rounded-xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.04] hover:border-violet-500/30 p-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-400 mb-2">
+                  Meaning &middot; longevity &middot; AI era
+                </p>
+                <h3 className="text-base font-semibold text-zinc-50 mb-2">
+                  Blue Zones, Ikigai, and the AI Era
+                </h3>
+                <p className="text-sm text-zinc-400 leading-relaxed">
+                  What 110-year-olds in Okinawa understand about meaning that AI is now
+                  forcing the rest of us to learn. 12-min read.
+                </p>
+              </Link>
+              <Link
+                href="/research/conscious-ai-operating-systems"
+                className="group block rounded-xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.04] hover:border-violet-500/30 p-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-400 mb-2">
+                  Sovereign AI &middot; architecture
+                </p>
+                <h3 className="text-base font-semibold text-zinc-50 mb-2">
+                  Conscious AI Operating Systems
+                </h3>
+                <p className="text-sm text-zinc-400 leading-relaxed">
+                  The architectural answer to the meaning question. Sovereign AI as the
+                  instrument, not the replacement.
+                </p>
+              </Link>
+            </div>
+            <div className="mt-5">
+              <Link
+                href="/research"
+                className="inline-flex items-center gap-1.5 text-sm text-violet-300 hover:text-violet-200 transition-colors rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] px-1 py-0.5"
+              >
+                Browse the full Research Hub
+                <ArrowRight className="w-4 h-4" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* Connection matrix */}
       <section className="py-12">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -586,6 +586,87 @@ function CTASection() {
   )
 }
 
+function FlagshipArticles() {
+  const shouldReduceMotion = useReducedMotion()
+  const articles = [
+    {
+      kanji: '長',
+      label: 'meaning · longevity · ai era',
+      title: 'Blue Zones, Ikigai, and the AI Era',
+      href: '/research/blue-zones-ikigai-ai-era',
+      blurb:
+        'What 110-year-olds in Okinawa understand about meaning that AI is now forcing the rest of us to learn.',
+      readingTime: '12 min',
+    },
+    {
+      kanji: '識',
+      label: 'sovereign ai · architecture',
+      title: 'Conscious AI Operating Systems',
+      href: '/research/conscious-ai-operating-systems',
+      blurb:
+        'Sovereign AI architectures that integrate biometrics, persistent memory, and ethical guardrails.',
+      readingTime: '15 min',
+    },
+  ]
+  return (
+    <section className="py-12 md:py-16 border-b border-white/[0.04]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <motion.div
+          initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={shouldReduceMotion ? { duration: 0 } : { delay: 0.1 }}
+          className="mb-8"
+        >
+          <div className="flex items-center gap-3 mb-3">
+            <FileText className="w-5 h-5 text-violet-400" />
+            <h2 className="text-2xl md:text-3xl font-bold text-white">Flagship Articles</h2>
+          </div>
+          <p className="text-white/50 max-w-2xl">
+            Deep editorial pieces &mdash; sourced, FAQ&rsquo;d, schema-marked, designed to be cited.
+            The longform thinking beneath the domain navigation.
+          </p>
+        </motion.div>
+        <div className="grid md:grid-cols-2 gap-4">
+          {articles.map((a, i) => (
+            <motion.div
+              key={a.href}
+              initial={shouldReduceMotion ? false : { opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={shouldReduceMotion ? { duration: 0 } : { delay: 0.15 + i * 0.08 }}
+            >
+              <Link
+                href={a.href}
+                className="group relative block rounded-2xl border border-violet-500/[0.18] bg-violet-500/[0.03] hover:bg-violet-500/[0.06] hover:border-violet-500/[0.32] p-6 h-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <div className="flex items-start justify-between gap-4 mb-4">
+                  <span
+                    className="text-4xl text-white/85 leading-none font-light group-hover:text-white transition-colors"
+                    aria-hidden="true"
+                    style={{ fontFamily: 'var(--font-jp-serif), serif' }}
+                  >
+                    {a.kanji}
+                  </span>
+                  <ArrowUpRight aria-hidden="true" className="w-4 h-4 text-violet-300 group-hover:text-white transition-colors flex-shrink-0 mt-1" />
+                </div>
+                <p className="text-[10px] uppercase tracking-[0.24em] text-white/40 mb-2">
+                  {a.label}
+                </p>
+                <h3 className="text-lg font-semibold text-white mb-2 leading-snug">
+                  {a.title}
+                </h3>
+                <p className="text-sm text-white/70 leading-relaxed mb-3">{a.blurb}</p>
+                <p className="text-[11px] text-white/40 uppercase tracking-wider">
+                  {a.readingTime} read
+                </p>
+              </Link>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
 export default function ResearchPage() {
   return (
     <main className="relative min-h-screen bg-[#0a0a0b] text-white overflow-hidden">
@@ -623,6 +704,7 @@ export default function ResearchPage() {
 
       <div className="relative z-10">
         <HeroSection />
+        <FlagshipArticles />
         <FeaturedSpotlight />
         <DomainsGrid />
         <ResearchTeamSection />

--- a/app/workshops/page.tsx
+++ b/app/workshops/page.tsx
@@ -179,7 +179,7 @@ export default function WorkshopsPage() {
       </section>
 
       {/* Workshop Grid */}
-      <section className="pb-24">
+      <section className="pb-12">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             {workshops.map((workshop, index) => (
@@ -190,6 +190,73 @@ export default function WorkshopsPage() {
               />
             ))}
           </div>
+        </div>
+      </section>
+
+      {/* Ikigai design-iteration badge — V2/V3/V4 live as public variants */}
+      <section className="pb-12">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+            className="rounded-2xl border border-violet-500/[0.20] bg-violet-500/[0.04] p-6 sm:p-8"
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-3 mb-4">
+              <h2 className="text-lg sm:text-xl font-semibold text-white">
+                Ikigai workshop — explore the design iterations
+              </h2>
+              <span className="text-[10px] uppercase tracking-[0.18em] text-violet-200">
+                4 public versions live
+              </span>
+            </div>
+            <p className="text-sm text-zinc-300 leading-relaxed mb-5">
+              The Ikigai &amp; Branding workshop is shipped as four parallel design surfaces. The
+              canonical lives at the original URL; three iterations sit alongside as public
+              comparisons. Same prompts, same outcomes, different editorial register. Pick
+              the one that reads right for you.
+            </p>
+            <div className="grid sm:grid-cols-2 gap-3">
+              <Link
+                href="/workshops/ikigai-branding"
+                className="group block rounded-xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.04] hover:border-white/[0.16] p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-400 mb-1">V1 — canonical</p>
+                <p className="text-sm font-medium text-white">Wizard + 6 prompts</p>
+              </Link>
+              <Link
+                href="/workshops/ikigai/v2"
+                className="group block rounded-xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.04] hover:border-white/[0.16] p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-400 mb-1">V2 — editorial clean</p>
+                <p className="text-sm font-medium text-white">Wisdom panel + 13 prompts</p>
+              </Link>
+              <Link
+                href="/workshops/ikigai/v3"
+                className="group block rounded-xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.04] hover:border-white/[0.16] p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-400 mb-1">V3 — editorial cinema</p>
+                <p className="text-sm font-medium text-white">Black canvas + kanji chapters</p>
+              </Link>
+              <Link
+                href="/workshops/ikigai/v4"
+                className="group block rounded-xl border border-violet-500/30 bg-violet-500/[0.06] hover:bg-violet-500/[0.10] hover:border-violet-500/50 p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <p className="text-[10px] uppercase tracking-[0.18em] text-violet-200 mb-1">V4 — composed canonical</p>
+                <p className="text-sm font-medium text-white">Best-of synthesis + meaning anchors</p>
+              </Link>
+            </div>
+            <p className="text-xs text-zinc-400 mt-5 leading-relaxed">
+              Read the research behind the workshop:{' '}
+              <Link
+                href="/research/blue-zones-ikigai-ai-era"
+                className="text-violet-300 hover:text-violet-200 transition-colors underline underline-offset-4"
+              >
+                Blue Zones, Ikigai, and the AI Era →
+              </Link>
+            </p>
+          </motion.div>
         </div>
       </section>
 


### PR DESCRIPTION
Closes the 'we link from sites to it' loop. Pure additive cross-link sweep across 4 index pages. No existing logic touched. See commit for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Research grounded in this collection" section to Library page featuring a linked research article
  * Introduced Research Hub section on OS page showcasing flagship research cards with interactive styling
  * Launched Flagship Articles section on Research page with animated article cards
  * Created Ikigai workshop showcase on Workshops page linking to multiple workshop versions and design iterations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankxai/frankx.ai-vercel-website/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->