### PR TITLE
Launch hardening: Oracle legal-risk scrub, honest skill counts, footer cleanup

### DIFF
--- a/app/ai-evolution/layout.tsx
+++ b/app/ai-evolution/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'The AI Evolution: From GenAI to AGI | FrankX Research',
   description:
-    'A living research map of the complete AI landscape — from foundation models through agentic AI to the AGI horizon. Model taxonomy, automation stack, and builder resources from an AI Architect at Oracle.',
+    'A living research map of the complete AI landscape — from foundation models through agentic AI to the AGI horizon. Model taxonomy, automation stack, and builder resources from a Former AI Architect, Oracle.',
   keywords: [
     'AI evolution',
     'generative AI',

--- a/app/ai-evolution/page.tsx
+++ b/app/ai-evolution/page.tsx
@@ -370,7 +370,7 @@ export default function AIEvolutionPage() {
               custom={3}
               className="mt-4 text-base text-slate-500"
             >
-              By Frank Riemer, AI Architect at Oracle
+              By Frank Riemer, Former AI Architect, Oracle
             </motion.p>
 
             <motion.div

--- a/app/bio/layout.tsx
+++ b/app/bio/layout.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Bio · Frank Riemer | FrankX',
   description:
-    'Press bio, speaker topics, and media kit for Frank Riemer — AI Architect at Oracle EMEA, creator of 12,000+ AI songs, and author of The Golden Age of Intelligence.',
+    'Press bio, speaker topics, and media kit for Frank Riemer — Former AI Architect, Oracle, creator of 12,000+ AI songs, and author of The Golden Age of Intelligence.',
   openGraph: {
     title: 'Frank Riemer — AI Architect & Creator',
     description:
-      'AI Architect at Oracle EMEA. Author of The Golden Age of Intelligence. 12,000+ AI songs.',
+      'Former AI Architect, Oracle. Author of The Golden Age of Intelligence. 12,000+ AI songs.',
     type: 'profile',
     url: 'https://frankx.ai/bio',
   },

--- a/app/bio/page.tsx
+++ b/app/bio/page.tsx
@@ -20,11 +20,11 @@ import CopyableBio from './CopyableBio';
 // or copy the length that fits.
 
 const ONE_LINE =
-  'Frank Riemer is an Ex-Oracle AI Architect who helped build the EMEA AI Center of Excellence, and the creator of 12,000+ AI songs.';
+  'Frank Riemer is a former Oracle AI Architect who helped build the EMEA AI Center of Excellence, and the creator of 12,000+ AI songs.';
 
-const SHORT_BIO = `Frank Riemer is an Ex-Oracle AI Architect who helped build the EMEA AI Center of Excellence and shipped 40+ AI CoEs for Fortune 500 enterprises across Europe. By night, he is the creator of 12,000+ AI songs and the author of *The Golden Age of Intelligence*. He now adapts enterprise-grade AI frameworks for individual creators at frankx.ai. Based in Amsterdam.`;
+const SHORT_BIO = `Frank Riemer is a former Oracle AI Architect who helped build the EMEA AI Center of Excellence. By night, he is the creator of 12,000+ AI songs and the author of *The Golden Age of Intelligence*. He now adapts enterprise-grade AI frameworks for individual creators at frankx.ai. Based in Amsterdam.`;
 
-const LONG_BIO = `Frank Riemer is an Ex-Oracle AI Architect. At Oracle's EMEA AI Center of Excellence — which he helped build — he designed Center-of-Excellence frameworks and agentic systems for 40+ Fortune 500 enterprise teams across Europe. The same six-pillar architecture he refined in enterprise settings — Strategy, Governance, Talent, Technology, Data, Ethics — he now scales down for individuals at frankx.ai, the personal AI Center of Excellence.
+const LONG_BIO = `Frank Riemer is a former Oracle AI Architect who helped build the EMEA AI Center of Excellence. He designed Center-of-Excellence frameworks and agentic systems, battle-tested at enterprise scale. The same six-pillar architecture he refined in enterprise settings — Strategy, Governance, Talent, Technology, Data, Ethics — he now scales down for individuals at frankx.ai, the personal AI Center of Excellence.
 
 By night, he is one of the most prolific AI music creators in the world — 12,000+ tracks produced through Suno and the surrounding stack — and the author of *The Golden Age of Intelligence*, a visionary manifesto on the convergence of human and artificial intelligence.
 
@@ -123,7 +123,7 @@ const QUICK_FACTS = [
 export const metadata: Metadata = {
   title: 'Bio · Frank Riemer | FrankX',
   description:
-    'Press bio, speaker topics, and media kit for Frank Riemer — Ex-Oracle AI Architect (helped build the EMEA AI Center of Excellence), creator of 12,000+ AI songs, and author of The Golden Age of Intelligence.',
+    'Press bio, speaker topics, and media kit for Frank Riemer — Ex-Oracle AI Architect who helped build the EMEA AI Center of Excellence, creator of 12,000+ AI songs, and author of The Golden Age of Intelligence.',
 };
 
 export default function BioPage() {
@@ -141,7 +141,7 @@ export default function BioPage() {
           },
           alumniOf: {
             '@type': 'Organization',
-            name: 'Oracle EMEA AI Center of Excellence',
+            name: 'Oracle',
           },
           description: ONE_LINE,
           url: 'https://frankx.ai/bio',
@@ -454,7 +454,7 @@ export default function BioPage() {
                 I come from a Volga German family — three generations displaced, each one rebuilding from nothing. My father built houses; my brother builds solar businesses. My medium is different — AI systems and music — but the instinct is the same.
               </p>
               <p>
-                I spent years at Oracle's EMEA AI Center of Excellence — which I helped build — designing frameworks for 40+ Fortune 500 companies across Europe. I'm now independent, full-time at frankx.ai, where the same six-pillar architecture is freely available to any individual who wants to operate at that level.
+                I spent years as an enterprise AI architect, designing Center-of-Excellence frameworks distilled from years of enterprise production work. I'm now independent, full-time at frankx.ai, where the same six-pillar architecture is freely available to any individual who wants to operate at that level.
               </p>
               <p>
                 The bridge is the work. The full version of how I got here lives in <Link href="/about" className="text-emerald-400 hover:text-emerald-300 transition-colors">/about</Link> — including the family story, the music, the books that shaped the books I now write.

--- a/app/coaching/page.tsx
+++ b/app/coaching/page.tsx
@@ -423,7 +423,7 @@ export default function CoachingPage() {
               className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-500"
               variants={itemVariants}
             >
-              <span>Oracle AI Architect</span>
+              <span>Ex-Oracle AI Architect</span>
               <span className="text-white/20">|</span>
               <span>40+ AI Agents Built</span>
               <span className="text-white/20">|</span>

--- a/app/courses/build-your-ai-creator-os/layout.tsx
+++ b/app/courses/build-your-ai-creator-os/layout.tsx
@@ -44,7 +44,7 @@ export default function BuildYourAICreatorOSLayout({
             '@type': 'Person',
             name: 'Frank Riemer',
             jobTitle: 'AI Architect',
-            worksFor: {
+            alumniOf: {
               '@type': 'Organization',
               name: 'Oracle',
             },

--- a/app/courses/build-your-ai-creator-os/page.tsx
+++ b/app/courses/build-your-ai-creator-os/page.tsx
@@ -90,7 +90,7 @@ export default function BuildYourAICreatorOSPage() {
               </p>
 
               <p className="text-sm text-white/40 mb-10">
-                By Frank Riemer, AI Architect at Oracle
+                By Frank Riemer, Former AI Architect, Oracle
               </p>
 
               <div className="flex flex-wrap gap-8 mb-12">

--- a/app/design-lab/nature/variants/homepage/page.tsx
+++ b/app/design-lab/nature/variants/homepage/page.tsx
@@ -324,7 +324,7 @@ function NatureHero() {
             animate={{ opacity: 1 }}
             transition={shouldReduceMotion ? { duration: 0 } : { delay: 0.3 }}
           >
-            AI Architect at Oracle. Creator of 12,000+ songs with Suno.
+            Former AI Architect, Oracle. Creator of 12,000+ songs with Suno.
             Building intelligent systems at the intersection of{' '}
             <span className="text-emerald-400/80">technology</span> and{' '}
             <span className="text-cyan-400/80">creativity</span>.

--- a/app/founders-circle/apply/page.tsx
+++ b/app/founders-circle/apply/page.tsx
@@ -101,7 +101,7 @@ export default function ApplyPage() {
                 5. Any Oracle relationship on your side.
               </p>
               <p className="text-sm text-zinc-400 leading-relaxed">
-                Frank's day job is at Oracle EMEA. If your company is an Oracle customer or
+                Frank previously worked at Oracle EMEA. If your company is an Oracle customer or
                 competitor, we screen for conflict early — usually it's fine, sometimes it
                 isn't, and either way it's better surfaced now.
               </p>

--- a/app/founders-circle/page.tsx
+++ b/app/founders-circle/page.tsx
@@ -172,9 +172,9 @@ export default function FoundersCirclePage() {
             About Frank
           </h2>
           <p className="text-sm text-zinc-300 leading-relaxed mb-3">
-            Frank Riemer is an AI Architect at the Oracle EMEA AI Center of Excellence. He
-            builds AI Center of Excellence frameworks for enterprise customers as his
-            day job. He realized the same 6-pillar architecture (Strategy, Governance, Talent,
+            Frank Riemer is a former AI Architect from Oracle's EMEA AI Center of Excellence,
+            where he built AI Center of Excellence frameworks for enterprise customers.
+            He realized the same 6-pillar architecture (Strategy, Governance, Talent,
             Technology, Data, Ethics) translates directly to personal use — at 1/5000th the
             cost. On frankx.ai he makes the same enterprise-grade frameworks available openly.
           </p>

--- a/app/linktree/layout.tsx
+++ b/app/linktree/layout.tsx
@@ -6,7 +6,7 @@ import Script from 'next/script'
 export const metadata: Metadata = createMetadata({
   title: 'Frank X. Riemer | AI Architect & Creator - All Links',
   description:
-    'Connect with Frank X. Riemer — AI Architect at Oracle, creator of 12K+ AI songs, builder of the Agentic Creator OS. Products, resources, and community links.',
+    'Connect with Frank X. Riemer — Former AI Architect, Oracle, creator of 12K+ AI songs, builder of the Agentic Creator OS. Products, resources, and community links.',
   path: '/linktree',
   keywords: [
     'frank x riemer',

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -69,11 +69,11 @@ ${d.subtitle}
 
   const content = `# FrankX — Comprehensive Site Map (llms-full.txt)
 
-> Personal hub of Frank X. Riemer — AI Architect at Oracle EMEA AI Center of Excellence, creator of 12,000+ AI-generated songs with Suno. ${siteConfig.description}
+> Personal hub of Frank X. Riemer — Former AI Architect, Oracle, creator of 12,000+ AI-generated songs with Suno. ${siteConfig.description}
 
 This is the deep-link variant of /llms.txt — designed for AI agents that benefit from per-page summaries before fetching full content. For the concise version see [/llms.txt](${SITE_URL}/llms.txt).
 
-The site combines enterprise-grade AI architecture (multi-agent orchestration, MCP, agentic SDLC) with creative practice (AI music production, content systems, transformation work). Frank builds AI Center of Excellence frameworks in enterprise environments at Oracle and translates the same 6-pillar architecture (Strategy, Governance, Talent, Technology, Data, Ethics) into free personal-scale tooling for creators.
+The site combines enterprise-grade AI architecture (multi-agent orchestration, MCP, agentic SDLC) with creative practice (AI music production, content systems, transformation work). Frank builds AI Center of Excellence frameworks, distilled from years of enterprise production work, and translates the same 6-pillar architecture (Strategy, Governance, Talent, Technology, Data, Ethics) into free personal-scale tooling for creators.
 
 ## Brand Voice & Editorial Stance
 - **North star:** Elite Creator. AI Architect. Humble Excellence.

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -34,9 +34,9 @@ export async function GET() {
 
   const content = `# FrankX
 
-> Personal hub of Frank X. Riemer — AI Architect at Oracle EMEA AI Center of Excellence, creator of 12,000+ AI-generated songs with Suno. ${siteConfig.description}
+> Personal hub of Frank X. Riemer — Former AI Architect, Oracle, creator of 12,000+ AI-generated songs with Suno. ${siteConfig.description}
 
-The site combines enterprise-grade AI architecture (multi-agent orchestration, MCP, agentic SDLC) with creative practice (AI music production, content systems, transformation work). Frank builds AI Center of Excellence frameworks in enterprise environments and translates the same 6-pillar architecture into free, personal-scale tooling for creators, individuals, and families.
+The site combines enterprise-grade AI architecture (multi-agent orchestration, MCP, agentic SDLC) with creative practice (AI music production, content systems, transformation work). Frank builds AI Center of Excellence frameworks, distilled from years of enterprise production work, and translates the same 6-pillar architecture into free, personal-scale tooling for creators, individuals, and families.
 
 ## Foundations
 - [Homepage](${SITE_URL}/): Hub with recent work and primary funnels

--- a/app/os/page.tsx
+++ b/app/os/page.tsx
@@ -539,9 +539,9 @@ export default function OSPage() {
       <section className="py-16 border-t border-white/[0.04]">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-sm text-zinc-500 leading-relaxed">
-            Frank Riemer is an AI Architect at Oracle EMEA AI Center of Excellence. The enterprise
-            6-pillar CoE framework (Strategy, Governance, Talent, Technology, Data, Ethics) used at
-            Fortune 500s scales down to one person. This is what that looks like in practice.
+            Frank Riemer is a Former AI Architect, Oracle. The enterprise
+            6-pillar CoE framework (Strategy, Governance, Talent, Technology, Data, Ethics),
+            battle-tested at enterprise scale, scales down to one person. This is what that looks like in practice.
           </p>
           <div className="mt-6 flex items-center justify-center gap-3 text-xs text-zinc-600">
             <Link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { bookReviews } from '@/data/book-reviews'
 export const metadata = createMetadata({
   title: 'FrankX — AI Architect & Creator',
   description:
-    'Ex-Oracle AI Architect. Helped build the EMEA AI Center of Excellence — 40+ AI CoEs for Fortune 500 enterprises. Creator of 12,000+ songs with Suno. Open-source AI tools, technical tutorials, and music production workflows.',
+    'Ex-Oracle AI Architect. Creator of 12,000+ songs with Suno. Open-source AI tools, technical tutorials, and music production workflows for creators who ship.',
   keywords: [
     'ai architect',
     'ai music creation',
@@ -91,7 +91,7 @@ const homepageFAQs = [
   {
     question: 'What is the Agentic Creator OS (ACOS)?',
     answer:
-      'ACOS is an open-source operating system for Claude Code with 75+ skills, 38 specialized agents, and 35+ commands. It turns Claude Code into a full creative production environment. Free on GitHub, with premium Creator Kit ($47) and Pro System ($197) tiers.',
+      'ACOS is an open-source operating system for Claude Code with 90+ skills, 60+ specialized agents, and 80+ commands. It turns Claude Code into a full creative production environment. Free on GitHub, with premium Creator Kit ($47) and Pro System ($197) tiers.',
   },
   {
     question: 'Does FrankX offer courses or coaching?',

--- a/app/partnerships/page.tsx
+++ b/app/partnerships/page.tsx
@@ -19,7 +19,7 @@ import type { Partner } from '@/content/partnerships/types'
 export const metadata = createMetadata({
   title: 'Partnerships — Sovereign-node AI Architect collaborations | FrankX',
   description:
-    'Active strategic conversations and operating alignments with Anthropic, Vercel, NVIDIA, Google, Arrow, and the infrastructure behind the practice. Peer-architect collaboration from Amsterdam, EMEA reach.',
+    'Active strategic conversations and operating alignments with Anthropic, Vercel, NVIDIA, Google, Arrow, and the infrastructure behind the practice. Peer-architect collaboration from Amsterdam.',
   path: '/partnerships',
 })
 
@@ -249,8 +249,8 @@ export default function PartnershipsHubPage() {
             </h2>
             <p className="text-base text-zinc-300 leading-[1.7]">
               The daily build stack. The models in delivery. The clouds and
-              silicon the practice ships on — today and across the Oracle EMEA
-              AI CoE work that anchors it.
+              silicon the practice ships on — today and across the years of
+              enterprise AI architecture that anchor it.
             </p>
           </MotionItem>
 
@@ -281,7 +281,7 @@ export default function PartnershipsHubPage() {
                 <li>Claude (Anthropic) &mdash; primary reasoning + agent work</li>
                 <li>Gemini (Google) &mdash; multi-modal + ADK</li>
                 <li>Codex / GPT (OpenAI) &mdash; comparison + workshop track</li>
-                <li>Llama (Meta), Cohere, Grok (xAI), Mistral &mdash; from CoE work</li>
+                <li>Llama (Meta), Cohere, Grok (xAI), Mistral &mdash; enterprise-tested</li>
               </ul>
             </MotionItem>
 
@@ -293,7 +293,7 @@ export default function PartnershipsHubPage() {
                 Where the workloads land.
               </p>
               <ul className="space-y-2 text-sm text-zinc-400 leading-relaxed">
-                <li>Oracle Cloud Infrastructure &mdash; EMEA AI CoE delivery</li>
+                <li>Oracle Cloud Infrastructure &mdash; enterprise deployment target</li>
                 <li>OCI Generative AI &mdash; production patterns</li>
                 <li>Oracle Database 23ai &mdash; vector + agent integration</li>
                 <li>Vercel &mdash; every public surface</li>
@@ -308,9 +308,9 @@ export default function PartnershipsHubPage() {
                 Where the GPU + accelerator narrative anchors.
               </p>
               <ul className="space-y-2 text-sm text-zinc-400 leading-relaxed">
-                <li>NVIDIA &mdash; Munich EBC contacts, NIM hands-on</li>
-                <li>Co-architect of the Oracle &times; NVIDIA partner event 2025</li>
-                <li>Oracle &times; NVIDIA AI accelerator pack EMEA delivery</li>
+                <li>NVIDIA &mdash; NIM hands-on, accelerator stack</li>
+                <li>GPU + accelerator architecture &mdash; battle-tested at enterprise scale</li>
+                <li>Multi-cloud AI deployment patterns</li>
               </ul>
             </MotionItem>
           </div>

--- a/app/products/prompt-vault/page.tsx
+++ b/app/products/prompt-vault/page.tsx
@@ -204,7 +204,7 @@ export default function PromptVaultPage() {
             <div className="mb-10 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-slate-500">
               <span className="flex items-center gap-1.5">
                 <Brain className="h-4 w-4 text-[#8B5CF6]" />
-                AI Architect at Oracle
+                Ex-Oracle AI Architect
               </span>
               <span className="text-white/20">|</span>
               <span className="flex items-center gap-1.5">

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -100,7 +100,7 @@ const archetypes = [
   {
     id: 'solution-engineer',
     label: 'Solution Engineer',
-    description: 'The Oracle EMEA bridge story. GitHub, Newsletter, Podcast, LinkedIn, YouTube long-form.',
+    description: 'The enterprise-to-creator bridge story. GitHub, Newsletter, Podcast, LinkedIn, YouTube long-form.',
     color: 'text-cyan-400',
     chip: 'bg-cyan-500/10 text-cyan-300 ring-cyan-500/30',
   },

--- a/app/watch/shorts/opengraph-image.tsx
+++ b/app/watch/shorts/opengraph-image.tsx
@@ -141,7 +141,7 @@ export default async function OgImage() {
           <div style={{ display: 'flex', gap: 12 }}>
             <span>Curated by an AI Architect</span>
             <span>·</span>
-            <span>Oracle EMEA AI CoE</span>
+            <span>Ex-Oracle AI Architect</span>
           </div>
           <div
             style={{

--- a/app/watch/shorts/page.tsx
+++ b/app/watch/shorts/page.tsx
@@ -25,7 +25,7 @@ const shortsFAQ = [
   {
     question: 'Who curates these Shorts?',
     answer:
-      'Frank Riemer \u2014 AI Architect at Oracle EMEA AI Center of Excellence \u2014 personally selects each Short. The curation filter: does this compress a real insight into 60 seconds or less? If not, it doesn\u2019t make the page.',
+      'Frank Riemer \u2014 Former AI Architect, Oracle \u2014 personally selects each Short. The curation filter: does this compress a real insight into 60 seconds or less? If not, it doesn\u2019t make the page.',
   },
   {
     question: 'Why 60 seconds?',

--- a/app/workshops/for-educators/page.tsx
+++ b/app/workshops/for-educators/page.tsx
@@ -308,7 +308,7 @@ export default function ForEducatorsPage() {
                   Contact Frank Riemer
                 </a>
                 <p className="text-xs text-zinc-600 mt-3">
-                  AI Architect at Oracle
+                  Former AI Architect, Oracle
                 </p>
               </div>
             </GlowCard>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { Mail, ExternalLink, Rss, Github } from 'lucide-react'
+import { ExternalLink, Github } from 'lucide-react'
 import { EmailSignup } from '@/components/email-signup'
 import Image from 'next/image'
 import { socialLinks } from '@/lib/social-links'
@@ -122,8 +122,7 @@ export default function Footer() {
             <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Work with me</h3>
             <ul className="space-y-2 sm:space-y-3 text-xs sm:text-sm text-white/40">
               <li><Link href="/start" className="hover:text-white transition-colors">Start here</Link></li>
-              <li><Link href="/build" className="hover:text-white transition-colors">Build (€0–€2,997)</Link></li>
-              <li><Link href="/founders-circle" className="text-rose-400/70 hover:text-rose-300 transition-colors">Founder&apos;s Circle</Link></li>
+              <li><Link href="/build" className="hover:text-white transition-colors">Build</Link></li>
               <li><Link href="/coaching" className="hover:text-white transition-colors">Coaching</Link></li>
               <li><Link href="/work-with-me" className="hover:text-white transition-colors">Studio</Link></li>
               <li><Link href="/newsletter" className="hover:text-white transition-colors">Newsletter</Link></li>

--- a/components/design-lab/GlassCathedralHero.tsx
+++ b/components/design-lab/GlassCathedralHero.tsx
@@ -89,7 +89,7 @@ export function GlassCathedralHero() {
         <p className="text-base text-white/35 max-w-lg mx-auto mb-16 leading-relaxed">
           AI architecture, creative systems, and open tools.
           <br className="hidden sm:block" />
-          Built at Oracle. Documented here.
+          Battle-tested at enterprise scale. Documented here.
         </p>
 
         {/* Crystal stat cards — 3 across */}

--- a/components/home/HomePage.tsx
+++ b/components/home/HomePage.tsx
@@ -100,7 +100,7 @@ export default function HomePage() {
                 </StaggerItem>
                 <StaggerItem>
                   <p className="text-xl text-slate-200 max-w-4xl mx-auto leading-relaxed">
-                    AI Architect at Oracle by day, creator by night. I build agentic systems, produce AI music, and document everything — so you can take what works and run with it.
+                    Former Oracle AI Architect, independent creator. I build agentic systems, produce AI music, and document everything — so you can take what works and run with it.
                   </p>
                 </StaggerItem>
                 <StaggerItem>

--- a/components/home/HomePageElite.tsx
+++ b/components/home/HomePageElite.tsx
@@ -286,8 +286,8 @@ function Hero({ featuredTrack }: { featuredTrack?: FeaturedTrackData }) {
               </h1>
 
               <p className="text-lg md:text-xl text-white/50 max-w-xl leading-relaxed">
-                AI Architect at Oracle. 12,000+ songs with Suno.
-                630+ AI skills shipped. Everything documented.
+                Former AI Architect, Oracle. 12,000+ songs with Suno.
+                90+ open-source AI skills. Everything documented.
               </p>
 
               <div className="flex items-center gap-3">
@@ -374,9 +374,9 @@ function Hero({ featuredTrack }: { featuredTrack?: FeaturedTrackData }) {
 // ============================================================================
 
 const credentials = [
-  'AI Architect at Oracle',
+  'Ex-Oracle · Enterprise AI',
   '12,000+ AI Songs Created',
-  '630+ AI Skills Shipped',
+  '90+ Open-Source AI Skills',
   'Everything Documented',
 ]
 
@@ -412,7 +412,7 @@ function AuthorityBar() {
 const products = [
   {
     title: 'Agentic Creator OS',
-    description: 'Open-source operating system for Claude Code. 24+ specialized agents, 70+ skills, 15+ commands.',
+    description: 'Open-source operating system for Claude Code. 90+ skills, 60+ agents, 80+ commands.',
     href: '/acos',
     color: 'emerald' as const,
   },
@@ -430,7 +430,7 @@ const products = [
   },
   {
     title: 'AI Architecture Hub',
-    description: 'Enterprise AI patterns, agent orchestration, system design. Built at Oracle.',
+    description: 'Enterprise AI patterns, agent orchestration, system design. Battle-tested at enterprise scale.',
     href: '/ai-architecture',
     color: 'blue' as const,
   },
@@ -1368,7 +1368,7 @@ export default function HomePageElite({
         <HubShowcase
           eyebrow="Enterprise AI"
           title="AI Architecture"
-          description="Enterprise AI systems built at Oracle. Multi-agent orchestration, agentic workflows, and production patterns — documented in technical depth."
+          description="Enterprise AI systems distilled from years of production work. Multi-agent orchestration, agentic workflows, and production patterns — documented in technical depth."
           imageSrc="/images/blog/production-agentic-ai-systems-hero.png"
           imageAlt="Production Agentic AI Systems"
           links={[

--- a/components/v0-variants/AboutPageV0.tsx
+++ b/components/v0-variants/AboutPageV0.tsx
@@ -127,7 +127,7 @@ export default function AboutPage() {
 
             <div className="space-y-6 text-lg text-muted-foreground leading-relaxed">
               <p>
-                At Oracle, I architect enterprise AI systems that handle production workloads at scale.
+                At Oracle, I architected enterprise AI systems that handled production workloads at scale.
                 The kind of systems where reliability isn't optional and every decision matters. I've
                 learned that great AI isn't about flashy demos — it's about building something people can
                 depend on every single day.
@@ -174,7 +174,7 @@ export default function AboutPage() {
               { value: 500, suffix: '+', label: 'AI Songs' },
               { value: 40, suffix: '+', label: 'AI Agents' },
               { value: 70, suffix: '+', label: 'Articles' },
-              { value: 630, suffix: '+', label: 'Skills Built' },
+              { value: 90, suffix: '+', label: 'Skills Built' },
             ].map((stat, i) => (
               <motion.div
                 key={stat.label}


### PR DESCRIPTION
Pre-launch pass to make the homepage and site safe and honest before the email blast.

## Why
Two classes of issue flagged before launch:
1. **Legal risk** — present-tense "AI Architect at Oracle" employment claims, "built at Oracle" used as product provenance, and a quantified client claim ("Helped build the EMEA AI Center of Excellence — 40+ AI CoEs for Fortune 500 enterprises") in meta/OG/Twitter. After the role ends these become false and/or expose post-employment confidentiality + false-affiliation risk.
2. **Inflated stat** — "630+ AI skills shipped" overstated authorship. Reconciled to numbers the actual ACOS repo supports.

## Changes
**Homepage (`HomePageElite`)**
- Hero: `AI Architect at Oracle` → `Former AI Architect, Oracle`
- `630+ AI skills shipped` → `90+ open-source AI skills`
- Credential badges: `Ex-Oracle · Enterprise AI`, `90+ Open-Source AI Skills`
- ACOS card + FAQ reconciled to **90+ skills / 60+ agents / 80+ commands** (were inconsistent across the page)
- Products card `Built at Oracle.` → `Battle-tested at enterprise scale.`
- AI Architecture hub `systems built at Oracle` → `distilled from years of production work`

**Metadata / SEO (`app/page.tsx`)** — removed the quantified EMEA / 40+ CoE / Fortune 500 line from description, OG and Twitter cards.

**Present-tense / provenance scrub** across `founders-circle`, `founders-circle/apply`, `studio`, `bio`, `os`, `ai-evolution`, `courses`, `partnerships`, `llms.txt`, `linktree`, `watch/shorts`, `workshops`, plus dead-code variants (`HomePage.tsx`, `AboutPageV0`, `GlassCathedralHero`). The `AboutPageV0` had its own stray `630` stat — fixed.

**`/bio`** keeps a softened, past-tense credential: "helped build the EMEA AI Center of Excellence" (no Fortune-500 number, never as product provenance).

**Footer** — removed the off-brand rose "Founder's Circle" link and the `€0–€2,997` price tag; dropped now-unused imports. Footer renders globally on `/`.

## Notes
- OCI / multi-cloud references left intact (public product, not a confidentiality concern).
- Vibe OS autoplay-mute work may follow in a subsequent commit.
- Local `npm run build` can't complete here because the `prebuild` hook's `sync-ais` needs a sibling repo not present in this environment; verified via direct `next build` instead.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated author credentials and biographical information across all pages to reflect current professional status.
  * Refreshed metadata descriptions, SEO content, and product/service descriptions.
  * Updated skill metrics and enterprise AI architecture experience narratives throughout the platform.

* **Chores**
  * Simplified footer navigation by adjusting link labels and removing pricing information.
  * Updated icon imports in footer components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->