### PR TITLE
fix(nav): restore mobile menu overlay (hotfix — broken on prod)

### DIFF
--- a/components/NavigationMega.tsx
+++ b/components/NavigationMega.tsx
@@ -43,7 +43,7 @@ import {
 } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
-// import MobileNavOverlay from '@/components/MobileNavOverlay'
+import MobileNavOverlay from '@/components/MobileNavOverlay'
 
 // Navigation: 5 megas + Blog. Invest merged into Build (AI Architecture covers enterprise + investor tooling).
 const navigation = {
@@ -512,7 +512,7 @@ export default function NavigationMega() {
         </nav>
       </header>
 
-      {/* Mobile nav overlay removed */}
+      <MobileNavOverlay isOpen={isOpen} onClose={() => setIsOpen(false)} />
     </>
   )
 }


### PR DESCRIPTION
## Hotfix — mobile menu is broken on prod right now

Commit `0b0a474b chore: sync FrankX production hardening` commented out `MobileNavOverlay` and removed its render block from `NavigationMega`. The hamburger button still toggles `isOpen` but nothing draws — the mobile menu has been dead since that commit landed.

The two `revert(regressions...)` commits that followed (`#395489de`, `#a5ba0f2d`) restored other clobbered files but missed this one. `MobileNavOverlay.tsx` itself is intact — just disconnected.

## Change

2 lines in `components/NavigationMega.tsx`:
1. Uncomment the `MobileNavOverlay` import.
2. Render `<MobileNavOverlay isOpen onClose>` (signature unchanged from pre-regression).

## Verification

- `npm run type-check` — clean
- `MobileNavOverlay` sits at `z-[90]`, header at `z-50`, so it cleanly covers global chrome when open
- This same fix is also bundled in PR #93 (Studio Crew freemium chat) but extracted here so prod can be unblocked immediately without waiting for that PR's CI

Merging this as soon as CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1X65PZta1URtN61zGoAav)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled mobile navigation overlay functionality to improve navigation experience on mobile devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankxai/frankx.ai-vercel-website/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->