### PR TITLE
fix(deploy): unblock prod — sitemap was over-bundling 42k+ files into the lambda

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,8 +4,13 @@ import path from 'path'
 import matter from 'gray-matter'
 import { researchDomains } from '@/lib/research/domains'
 import { listPartners } from '@/content/partnerships'
-// lib/route-enumeration.mjs is plain ESM JS, intentional for cross-runtime sharing with scripts/
-import { enumerateRoutes } from '@/lib/route-enumeration.mjs'
+// Pre-baked at build time by scripts/build-route-index.mjs (which uses
+// lib/route-enumeration.mjs). Importing the JSON keeps the sitemap lambda
+// small — calling enumerateRoutes() at request time forces Turbopack to
+// bundle every file under content/, data/, lib/research/ etc. into the
+// function (42k+ files → blows past Vercel's 250MB lambda limit and the
+// deploy ERRORs after build).
+import routeIndex from '@/data/route-index.json'
 
 const BASE_URL = 'https://frankx.ai'
 
@@ -661,14 +666,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })
   })
 
-  // Auto-discovery safety net — pull every route from lib/route-enumeration.mjs
-  // (the single source of truth shared with data/route-index.json + the link
-  // checker) and add any that the hand-curated arrays above missed. The
-  // existing entry wins on collision, so manual priority/changeFrequency
-  // settings are preserved.
+  // Auto-discovery safety net — pull every route from the pre-baked
+  // data/route-index.json (built from lib/route-enumeration.mjs at prebuild)
+  // and add any that the hand-curated arrays above missed. The existing
+  // entry wins on collision, so manual priority/changeFrequency settings
+  // are preserved.
   const seenUrls = new Set(entries.map((e) => e.url))
   try {
-    const discovered = enumerateRoutes() as Array<{ href: string; type: string }>
+    const discovered = (routeIndex as { routes: Array<{ href: string; type: string }> }).routes
     // Heuristic priority + frequency by route type — only used for routes that
     // weren't already in the hand-curated arrays above.
     const defaults: Record<string, { priority: number; changeFrequency: 'weekly' | 'monthly' | 'yearly' }> = {
@@ -702,9 +707,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
       })
     }
   } catch (err) {
-    // Don't fail sitemap generation if the enumerator can't load —
-    // the hand-curated arrays above still produce a valid sitemap.
-    console.warn('[sitemap] route-enumeration auto-discovery failed:', (err as Error).message)
+    // Don't fail sitemap generation if the pre-baked index is missing or
+    // malformed — the hand-curated arrays above still produce a valid sitemap.
+    console.warn('[sitemap] route-index auto-discovery failed:', (err as Error).message)
   }
 
   return entries


### PR DESCRIPTION
## Why

Every prod deploy on `main` since 2026-05-22 has been **ERRORing after build succeeds**. Production has been pinned on the older `969ff907` (May 22) since then. As a result the merge of #90 — which added `/learn/gemini-mastery` — is on `main` but **not live on frankx.ai**, and the user is rightfully asking "fix".

This isn't a #90-specific failure. Every prod-target deploy has hit the same wall:

| commit | merged | deploy state |
|--------|--------|-------------|
| `85987ba8` (PR #90, Gemini portal) | 2026-05-23 | ERROR |
| `7bf992b6` (smart-404 follow-ups) | 2026-05-23 | ERROR |
| `a5ba0f2d` (revert regressions batch 2) | 2026-05-22 | ERROR |
| `395489de` (revert regressions) | 2026-05-22 | ERROR |
| `969ff907` (ikigai V9 restore) | 2026-05-22 | READY ← current prod |

## Root cause

The smart-404 follow-up `7bf992b6` wired `app/sitemap.ts` to call `enumerateRoutes()` from `lib/route-enumeration.mjs` **at request time**. That function does live `fs.readdirSync` / `fs.readFileSync` walks across `content/blog`, `content/guides`, `content/newsletters`, `content/partnerships`, `data/*.json`, `data/*.ts`, `lib/research/domains.ts`, etc.

Turbopack can't statically analyze `path.join(ROOT, dynamic)` reads, so it conservatively bundles every file under those patterns into the sitemap lambda. Build-log signal:

```
./lib/route-enumeration.mjs:76:37
The file pattern matches 42598 files in [project]/
./lib/route-enumeration.mjs:57:39
The file pattern matches 21352 files in [project]/
Overly broad patterns can lead to build performance issues and over bundling.
```

Bundle exceeds Vercel's 250MB compressed lambda limit → deploy ERRORs after build completes.

## Fix

Import the **pre-baked** `data/route-index.json` instead. It's already built at prebuild time by `scripts/build-route-index.mjs` (which still uses `route-enumeration.mjs` — that's fine for build-server scripts, just not for lambdas). The JSON has all 559 routes with the same `{ href, type }` shape the auto-discovery branch consumes.

Pattern is already used by 5 sibling files: `middleware.ts`, `app/not-found.tsx`, `app/api/404/alias/route.ts`, `app/api/404/agent/route.ts`, `lib/fuzzy-route-match.ts`. JSON imports are static, Turbopack-trivial, lambda stays small.

`scripts/build-route-index.mjs` and `scripts/check-internal-links.mjs` are unchanged — they still call `enumerateRoutes()` directly because they run on the build server where filesystem walks are fine.

## Unblocks

- `/learn/gemini-mastery` on production (the user-facing reason)
- Every other prod-only change merged to `main` since 5/22 that has been invisible because deploys never finished

## Test plan

- [x] `npm run type-check` → exit 0
- [x] JSON-import pattern matches existing codebase usage
- [ ] Watch Vercel deploy after merge — sitemap lambda should land under the size limit and prod should serve the Gemini portal
- [ ] `curl -I https://frankx.ai/learn/gemini-mastery` returns 200
- [ ] `curl https://frankx.ai/sitemap.xml | head` includes `/learn/gemini-mastery`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NtRsdxZZmsuUvZdRpP5PUy)_