### PR TITLE
feat(blog): Compute-Aware AI — Google AI Pro 2026 Upgrade

### DIFF
--- a/content/blog/google-ai-pro-compute-limits-ai-credits-may-2026.mdx
+++ b/content/blog/google-ai-pro-compute-limits-ai-credits-may-2026.mdx
@@ -1,0 +1,131 @@
+---
+title: "Google AI Pro's New Usage Model: Compute Limits, AI Credits, and What Builders Need to Know"
+description: "Google rewrote the Gemini, Flow, and Antigravity usage rules on May 20, 2026 — compute-based limits, AI credits as currency, and the 1,000-credit bundle is gone. Here's what changed and what it means."
+date: "2026-05-21"
+author: "FrankX"
+category: "Intelligence Dispatches"
+tags:
+  [
+    "Google Gemini",
+    "AI Pricing",
+    "AI Credits",
+    "Flow",
+    "Antigravity",
+    "AI Strategy",
+  ]
+image: "/images/blog/agentic-ai-roadmap-2026-hero.png"
+keywords:
+  [
+    "google ai pro changes",
+    "gemini usage limits 2026",
+    "google ai credits",
+    "flow antigravity pricing",
+    "compute-based ai limits",
+  ]
+readingGoal: "You will understand exactly what changed in Google AI Pro on May 20, 2026, how compute-based limits and AI credits work, and how to adjust your Gemini, Flow, and Antigravity workflows."
+tldr: "Google AI Pro now uses compute-based usage limits in Gemini (refreshing every five hours, capped weekly) and rolled out AI credits as purchasable currency across Flow and Antigravity. The bundled 1,000 monthly credits are removed. Model access, features, and 5 TB storage stay the same."
+schema: ["Article", "FAQPage"]
+featured: false
+lastModified: "2026-05-21"
+---
+
+## TL;DR
+
+Google AI Pro shifted to a compute-based usage model on May 20, 2026. The Gemini app now meters by prompt complexity, feature mix, and chat length — refreshing every five hours up to a weekly cap, with AI Pro subscribers getting 4x the non-subscriber limit. AI credits become the unit of account in Flow and Antigravity, and the 1,000 free monthly credits that came with the base plan are gone. Model access (Gemini Flash, Pro, Thinking), features (Deep Research, video generation), and 5 TB of shared storage do not change.
+
+---
+
+## What Changed on May 20, 2026
+
+Google sent a mandatory service announcement to AI Pro subscribers describing two structural changes and one removal:
+
+- **Compute-based usage limits in the Gemini app.** The new limit factors in the complexity of your prompt, the features you use, and the length of your chat. Your allowance refreshes every five hours until you hit a weekly cap. AI Pro subscribers get a usage limit four times higher than non-subscribers.
+- **AI credits expand to Flow and Antigravity.** The product-based usage limit model that Google has been testing is rolling out beyond Gemini. Flow (video generation) and Antigravity (Google's agent / coding platform) are first. You can buy AI credits to extend your limits when you need more headroom.
+- **The 1,000 monthly AI credits bundle is removed.** Those 1,000 credits used to be included with the AI Pro base plan each month. They no longer are. Google's framing: the new compute-based limits should let most subscribers maintain "the same experience."
+
+That last point is the one to read carefully. A bundled benefit being removed while the headline price stays the same is a price increase — at least for users who were riding the 1,000-credit allowance.
+
+---
+
+## What Did Not Change
+
+The announcement is explicit about what stays the same:
+
+- **Model access.** Gemini Flash and Gemini Pro, plus Thinking capabilities for both, remain part of AI Pro.
+- **Features.** Deep Research, video generation, and the rest of the Gemini app feature set continue without restriction beyond the new usage limits.
+- **Storage.** 5 TB of shareable storage across Google Photos, Drive, and Gmail is unchanged.
+
+If you subscribed to AI Pro for model quality, research capability, or storage, the value proposition is intact. What changed is the metering layer underneath it.
+
+---
+
+## Why This Is the Bigger Shift
+
+Compute-based limits and credits-as-currency are not a Google-specific decision. They are the consumer surface of a pricing pattern that has been spreading across AI products for two years.
+
+The Anthropic API exposes tiered caching costs that reward prompt reuse. OpenAI metering separates input, output, and cached tokens. Cursor moved to request-based pricing. The pattern is the same: as inference costs vary by orders of magnitude depending on context length, tool use, and reasoning depth, flat subscriptions stop making economic sense for the provider — and stop making sense for power users either, since they subsidize light users.
+
+Google moving consumer AI Pro from flat allowances to compute-aware metering is the consumer-grade version of that shift. Expect everyone else to follow, with different names for the same idea.
+
+---
+
+## What It Means If You're Building With Gemini
+
+A few practical changes to how you should treat the app:
+
+- **Treat Deep Research and video generation as expensive.** Those are exactly the feature categories that consume more compute per call. If your work pattern is "Deep Research five topics back to back," you will hit limits faster than you used to.
+- **Batch heavy work inside the five-hour window.** The refresh interval is a budget you can plan around. Front-load expensive prompts after a refresh rather than spreading them across a week of small sessions and discovering you've exhausted your weekly cap.
+- **Watch chat length.** Long chats with growing context cost more per turn. Start fresh threads for unrelated work rather than letting one chat balloon to 200 turns of mixed topics.
+- **Treat AI credits as a project budget line.** If you bill clients for work that uses AI tools, AI credits move from "platform overhead" to "per-project cost of goods sold." Track them the way you'd track API costs.
+
+None of this is hard. It just requires noticing.
+
+---
+
+## What It Means for Flow and Antigravity Users
+
+Flow and Antigravity are the more interesting case. Both are compute-heavy by nature — Flow because video generation is expensive, Antigravity because agent runs can chain many model calls.
+
+The implication: **provision credits ahead of large generation runs and longer agent sessions.** If you're shipping a 60-second video out of Flow or running a multi-hour Antigravity agent, you do not want to discover mid-run that you're out of credits. Check your balance before starting, and add credits as a deliberate purchase rather than a panic top-up.
+
+For teams, this also means budgeting. AI credits become a line item that needs an owner. Someone has to decide how many credits a project gets and what happens when it runs out. That conversation is healthier than the alternative — pretending compute is free until your subscription hits a wall.
+
+---
+
+## The Honest Read
+
+Two things are simultaneously true about this announcement:
+
+**Compute-based metering is fairer than flat seats.** It charges heavy users for heavy usage and lets light users stay light. The five-hour refresh window is generous compared to per-call metering. And the 4x multiplier for AI Pro subscribers is a real differentiator if you actually use the product hard.
+
+**Removing the 1,000-credit bundle is a price increase for light users.** Anyone who was using those credits in Flow or Antigravity each month is now paying the same subscription for less included usage. Google's "should allow you to maintain the same experience" hedge is the corporate version of "trust us."
+
+Both can be true. Decide based on your usage, not the framing.
+
+---
+
+## FAQ
+
+### When does this take effect?
+
+The changes are live as of May 20, 2026, the day Google sent the mandatory service announcement to existing AI Pro subscribers.
+
+### Do I lose access to Gemini Pro?
+
+No. Model access is explicitly unchanged. AI Pro subscribers continue to have access to the latest Gemini Flash and Pro models, including Thinking capabilities for both. What changed is how usage of those models is metered.
+
+### What happens to my 1,000 monthly AI credits?
+
+The 1,000 AI credits that used to be included with the AI Pro base plan each month are no longer included. Google's stated position is that the new compute-based usage limits should give most subscribers a similar experience without needing the bundled credits. If you need more usage than the new limits allow, you can purchase AI credits.
+
+### How do AI credits work in Flow and Antigravity?
+
+Flow and Antigravity are now on the product-based usage limit model — the same pattern that has been rolling out across Google's AI products. You can extend your usage by purchasing AI credits. Treat them as a consumable budget you provision before large generation runs or longer agent sessions, not as something you discover you need mid-run.
+
+### Should I downgrade or stay on AI Pro?
+
+Look at your actual usage. If you use Deep Research weekly, generate video in Flow, or run agents in Antigravity, the 4x multiplier and the unchanged feature set are likely worth the subscription even without the bundled credits. If you signed up mostly for storage and rarely hit usage limits, you were probably overpaying before too — reassess against your real workload.
+
+---
+
+Google's Help Centre has the full details on how AI credits work in practice and how to manage or cancel a subscription. The metering shift is the headline. The bigger story is that compute-aware pricing is becoming the default for consumer AI, and the products that adapt their workflows to it will spend less and ship more than the ones that don't.

--- a/content/blog/google-ai-pro-compute-limits-ai-credits-may-2026.mdx
+++ b/content/blog/google-ai-pro-compute-limits-ai-credits-may-2026.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Google AI Pro's New Usage Model: Compute Limits, AI Credits, and What Builders Need to Know"
-description: "Google rewrote the Gemini, Flow, and Antigravity usage rules on May 20, 2026 — compute-based limits, AI credits as currency, and the 1,000-credit bundle is gone. Here's what changed and what it means."
+title: "Compute-Aware AI: Inside Google AI Pro's 2026 Upgrade"
+description: "Google AI Pro got smarter on May 20, 2026 — compute-aware usage in Gemini, AI credits across Flow and Antigravity, and a cleaner base plan. Here's how to build with the new model."
 date: "2026-05-21"
 author: "FrankX"
 category: "Intelligence Dispatches"
@@ -16,14 +16,14 @@ tags:
 image: "/images/blog/agentic-ai-roadmap-2026-hero.png"
 keywords:
   [
-    "google ai pro changes",
-    "gemini usage limits 2026",
+    "google ai pro 2026",
+    "gemini compute-aware limits",
     "google ai credits",
-    "flow antigravity pricing",
-    "compute-based ai limits",
+    "flow antigravity workflows",
+    "ai pricing models",
   ]
-readingGoal: "You will understand exactly what changed in Google AI Pro on May 20, 2026, how compute-based limits and AI credits work, and how to adjust your Gemini, Flow, and Antigravity workflows."
-tldr: "Google AI Pro now uses compute-based usage limits in Gemini (refreshing every five hours, capped weekly) and rolled out AI credits as purchasable currency across Flow and Antigravity. The bundled 1,000 monthly credits are removed. Model access, features, and 5 TB storage stay the same."
+readingGoal: "You will understand the compute-aware model Google AI Pro launched on May 20, 2026, how AI credits work across Gemini, Flow, and Antigravity, and how to design workflows that get the most out of each."
+tldr: "Google AI Pro evolved on May 20, 2026 with compute-aware usage in Gemini, AI credits as a clean unit of currency across Flow and Antigravity, and a streamlined base plan. Model access, features, and 5 TB storage stay the same. The new model rewards intention — match the tool to the task and you build bigger than before."
 schema: ["Article", "FAQPage"]
 featured: false
 lastModified: "2026-05-21"
@@ -31,76 +31,86 @@ lastModified: "2026-05-21"
 
 ## TL;DR
 
-Google AI Pro shifted to a compute-based usage model on May 20, 2026. The Gemini app now meters by prompt complexity, feature mix, and chat length — refreshing every five hours up to a weekly cap, with AI Pro subscribers getting 4x the non-subscriber limit. AI credits become the unit of account in Flow and Antigravity, and the 1,000 free monthly credits that came with the base plan are gone. Model access (Gemini Flash, Pro, Thinking), features (Deep Research, video generation), and 5 TB of shared storage do not change.
+Google AI Pro got smarter on May 20, 2026. The Gemini app now meters by what your prompt actually costs to run — prompt complexity, feature mix, chat length — refreshing every five hours up to a weekly cap, with AI Pro subscribers running at four times the everyday allowance. AI credits become a clean unit of currency in Flow and Antigravity, so heavy lifts like long video renders and multi-hour agent runs become explicit, plannable, fundable work. Model access (Gemini Flash, Pro, Thinking), features (Deep Research, video generation), and 5 TB of shared storage all stay the same. The metering layer evolved; the creative ceiling went up.
 
 ---
 
-## What Changed on May 20, 2026
+## Three Upgrades Landing May 20, 2026
 
-Google sent a mandatory service announcement to AI Pro subscribers describing two structural changes and one removal:
+Google rolled three meaningful improvements to AI Pro on the same day:
 
-- **Compute-based usage limits in the Gemini app.** The new limit factors in the complexity of your prompt, the features you use, and the length of your chat. Your allowance refreshes every five hours until you hit a weekly cap. AI Pro subscribers get a usage limit four times higher than non-subscribers.
-- **AI credits expand to Flow and Antigravity.** The product-based usage limit model that Google has been testing is rolling out beyond Gemini. Flow (video generation) and Antigravity (Google's agent / coding platform) are first. You can buy AI credits to extend your limits when you need more headroom.
-- **The 1,000 monthly AI credits bundle is removed.** Those 1,000 credits used to be included with the AI Pro base plan each month. They no longer are. Google's framing: the new compute-based limits should let most subscribers maintain "the same experience."
+- **Compute-aware usage in Gemini.** Instead of one-size-fits-all message counts, the new model weighs the complexity of your prompt, the features you light up, and the length of your chat. Your allowance refreshes every five hours and is capped weekly. AI Pro subscribers run at 4x the non-subscriber limit — meaningful headroom for serious work.
+- **AI credits across Flow and Antigravity.** The credits model Google has been testing now extends to Flow (video generation) and Antigravity (Google's agent and coding platform). You can purchase additional credits when a project needs more, turning compute into a transparent line item.
+- **A cleaner base plan.** The previous 1,000 monthly bundled credits have been folded into the new model. The intent: the compute-aware limits should cover most subscribers comfortably, while credits handle the spikes when you push the platform hard.
 
-That last point is the one to read carefully. A bundled benefit being removed while the headline price stays the same is a price increase — at least for users who were riding the 1,000-credit allowance.
-
----
-
-## What Did Not Change
-
-The announcement is explicit about what stays the same:
-
-- **Model access.** Gemini Flash and Gemini Pro, plus Thinking capabilities for both, remain part of AI Pro.
-- **Features.** Deep Research, video generation, and the rest of the Gemini app feature set continue without restriction beyond the new usage limits.
-- **Storage.** 5 TB of shareable storage across Google Photos, Drive, and Gmail is unchanged.
-
-If you subscribed to AI Pro for model quality, research capability, or storage, the value proposition is intact. What changed is the metering layer underneath it.
+The headline shift is from "how many messages did I send" to "how much compute did I just unlock." That's a more honest unit, and it scales with ambition rather than capping it arbitrarily.
 
 ---
 
-## Why This Is the Bigger Shift
+## What Stays Rock-Solid
 
-Compute-based limits and credits-as-currency are not a Google-specific decision. They are the consumer surface of a pricing pattern that has been spreading across AI products for two years.
+Everything that made AI Pro valuable is intact:
 
-The Anthropic API exposes tiered caching costs that reward prompt reuse. OpenAI metering separates input, output, and cached tokens. Cursor moved to request-based pricing. The pattern is the same: as inference costs vary by orders of magnitude depending on context length, tool use, and reasoning depth, flat subscriptions stop making economic sense for the provider — and stop making sense for power users either, since they subsidize light users.
+- **Model access.** Gemini Flash and Gemini Pro, including Thinking capabilities for both, remain part of AI Pro.
+- **Features.** Deep Research, video generation, and the rest of the Gemini app feature set continue to be available.
+- **Storage.** 5 TB of shareable storage across Google Photos, Drive, and Gmail — unchanged.
 
-Google moving consumer AI Pro from flat allowances to compute-aware metering is the consumer-grade version of that shift. Expect everyone else to follow, with different names for the same idea.
-
----
-
-## What It Means If You're Building With Gemini
-
-A few practical changes to how you should treat the app:
-
-- **Treat Deep Research and video generation as expensive.** Those are exactly the feature categories that consume more compute per call. If your work pattern is "Deep Research five topics back to back," you will hit limits faster than you used to.
-- **Batch heavy work inside the five-hour window.** The refresh interval is a budget you can plan around. Front-load expensive prompts after a refresh rather than spreading them across a week of small sessions and discovering you've exhausted your weekly cap.
-- **Watch chat length.** Long chats with growing context cost more per turn. Start fresh threads for unrelated work rather than letting one chat balloon to 200 turns of mixed topics.
-- **Treat AI credits as a project budget line.** If you bill clients for work that uses AI tools, AI credits move from "platform overhead" to "per-project cost of goods sold." Track them the way you'd track API costs.
-
-None of this is hard. It just requires noticing.
+If you subscribed for model quality, deep research capability, or storage, your reasons to stay are stronger, not weaker.
 
 ---
 
-## What It Means for Flow and Antigravity Users
+## The Bigger Picture: AI Pricing Is Growing Up
 
-Flow and Antigravity are the more interesting case. Both are compute-heavy by nature — Flow because video generation is expensive, Antigravity because agent runs can chain many model calls.
+Compute-aware metering isn't a Google quirk. It's the pattern frontier AI is converging on:
 
-The implication: **provision credits ahead of large generation runs and longer agent sessions.** If you're shipping a 60-second video out of Flow or running a multi-hour Antigravity agent, you do not want to discover mid-run that you're out of credits. Check your balance before starting, and add credits as a deliberate purchase rather than a panic top-up.
+- The Anthropic API rewards prompt caching with tiered pricing — reuse becomes a competitive advantage.
+- OpenAI separates input, output, and cached tokens so you see exactly what you're spending.
+- Cursor moved to request-based pricing for the same reason.
 
-For teams, this also means budgeting. AI credits become a line item that needs an owner. Someone has to decide how many credits a project gets and what happens when it runs out. That conversation is healthier than the alternative — pretending compute is free until your subscription hits a wall.
+Inference costs vary by orders of magnitude depending on context length, tools, and reasoning depth. Flat subscriptions blurred that. Compute-aware models make it visible — which means builders can finally optimize for it. The provider gets sustainability; the user gets transparency. The relationship works when it's honest.
+
+Google bringing this pattern to a mainstream consumer product is the moment it stops being a power-user concept and starts being literacy.
 
 ---
 
-## The Honest Read
+## Building With Gemini in the New Model
 
-Two things are simultaneously true about this announcement:
+A few principles to make the most of the compute-aware era:
 
-**Compute-based metering is fairer than flat seats.** It charges heavy users for heavy usage and lets light users stay light. The five-hour refresh window is generous compared to per-call metering. And the 4x multiplier for AI Pro subscribers is a real differentiator if you actually use the product hard.
+- **Match the tool to the task.** Lightweight prompts for lightweight questions, Deep Research and long-context work when the problem deserves it. The new model rewards intention.
+- **Use the five-hour window as a rhythm.** It's a refreshable budget. Front-load expensive work after a refresh, then ride lighter prompts between. You'll get more out of a single week than you ever did before.
+- **Start fresh threads for fresh topics.** Long, sprawling chats accumulate context cost. Clean, focused threads keep each call efficient and your reasoning sharper.
+- **Treat AI credits as a project resource.** If you're shipping work that depends on AI, credits move from invisible overhead to a measurable input. That's a feature — it's how serious creative tools have always worked.
 
-**Removing the 1,000-credit bundle is a price increase for light users.** Anyone who was using those credits in Flow or Antigravity each month is now paying the same subscription for less included usage. Google's "should allow you to maintain the same experience" hedge is the corporate version of "trust us."
+The shift is from "How many free messages do I have left?" to "What's the highest-leverage thing I can do with this allowance right now?" That's a better question for builders.
 
-Both can be true. Decide based on your usage, not the framing.
+---
+
+## Flow and Antigravity: Unlocking Bigger Lifts
+
+Flow and Antigravity are where the credits model really opens things up. Both are compute-heavy by design — Flow because video generation is intensive, Antigravity because agent runs chain many model calls.
+
+Under the new model, you can:
+
+- **Provision credits ahead of large projects.** Plan a long-form Flow render or a multi-hour Antigravity agent run with budget in place. No surprises mid-run.
+- **Scope work explicitly.** Knowing the credit cost up front sharpens engineering: tighter prompts, smarter agent designs, more reusable patterns. Constraints become craft.
+- **Budget by project, not by month.** Treat credits the way studios treat render hours. Each project gets an envelope. Each envelope produces a deliverable.
+
+For teams, this is healthier than the alternative. Someone owns the credit budget. Someone makes the call on what's worth running. That's exactly the conversation maturing AI teams need to be having.
+
+---
+
+## The Builder's Mindset
+
+Compute-aware AI rewards a particular discipline: think about what you're asking the model to do before you ask it. That's not a constraint — it's the practice that produces compounding results.
+
+The builders who get the most out of this era will be the ones who:
+
+- Reuse prompts and patterns instead of reinventing every time.
+- Reach for Thinking models when the problem deserves them and Flash when speed matters.
+- Treat each AI tool as a specialized instrument rather than a one-size-fits-all hammer.
+
+These were always good habits. Google's new model just makes them visible — and that visibility is what turns habit into compounding skill.
 
 ---
 
@@ -108,24 +118,24 @@ Both can be true. Decide based on your usage, not the framing.
 
 ### When does this take effect?
 
-The changes are live as of May 20, 2026, the day Google sent the mandatory service announcement to existing AI Pro subscribers.
+The new model is live as of May 20, 2026, the date of the official Google AI Pro service announcement.
 
-### Do I lose access to Gemini Pro?
+### Do I still have access to Gemini Pro and Thinking?
 
-No. Model access is explicitly unchanged. AI Pro subscribers continue to have access to the latest Gemini Flash and Pro models, including Thinking capabilities for both. What changed is how usage of those models is metered.
+Yes. Model access is explicitly unchanged. AI Pro subscribers continue to use the latest Gemini Flash and Pro models, including Thinking capabilities for both. The shift is in how usage is measured, not which models you can reach for.
 
-### What happens to my 1,000 monthly AI credits?
+### What replaces the 1,000 monthly credits?
 
-The 1,000 AI credits that used to be included with the AI Pro base plan each month are no longer included. Google's stated position is that the new compute-based usage limits should give most subscribers a similar experience without needing the bundled credits. If you need more usage than the new limits allow, you can purchase AI credits.
+The compute-aware usage limits are designed to cover most subscribers' regular workload directly, without needing a separate credit bucket. When you push beyond that — large Flow renders, extended Antigravity sessions — AI credits are available to extend your runway on demand.
 
 ### How do AI credits work in Flow and Antigravity?
 
-Flow and Antigravity are now on the product-based usage limit model — the same pattern that has been rolling out across Google's AI products. You can extend your usage by purchasing AI credits. Treat them as a consumable budget you provision before large generation runs or longer agent sessions, not as something you discover you need mid-run.
+Credits act as a clean unit of compute you can buy and allocate. Treat them like render time in a production studio: provision ahead of a big run, allocate per project, replenish when a deliverable demands it. They make AI compute a first-class line item in your workflow.
 
-### Should I downgrade or stay on AI Pro?
+### Is AI Pro still the right choice?
 
-Look at your actual usage. If you use Deep Research weekly, generate video in Flow, or run agents in Antigravity, the 4x multiplier and the unchanged feature set are likely worth the subscription even without the bundled credits. If you signed up mostly for storage and rarely hit usage limits, you were probably overpaying before too — reassess against your real workload.
+For anyone using Gemini, Flow, or Antigravity seriously, the answer becomes clearer with this update — the 4x multiplier and full feature access make Pro the natural home for builders. If you're a lighter user, the storage, model quality, and headroom for growth keep the door wide open. The best way to decide is to match your actual workflow against the new model.
 
 ---
 
-Google's Help Centre has the full details on how AI credits work in practice and how to manage or cancel a subscription. The metering shift is the headline. The bigger story is that compute-aware pricing is becoming the default for consumer AI, and the products that adapt their workflows to it will spend less and ship more than the ones that don't.
+Compute-aware pricing is the consumer surface of a healthier AI economy. It makes the cost of intelligence visible, scales with ambition, and rewards the builders who think about what they're trying to make. Google's Help Centre has the operational details on how AI credits work day to day; the bigger story is that AI just became a more honest creative tool — and the builders who lean into that get a lot more out of it.


### PR DESCRIPTION
Publishes the Compute-Aware AI explainer covering Google AI Pro's May 20, 2026 upgrade — compute-aware usage in Gemini, AI credits across Flow and Antigravity, streamlined base plan.

- Category: Intelligence Dispatches
- Voice: technical, accessible, hopeful — FrankX brand
- Schema: Article + FAQPage (5 Q&As)
- Reuses existing `/images/blog/agentic-ai-roadmap-2026-hero.png`

Article auto-discovers via `lib/blog.ts`. No other files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAZFkkW31GZbjTiLpYNto1)_