### PR TITLE
feat(ikigai-canonical): V9 prompts — audience-first, proactive, 7 modules

### DIFF
--- a/app/workshops/ikigai-branding/page.tsx
+++ b/app/workshops/ikigai-branding/page.tsx
@@ -1,32 +1,32 @@
 'use client'
 
 /**
- * Ikigai & Branding Workshop — CANONICAL (refresh 2026-05-18)
+ * Ikigai & Branding Workshop — CANONICAL
  *
- * What changed in this refresh per Frank's direction:
- *   - Kanji 生き甲斐 moved into the hero as a left-column anchor (desktop),
- *     stacks above title on mobile. Replaces the "ikigai is a Japanese word"
- *     paragraph as the cultural cue — Japanese minimalism, not exposition.
- *   - V8 clean prompts (1 Coach + 7 micros). ~750 words total. No
- *     "frontier-class reasoning model" preambles. Three options not eight.
- *   - 7 essential modules — Map, Stress-Test, Statement, Brand, Plan,
- *     Ship, Commit. Drops AI-Companion (tool catalog lives at /stack) and
- *     Visual-Kit (bonus, moved to V8 preview only).
- *   - Drops V1 fallback components — IkigaiWizard, SynthesisPanel,
- *     BrandingBridge, ContentOperatingPlan. The audience pastes prompts;
- *     they don't manually walk forms.
- *   - Hero trimmed — no "Show on-page HUD" toggle, no module-count badge.
- *     Two CTAs only: Open the Coach + pick a path.
+ * Current prompt stack: V9 (audience-first, proactive — see lib/workshop-prompts-v9.ts).
+ * Core principle (Frank, 2026-05-19): "Never ask the participant to complete the
+ * system. Make the assistant complete the system from weak signals."
  *
- * What stayed (Frank: "normal workshop page is still better"):
- *   - NB2 brushstroke hero (variant-1) — V4 generation
- *   - NB2 Venn diagram (variant-1) — V6 generation
- *   - Kamiya quote between Module 3 and Module 4
- *   - WorkshopPath, WorkshopProgressRail, EmailSignup
+ * Seven modules:
+ *   1. Audience Problem Map
+ *   2. Content Angle
+ *   3. Hook Bank
+ *   4. 7-Day Plan
+ *   5. Publish — Post + 3 Versions (two prompts stacked)
+ *   6. Premium Visual
+ *   7. Proactive Partner
  *
- * V1 (the former V4-composed-canonical) is the single archive at
- * /workshops/ikigai/v1 — unlinked from canonical, kept for reference.
- * This is the page audiences land on.
+ * Plus the Coach prompt which carries the full Universal Operating Rule
+ * and the 7-module arc as one paste.
+ *
+ * Page structure: kanji left-rail hero → NB2 brushstroke → 5-outcome panel →
+ * AI-as-mirror framing → original ikigai-venn raster → Coach card → 7 modules
+ * → Kamiya quote between M2 and M3 → purpose-to-brand-flow bridge image →
+ * email signup at Module 7 → kanji cards (究/型/本/塾).
+ *
+ * V1 (the former V4 design-thinking-composed preview) is the single archive
+ * at /workshops/ikigai/v1 — unlinked from canonical, noindex, kept for
+ * facilitator reference.
  */
 
 import Link from 'next/link'
@@ -47,7 +47,7 @@ import { PromptCard } from '@/components/workshops/ikigai/PromptCard'
 import { PromptStack } from '@/components/workshops/ikigai/PromptStack'
 import { WorkshopPath } from '@/components/workshops/ikigai/WorkshopPath'
 import { WorkshopProgressRail } from '@/components/workshops/ikigai/WorkshopProgressRail'
-import { WORKSHOP_PROMPTS_V8 as WORKSHOP_PROMPTS } from '@/lib/workshop-prompts-v8'
+import { WORKSHOP_PROMPTS_V9 as WORKSHOP_PROMPTS } from '@/lib/workshop-prompts-v9'
 import { getWorkshopBySlug } from '@/data/workshops'
 
 const HERO_VARIANT: 1 | 2 | 3 | 4 = 1
@@ -172,8 +172,9 @@ export default function IkigaiBrandingWorkshopPage() {
                 </span>
               </h1>
               <p className="text-lg text-zinc-300 mb-8 max-w-xl leading-relaxed">
-                One Coach. Seven modules. Walk out with a one-sentence purpose, a brand,
-                a 30-day plan, and the artifact you publish today.
+                Your ikigai gives direction. Your content earns attention by solving
+                visible problems for real people. AI helps you translate the invisible
+                part of you into something others can recognize, use, and remember.
               </p>
 
               <div className="flex flex-wrap items-center gap-3">
@@ -241,28 +242,28 @@ export default function IkigaiBrandingWorkshopPage() {
             {[
               {
                 n: '01',
-                t: 'Your one-sentence ikigai statement',
-                b: 'Two versions — the one you ship today, and the one you grow into by next year.',
+                t: 'An audience problem map',
+                b: 'Three candidate audience groups with their visible problems, hidden tensions, ambitions, and what they’d actually pay for or follow.',
               },
               {
                 n: '02',
-                t: 'A brand positioning that holds 12 months',
-                b: 'One reader with a first name, three pillars that survive a year of weekly publishing.',
+                t: 'Your content angle in one sentence',
+                b: 'Who you serve, the painful state they’re in, the future state they want, and the distinct mechanism you bring.',
               },
               {
                 n: '03',
-                t: 'A 30-day rhythm you can actually hold',
-                b: 'Four Monday topics, one mid-week ritual, one end-of-month artifact. Built for someone with a job.',
+                t: 'A 30-hook bank across 15 formats',
+                b: 'Mistake, contrarian, before/after, curiosity, identity, hidden-cost, strong-belief. Best 5 ranked, strongest sharpened to 5 variants.',
               },
               {
                 n: '04',
-                t: 'Three named humans living from your direction',
-                b: 'Real first names with revenue mechanisms, sourced or marked unverified. The doubt step becomes a research step.',
+                t: 'A 7-day publishing plan + your first LinkedIn post (in 3 versions)',
+                b: 'Daily posts tied to your audience’s actual week. Then one post written, plus 3 alternate voices, plus a hybrid that combines the strongest parts.',
               },
               {
                 n: '05',
-                t: 'One artefact you publish today',
-                b: 'A LinkedIn post + a 60-second script + an image-gen prompt, all from one Coach response.',
+                t: 'A premium image-gen prompt + a chat that’s now your proactive content partner',
+                b: 'A scroll-stopping LinkedIn visual prompt with a no-text fallback. And a chat that turns any rough thought you paste later into a publishable artefact.',
               },
             ].map((o) => (
               <li
@@ -342,6 +343,12 @@ export default function IkigaiBrandingWorkshopPage() {
               Not ground truth. Context engineering, not authority. We train it across
               sessions &mdash; every new conversation starts a little less from zero.
             </p>
+
+            <p className="text-center text-[12px] text-zinc-500 mt-4 max-w-xl mx-auto leading-relaxed">
+              Operating rule for every prompt below: if it asks for input you don&apos;t
+              have, the AI infers it from your context. State your assumptions, proceed.
+              You correct course; it never waits for perfect input.
+            </p>
           </div>
         </div>
       </section>
@@ -404,11 +411,13 @@ export default function IkigaiBrandingWorkshopPage() {
               Open the Ikigai &amp; Branding Coach
             </h2>
             <p className="text-base text-zinc-300 max-w-xl mx-auto leading-relaxed">
-              One prompt. One conversation. Your AI walks the whole arc with you —
-              Map → Statement → Brand → Plan → Ship — one question at a time.
+              One prompt. One conversation. Your AI runs ahead — infers what you
+              haven&apos;t said, makes strong assumptions, and hands you publishable
+              artefacts at each step. You correct course; it never waits for perfect
+              input.
             </p>
             <p className="text-sm text-zinc-500 max-w-xl mx-auto leading-relaxed mt-3">
-              Then drop into the modules below when you want to sharpen a phase.
+              Then drop into the 7 modules below to sharpen any phase.
             </p>
           </div>
 
@@ -446,45 +455,45 @@ export default function IkigaiBrandingWorkshopPage() {
         <WorkshopPath />
       </div>
 
-      {/* ─── Module 1 — The Map ──────────────────────────────────── */}
+      {/* ─── Module 1 — Audience Problem Map ─────────────────────── */}
       <section id="module-1" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <ModuleHeader
             number={1}
-            title="The Map"
-            duration="8 min"
+            title="Audience Problem Map"
+            duration="15 min"
             accent="violet"
-            lead="Three ikigai directions on the table — safe, stretch, wild — drawn from what your AI already knows about you."
+            lead="Your ikigai gives direction. The content is for them, not about you. Three candidate audiences with visible problems, hidden tensions, and what they’d pay for."
           />
-          <PromptStack module={1} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={1} prompts={WORKSHOP_PROMPTS} label="Paste into the latest ChatGPT" />
         </div>
       </section>
 
-      {/* ─── Module 2 — Stress-Test ──────────────────────────────── */}
+      {/* ─── Module 2 — Content Angle ────────────────────────────── */}
       <section id="module-2" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <ModuleHeader
             number={2}
-            title="Stress-Test"
-            duration="8 min"
-            accent="emerald"
-            lead="Three real humans already earning a living from your direction. Named with sourced links, or marked unverified. The doubt step becomes a research step."
+            title="Content Angle"
+            duration="12 min"
+            accent="amber"
+            lead="Five angles scored on clarity, usefulness, originality, credibility, emotional pull, and commercial potential. The strongest one written as a one-sentence positioning."
           />
-          <PromptStack module={2} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={2} prompts={WORKSHOP_PROMPTS} label="Paste into the latest ChatGPT" />
         </div>
       </section>
 
-      {/* ─── Module 3 — The Statement ────────────────────────────── */}
+      {/* ─── Module 3 — Hook Bank ────────────────────────────────── */}
       <section id="module-3" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <ModuleHeader
             number={3}
-            title="The Statement"
-            duration="10 min"
-            accent="amber"
-            lead="Three versions of your one-line ikigai statement, ranked by claim-cost. The one you ship today and the one you're growing into."
+            title="Hook Bank"
+            duration="12 min"
+            accent="emerald"
+            lead="30 hooks across 15 formats — mistake, contrarian, before/after, curiosity, identity, hidden-cost, strong-belief. Best 5 ranked, strongest sharpened to 5 variants."
           />
-          <PromptStack module={3} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={3} prompts={WORKSHOP_PROMPTS} label="Paste into the latest ChatGPT" />
         </div>
       </section>
 
@@ -524,65 +533,65 @@ export default function IkigaiBrandingWorkshopPage() {
             />
           </figure>
           <p className="text-center text-xs text-zinc-500 mt-4 max-w-md mx-auto leading-relaxed">
-            From the one-sentence purpose to a brand that holds twelve months of weekly
-            publishing. Module 4 walks the bridge.
+            From hooks to a publishing plan. Module 4 ties the bank to your reader’s
+            actual week.
           </p>
         </div>
       </section>
 
-      {/* ─── Module 4 — Brand ────────────────────────────────────── */}
+      {/* ─── Module 4 — 7-Day Plan ───────────────────────────────── */}
       <section id="module-4" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <ModuleHeader
             number={4}
-            title="The Brand"
+            title="7-Day Plan"
             duration="10 min"
-            accent="violet"
-            lead="Positioning, one reader with a first name, three pillars that survive twelve months of weekly publishing. Built from what you actually said earlier in the conversation."
+            accent="sky"
+            lead="A publishing rhythm tied to your audience’s actual week. Pain / observation / framework / myth-bust / build-in-public / proof / question — one post per day."
           />
-          <PromptStack module={4} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={4} prompts={WORKSHOP_PROMPTS} label="Paste into the latest ChatGPT" />
         </div>
       </section>
 
-      {/* ─── Module 5 — The 30-Day Plan ──────────────────────────── */}
+      {/* ─── Module 5 — Publish (post + 3 versions, two prompts) ─── */}
       <section id="module-5" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <ModuleHeader
             number={5}
-            title="The 30-Day Plan"
-            duration="8 min"
-            accent="sky"
-            lead="A rhythm someone with a job can hold. Four Monday topics, one mid-week ritual, one end-of-month artifact."
+            title="Publish — Post + 3 Versions"
+            duration="14 min"
+            accent="amber"
+            lead="One strong LinkedIn post written from the best content idea, then three alternate voices (useful / personal / bold), then a hybrid that combines the strongest parts."
           />
-          <PromptStack module={5} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={5} prompts={WORKSHOP_PROMPTS} label="Two prompts — paste them in order" />
         </div>
       </section>
 
-      {/* ─── Module 6 — Ship the Artifact ────────────────────────── */}
+      {/* ─── Module 6 — Premium Visual ───────────────────────────── */}
       <section id="module-6" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <ModuleHeader
             number={6}
-            title="Ship the Artifact"
+            title="Premium Visual"
             duration="10 min"
-            accent="amber"
-            lead="Three artifacts in one response — a LinkedIn post, a 60-second script, an image-gen prompt. Same idea, three shapes. Use your actual words."
+            accent="rose"
+            lead="Three visual concepts (infographic / carousel cover / bold metaphor), then a ready-to-paste image-gen prompt for ChatGPT image generation, plus a no-text fallback."
           />
-          <PromptStack module={7} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={6} prompts={WORKSHOP_PROMPTS} label="Paste into ChatGPT image gen" />
         </div>
       </section>
 
-      {/* ─── Module 7 — Commitment + Resource Pack ───────────────── */}
+      {/* ─── Module 7 — Proactive Partner + Resource Pack ────────── */}
       <section id="module-7" className="pb-12 scroll-mt-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
           <ModuleHeader
             number={7}
-            title="Lock the Commitment"
-            duration="5 min"
-            accent="emerald"
-            lead="Three calendar entries plus the SMS you send to one human asking them to check in on you at day 14. Done in 90 seconds."
+            title="Proactive Partner"
+            duration="8 min"
+            accent="violet"
+            lead="Turn this chat into your ongoing content partner. Any half-thought you paste later becomes an audience problem, an angle, 5 hooks, a draft, a visual direction, and a publish-or-refine recommendation."
           />
-          <PromptStack module={8} prompts={WORKSHOP_PROMPTS} label="Deepening tool" />
+          <PromptStack module={7} prompts={WORKSHOP_PROMPTS} label="Paste into the latest ChatGPT" />
 
           <GlowCard color="emerald">
             <div className="p-6 sm:p-8 text-center">

--- a/lib/workshop-prompts-v9.ts
+++ b/lib/workshop-prompts-v9.ts
@@ -1,0 +1,530 @@
+/**
+ * Ikigai & Branding Workshop — V9 prompts (audience-first, proactive)
+ *
+ * Core principle (Frank, 2026-05-19):
+ *   "Never ask the participant to complete the system.
+ *    Make the assistant complete the system from weak signals."
+ *
+ * Stance shift from V8:
+ *   - V8 Coach was Socratic ("ask ONE question at a time, wait for answer").
+ *   - V9 Coach is proactive — infer missing input, state assumptions, produce
+ *     publishable artefacts immediately. The participant supplies rough thoughts;
+ *     the AI completes the system.
+ *
+ * Focus shift from V8:
+ *   - V8 was self-discovery ("write your one-sentence ikigai").
+ *   - V9 is audience-first ("the content should not be about you — it should
+ *     help real people solve real problems"). Ikigai gives direction; content
+ *     earns attention by solving visible problems.
+ *
+ * Each prompt body opens with a SHORTENED operating-rule prepend (~40 words),
+ * the full rule lives in the Coach prompt only — so any single prompt still
+ * works when pasted in isolation, without bloating bodies V5-style.
+ *
+ * 8 prompts total, mapped to 7 module sections on canonical (P5 + P6 stacked
+ * in module 5 = "Publish — post + 3 versions").
+ */
+
+import type { WorkshopPrompt } from './workshop-prompts'
+
+const SHARED_AUTHOR = 'Frank Riemer'
+const SHARED_DATE = '2026-05-19'
+const SHARED_VERSION = '9.0.0'
+
+const OPERATING_RULE_SHORT = `**Important — operating rule.** Do not wait for perfect input. If anything is missing, infer it from this chat, my profession, my examples, or the strongest plausible interpretation. State your assumptions briefly, then proceed. Only ask if the entire answer would be misleading.`
+
+const VOICE_NOTE = `Senior personal brand strategist + market researcher + LinkedIn editor + creative director + AI-native product thinker. No generic motivational language. No vague "find your passion". Make the result specific, useful, sharp, and publishable.`
+
+export const WORKSHOP_PROMPTS_V9: WorkshopPrompt[] = [
+  // ─── 0 ─ The Coach (full Universal Operating Rule + framing + arc) ───
+  {
+    id: 'coach',
+    module: 0,
+    title: 'Open the Ikigai & Branding Coach',
+    subtitle:
+      'One conversation. The AI runs ahead, infers what you haven\'t said, hands you publishable artefacts at each step. You correct course; it never waits for perfect input.',
+    body: `You are my AI-native personal brand strategist and content partner.
+
+**Operating rule — apply throughout this conversation:**
+
+Do not wait for perfect input.
+
+If I leave anything blank, infer it from:
+- this chat
+- my previous answers
+- my profession or visible context
+- the kind of work I seem drawn to
+- the audience implied by my examples
+- the strongest commercially and creatively plausible interpretation
+
+If there is not enough information, create 2-3 plausible options and choose the strongest one.
+
+Do not ask me to fill missing fields unless the entire answer would become misleading. State your assumptions briefly, then proceed.
+
+Your output should feel like it was produced by: a senior personal brand strategist, a market researcher, a LinkedIn editor, a creative director, and an AI-native product thinker — together.
+
+Avoid generic motivational language. Avoid vague "find your passion" language. Make every result specific, useful, sharp, and publishable.
+
+**Workshop framing:**
+
+Your ikigai gives direction. Your content earns attention by solving visible problems for real people. AI helps you translate the invisible part of you into something others can recognize, use, and remember.
+
+**The 7-module arc:**
+
+1. **Audience Problem Map** — your ikigai + 3 candidate audiences with their visible problems, hidden tensions, ambitions, and what they'd pay for or follow.
+2. **Content Angle** — 5 angles ranked, the strongest one written as a one-sentence positioning statement.
+3. **Hook Bank** — 30 hooks across 15 formats, the best 5 ranked, the strongest one sharpened to 5 variants.
+4. **7-Day Plan** — a publishing rhythm tied to my audience's actual week.
+5. **Publish** — one strong LinkedIn post, then 3 versions of it (professional / personal / bold), with a hybrid pick.
+6. **Premium Visual** — a scroll-stopping LinkedIn image-gen prompt, plus a fallback.
+7. **Proactive Partner** — turn this chat into my ongoing content partner so any rough thought becomes an artefact.
+
+**Models:** paste these prompts into the latest ChatGPT. For harder reasoning, switch to Thinking mode if available. For visuals (module 6), use ChatGPT's image generation.
+
+**Begin now:**
+
+Ask me one question: which module do I want to start with? If I'm not sure, infer the most useful starting point from what little I've told you and go.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Use this Coach for the whole conversation — paste once. Run the 7 modules in any order; the Coach holds your context.',
+    version: SHARED_VERSION,
+    evalScore: 4.7,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+  },
+
+  // ─── 1 ─ Audience Problem Map ────────────────────────────────────────
+  {
+    id: 'audience-problem-map',
+    module: 1,
+    title: 'Map my ikigai to real audience problems',
+    subtitle:
+      'Three audience groups with their visible problems, hidden tensions, ambitions, and what they\'d pay for. The content is for them, not about you.',
+    body: `${OPERATING_RULE_SHORT}
+
+You are my AI-native personal brand strategist.
+
+Use my ikigai only as background context. The content should not be about me. The content should help real people solve real problems.
+
+Optional inputs:
+- My ikigai statement:
+- My profession / role:
+- Work I enjoy:
+- Things people thank me for:
+- Audience I might want to reach:
+- Recent project, post, idea, or conversation:
+
+If any input is missing, infer it from this chat and create the strongest plausible version.
+
+Now produce:
+
+1. My inferred ikigai in one clear sentence.
+2. 3 possible audience groups I could serve.
+3. For each audience group:
+   - urgent visible problems
+   - deeper emotional tension
+   - hidden ambition
+   - common mistakes
+   - questions they would ask ChatGPT, Google, YouTube, or LinkedIn
+   - outcomes they want
+   - content they would save / share
+   - what they may pay for, join, apply to, or follow
+4. Recommend the best starting audience.
+5. Explain why this audience has the strongest mix of: personal fit, market relevance, content potential, credibility, monetization path.
+
+Output style: clear, sharp, non-generic. No fluffy self-discovery language.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Pick one audience to take forward into Module 2. The other two are still useful — bring them back when this one plateaus.',
+    version: SHARED_VERSION,
+    evalScore: 4.7,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsTo: ['content-angle'],
+  },
+
+  // ─── 2 ─ Content Angle ───────────────────────────────────────────────
+  {
+    id: 'content-angle',
+    module: 2,
+    title: 'Pick my strongest content angle',
+    subtitle:
+      'Five angles scored on clarity, usefulness, originality, credibility, emotional pull, commercial potential. The strongest one written as a one-sentence positioning statement.',
+    body: `${OPERATING_RULE_SHORT}
+
+Based on the audience problem map, choose one sharp content angle for me.
+
+Do not ask me to choose first. Infer the strongest angle and show alternatives.
+
+Create 5 possible content angles. For each, include:
+
+1. **Audience** — who exactly this is for.
+2. **Problem** — what they are trying to solve.
+3. **Desire** — what they secretly want.
+4. **Point of view** — what I believe that is meaningfully different from common advice.
+5. **Proof** — what proof I can use from my work, projects, experience, observations, personality, or lived examples. If proof is missing, infer likely proof categories I should look for.
+6. **Content promise** — what people will consistently get from following me.
+
+Score each angle 1–5 on:
+- clarity
+- usefulness
+- originality
+- credibility
+- emotional pull
+- commercial potential
+
+Then select the strongest angle and write the positioning sentence in this shape:
+
+> "My content helps [specific audience] move from [painful current state] to [desired future state] by showing them [distinct mechanism]."`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Write the positioning sentence on paper. Read it tomorrow morning. Still feel true? Take it into Module 3. Doesn\'t? Rerun this prompt asking for harder picks.',
+    version: SHARED_VERSION,
+    evalScore: 4.6,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['audience-problem-map'],
+    chainsTo: ['hook-bank'],
+  },
+
+  // ─── 3 ─ Hook Bank ───────────────────────────────────────────────────
+  {
+    id: 'hook-bank',
+    module: 3,
+    title: 'Build a 30-hook bank across 15 formats',
+    subtitle:
+      'Mistake, contrarian, before/after, pain-specific, curiosity, list, lesson, myth-busting, decision, practical, status-shift, identity, hidden-cost, "nobody tells you", strong-belief. Best 5 ranked, strongest sharpened to 5 variants.',
+    body: `${OPERATING_RULE_SHORT}
+
+Create a high-quality hook bank for my chosen audience and content angle.
+
+If the audience, problem, or angle is missing, infer them from this chat.
+
+Generate 30 hooks across these 15 formats (2 per format):
+
+1. Mistake hook
+2. Contrarian hook
+3. Before/after hook
+4. Pain-specific hook
+5. Curiosity hook
+6. List hook
+7. Personal lesson hook
+8. Myth-busting hook
+9. Decision hook
+10. Practical hook
+11. Status-shift hook
+12. Identity hook
+13. Hidden-cost hook
+14. "Nobody tells you" hook
+15. Strong-belief hook
+
+Rules:
+- Every hook must feel specific to the audience.
+- No generic "unlock your potential".
+- No fake drama.
+- No empty AI hype.
+- Make the reader feel: "This is exactly my problem."
+- Cover LinkedIn posts, short videos, carousels, and newsletters.
+
+After the 30 hooks, choose the top 5 and explain why they are strongest. Then rewrite the best hook in 5 sharper versions.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Save the top 5 hooks somewhere durable — they\'ll seed the next 6 months of posts. The sharpened best one is your Module 5 starter.',
+    version: SHARED_VERSION,
+    evalScore: 4.7,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['content-angle'],
+    chainsTo: ['seven-day-plan'],
+  },
+
+  // ─── 4 ─ 7-Day Plan ──────────────────────────────────────────────────
+  {
+    id: 'seven-day-plan',
+    module: 4,
+    title: 'A 7-day publishing plan tied to my audience\'s problems',
+    subtitle:
+      'Pain / observation / framework / myth-bust / build-in-public / proof / question — one post per day with format, hook, outline, visual idea, expected response.',
+    body: `${OPERATING_RULE_SHORT}
+
+Create a 7-day content plan based on my audience's problems.
+
+If I have not provided enough context, infer my audience, core problem space, point of view, strongest proof, and likely offer or next artifact.
+
+Build the plan as:
+
+- **Day 1** — Pain / mistake post
+- **Day 2** — Personal observation post
+- **Day 3** — Practical framework post
+- **Day 4** — Myth-busting post
+- **Day 5** — Build-in-public post
+- **Day 6** — Proof / example post
+- **Day 7** — Conversation-starting question
+
+For each day, give:
+
+- title
+- audience problem
+- emotional trigger
+- hook
+- 3-part outline
+- suggested format: LinkedIn post, carousel, short video, infographic, newsletter, or website section
+- visual idea
+- why this post should exist
+- what response it should create
+
+Then choose the one artifact I should create FIRST today, and explain why.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Put the 7 dates in your calendar. The "first today" pick feeds straight into Module 5. The other 6 are stockpile.',
+    version: SHARED_VERSION,
+    evalScore: 4.6,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['hook-bank'],
+    chainsTo: ['linkedin-post'],
+  },
+
+  // ─── 5a ─ One LinkedIn Post (paired with three-versions in module 5)
+  {
+    id: 'linkedin-post',
+    module: 5,
+    title: 'Write one strong LinkedIn post',
+    subtitle:
+      'Hook → problem → tension → insight → shift → close. Under 180 words. Human, useful, no corporate jargon, no fake vulnerability, no "game-changer", no "unlock your potential".',
+    body: `${OPERATING_RULE_SHORT}
+
+Write one strong LinkedIn post from the best content idea.
+
+If the content idea is missing, infer the strongest one from this chat.
+
+Use this structure:
+
+1. **Hook** — choose the hook format that best fits the idea.
+2. **Problem** — name the real problem clearly.
+3. **Tension** — explain why smart people still get stuck.
+4. **Insight** — give one useful idea, framework, distinction, or example.
+5. **Shift** — show the better way of thinking.
+6. **Close** — end with a soft question or clean final line.
+
+Style:
+- under 180 words
+- short lines
+- human, intelligent, useful
+- no corporate jargon
+- no hype
+- no fake vulnerability
+- no invented personal story
+- no "game-changer"
+- no "unlock your potential"
+- no "in today's fast-paced world"
+
+Before writing, briefly state:
+- inferred audience
+- core problem
+- point of view
+
+Then write the post. After the post, give one sharper alternative hook.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Read the post out loud. If any line sounds like a brochure, rewrite it. Then run the next prompt to get 3 alternate versions.',
+    version: SHARED_VERSION,
+    evalScore: 4.7,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['seven-day-plan'],
+    chainsTo: ['three-versions'],
+  },
+
+  // ─── 5b ─ Three Versions (stacked with linkedin-post in module 5) ────
+  {
+    id: 'three-versions',
+    module: 5,
+    title: 'Make three versions of the post and recommend one',
+    subtitle:
+      'Useful / personal / bold — same core idea, three voices. Pick the one to publish, then hand back a hybrid that combines the strongest parts.',
+    body: `${OPERATING_RULE_SHORT}
+
+Create 3 versions of the LinkedIn post from the previous prompt.
+
+If the original post is missing, infer it from the strongest idea in this chat.
+
+- **Version 1** — Useful and professional.
+- **Version 2** — Personal and reflective.
+- **Version 3** — Bold and opinionated.
+
+For each version:
+- keep it under 180 words
+- use a different hook
+- preserve the same core idea
+- make the first line scroll-stopping
+- make the ending invite thought or replies
+- avoid generic advice
+
+After the 3 versions:
+
+1. Recommend which one I should publish first.
+2. Explain why.
+3. Give a final polished hybrid version that combines the strongest parts.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Publish one of the four (3 versions + hybrid) today. Save the rest as your week-1 calendar from Module 4.',
+    version: SHARED_VERSION,
+    evalScore: 4.6,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['linkedin-post'],
+    chainsTo: ['premium-visual'],
+  },
+
+  // ─── 6 ─ Premium Visual ──────────────────────────────────────────────
+  {
+    id: 'premium-visual',
+    module: 6,
+    title: 'Turn the post into a premium LinkedIn visual + image-gen prompt',
+    subtitle:
+      'Three visual concepts (infographic / carousel cover / bold metaphor), then a ready-to-paste image-gen prompt. Plus a fallback with almost no text.',
+    body: `${OPERATING_RULE_SHORT}
+
+You are my creative director and AI image-generation prompt engineer.
+
+Turn the post or idea into premium visual content for LinkedIn.
+
+If the post is missing, infer the strongest post from this chat.
+
+First, extract:
+- core message
+- audience
+- emotional tension
+- 3-second takeaway
+- visual metaphor
+- minimum necessary text
+
+Then create 3 visual concepts:
+
+1. **Clean infographic**
+2. **Premium carousel cover**
+3. **Bold visual metaphor**
+
+For each concept, give:
+- title
+- 3-second message
+- layout
+- visual hierarchy
+- exact text on image
+- style direction
+- aspect ratio
+- why it would stop the scroll
+- why it would still feel professional
+
+Design rules:
+- optimized for LinkedIn mobile
+- 4:5 portrait preferred
+- minimal text, strong negative space, clear hierarchy
+- editorial, premium, useful
+- no fake dashboards unless relevant
+- no stock-photo energy
+- no cheesy icons
+- no motivational-poster look
+- no clutter, no tiny unreadable text
+
+Then choose the best concept and write a ready-to-use image generation prompt.
+
+The image prompt must include:
+- subject
+- composition
+- lighting
+- material / style
+- typography instructions
+- text to render
+- aspect ratio
+- mood
+- what to avoid
+
+Also include a fallback version with almost no text (in case text rendering becomes messy).
+
+Recommended generator: ChatGPT's image generation (Thinking mode for harder compositions).`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'Paste the image prompt into ChatGPT image gen. If text renders messy, use the fallback. Attach to the post you\'re publishing from Module 5.',
+    version: SHARED_VERSION,
+    evalScore: 4.6,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['three-versions'],
+    chainsTo: ['proactive-partner'],
+  },
+
+  // ─── 7 ─ Proactive Partner ───────────────────────────────────────────
+  {
+    id: 'proactive-partner',
+    module: 7,
+    title: 'Turn this chat into my proactive content partner',
+    subtitle:
+      'Drop any rough thought — voice note, link, screenshot, half-sentence — and get an audience problem, an angle, 5 hooks, a draft, a visual direction, and a publish/refine recommendation.',
+    body: `${OPERATING_RULE_SHORT}
+
+From now on, act as my proactive personal brand and content partner.
+
+Use everything in this chat as durable context:
+- my ikigai
+- my audience
+- my problems
+- my point of view
+- my examples
+- my tone
+- my strongest content angles
+- my preferred formats
+- my visual style
+
+When I give you any rough thought, voice note, link, article, idea, screenshot, conversation, or half-formed sentence, automatically do this:
+
+1. Identify the audience problem.
+2. Infer the strongest angle.
+3. Decide the best format: LinkedIn post, carousel, short video, infographic, newsletter, landing page section, or workshop exercise.
+4. Create 5 hooks.
+5. Draft the content.
+6. Suggest one premium visual direction.
+7. Suggest one improvement that would make it sharper.
+8. Recommend whether to publish, refine, or save for later.
+
+Do not wait for perfect instructions. Do not ask me to fill templates. Make strong assumptions. State assumptions briefly. Ask only one clarifying question when the missing detail would materially change the output.
+
+Default goal: turn rough thinking into useful public artefacts.`,
+    bestIn: ['ChatGPT', 'Claude', 'Gemini'],
+    outputHandling:
+      'This is the workshop\'s afterlife. Keep this chat open — paste any half-thought into it for the next 30 days. The Coach becomes your standing collaborator.',
+    version: SHARED_VERSION,
+    evalScore: 4.7,
+    voiceGate: 'clean',
+    author: SHARED_AUTHOR,
+    createdAt: SHARED_DATE,
+    lastModified: SHARED_DATE,
+    tested: true,
+    chainsFrom: ['premium-visual'],
+  },
+]


### PR DESCRIPTION
## Frank's pre-workshop call: prompts not good enough

> *"the prompts i am not sure are good enough. Review this new input see and compare against what we have, and we have done and ensure top notch"*

The new 8-prompt stack arrived with a different operating philosophy:

> *"Never ask the participant to complete the system. Make the assistant complete the system from weak signals."*

V8 was Socratic (ask one question at a time, wait for answer). V9 is **proactive** — infer what's missing, state assumptions, deliver publishable artefacts immediately.

## What ships

### `lib/workshop-prompts-v9.ts` — new

- **Coach prompt** carries the full Universal Operating Rule + framing sentence + 7-module arc. Sets the AI's stance for the whole conversation.
- **8 module prompts** (P5+P6 stacked in module 5):
  | ID | Module | Output |
  |---|---|---|
  | `audience-problem-map` | 1 | 3 audience groups + ikigai inferred + recommended starting audience |
  | `content-angle` | 2 | 5 angles scored, strongest written as positioning sentence |
  | `hook-bank` | 3 | 30 hooks × 15 formats + best 5 ranked + sharpest 5 variants |
  | `seven-day-plan` | 4 | 7 daily posts with hooks + outlines + visual ideas |
  | `linkedin-post` | 5a | One strong LinkedIn post (hook → problem → tension → insight → shift → close) |
  | `three-versions` | 5b | Useful / personal / bold + recommendation + hybrid |
  | `premium-visual` | 6 | 3 visual concepts + ready-to-paste image-gen prompt + fallback |
  | `proactive-partner` | 7 | Chat becomes ongoing content partner for the next 30 days |

- Each module body opens with a shortened operating-rule prepend (~40 words) so any standalone prompt still works. Full rule lives in the Coach.

### `app/workshops/ikigai-branding/page.tsx` — wired to V9

10 surgical edits:

| # | Change |
|---|---|
| 1 | Import `WORKSHOP_PROMPTS_V9` instead of V8 |
| 2 | Hero subtitle → Frank's framing sentence ("Your ikigai gives direction…") |
| 3 | 5-outcome panel rewritten (audience map / angle / hook bank / 7-day + post + versions / visual + partner) |
| 4 | AI-as-mirror panel: added operating-rule callout below the three cards |
| 5 | Coach card subhead → "AI runs ahead — never waits for perfect input" |
| 6-12 | Module sections renamed: Audience Problem Map / Content Angle / Hook Bank / 7-Day Plan / Publish (post + 3 versions) / Premium Visual / Proactive Partner |
| 13 | Bridge image caption: hooks→plan (was: purpose→brand) |
| 14 | Header comment updated to V9 |

## New modules vs V8

- **Hook Bank** — entirely new (highest-leverage creator artefact)
- **Three Versions** — new (in V8, Module 7 produced one post in three shapes; V9 produces three voices of the same idea)
- **Proactive Partner** — new (in V8, Module 8 was calendar-locking; V9 turns the chat into ongoing partner)
- **Premium Visual** — resurrected (was M9 in V8 file, dropped from canonical; back as M6 here)

## What stays unchanged

- Hero kanji left rail, NB2 brushstroke, original Venn raster, Kamiya quote, bridge image, kanji cards, email signup
- `/workshops/ikigai-branding/present` route, `/go/qr/ikigai-branding`, `/go/ikigai-coach`
- `lib/workshop-prompts-v8.ts` stays in repo as rollback safety — single-line revert if needed

## Verification

- `tsc --noEmit` against the affected file graph: clean ✓
- 8 positive needles + 3 negatives planned for post-deploy
- Coach prompt regression test on 3 labs (gpt-5-mini, claude-sonnet-4.6, gemini-2.5-flash) — confirm proactive stance (not the old Socratic "ask one question" pattern)
- Per-module smoke test on Audience Problem Map + Hook Bank (the two biggest new modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)