### PR TITLE
obs(vercel-cost): 2026-W23 snapshot — RED

### DIFF
--- a/data/observability/vercel-cost/2026-W23.json
+++ b/data/observability/vercel-cost/2026-W23.json
@@ -1,0 +1,38 @@
+{
+  "week": "2026-W23",
+  "generatedAt": "2026-06-01T07:04:25Z",
+  "projectId": "prj_NHVIKZtglNidOE1FJiq6eYx5QjIL",
+  "windowDays": 7,
+  "windowStart": "2026-05-25T07:04:25Z",
+  "windowEnd": "2026-06-01T07:04:25Z",
+  "metrics": {
+    "count_total": 62,
+    "count_production": 24,
+    "count_preview": 38,
+    "count_skipped": 3,
+    "count_error": 14,
+    "count_ready": 45,
+    "duration_p50_seconds": 337,
+    "duration_p95_seconds": 373,
+    "duration_max_seconds": 432,
+    "total_build_minutes": 256.5,
+    "duration_method": "readyAt_minus_buildingAt",
+    "ready_deploys_sampled": 15,
+    "ready_deploys_total": 45,
+    "duration_note": "15/45 READY deploys sampled via get_deployment; total_build_minutes extrapolated as avg(342s) × 45 = 256.5 min"
+  },
+  "deltas_vs_prior_week": {
+    "duration_p50_seconds": "-10",
+    "count_total": "-21",
+    "total_build_minutes": "-90",
+    "prior_week": "2026-W22"
+  },
+  "verdict": "RED",
+  "alerts": [
+    "count_error=14 (threshold ≥2 → RED): 14 build failures across 5 clusters — PR#93 (Studio Crew freemium chat, 6 errors: ongoing merge-conflict + RAG/gateway rewrite churn; branch still open as of snapshot); feat/acos-pillar-9-10-agents (2 errors: Turbopack MDX path alias fix, resolved + merged as PR#103); PR#96 agentic-builder-lab (2 errors: route-index + initial build, fixed + merged); staging/madrid-2026-05-25 (1 error: intentional WIP safety-net per commit note); obs/vercel-cost-2026-W22 branch (1 error: W22 snapshot PR preview before sitemap fix); 2 production errors (main /connect QR before sitemap-lambda fix + /agents cold-cache 45-min timeout). Error count improved from W22=23.",
+    "PRODUCTION SITE HEALTHY: Sitemap-lambda regression (held production pinned at 969ff907 since 2026-05-22) was fixed by PR#91 merged at the very start of W23 on 2026-05-25. Production saw 22 successful deploys after that fix. Week ends on commit cb863be9 (PR#103, Pillar 9+10 agents + blog excellence). No production errors in the second half of the window.",
+    "duration_max=432s (dpl_B5vKSxd6, email site-wide replace across 33 files, 2026-05-27): 29% above p95=373s. Isolated to one large commit touching 216 occurrences; not a build-system regression.",
+    "count_total=62 (−25% vs W22=83): Reduced deploy velocity consistent with FrankX Madrid trip (2026-05-25 → 2026-06-08). No +30% threshold triggered in any direction.",
+    "p50=337s in YELLOW band (271–360s): −10s vs W22 (347s). Build times stable and within post-audit target. No RED risk from build duration."
+  ]
+}


### PR DESCRIPTION
## /vercel-cost-watch — 2026-W23

Project: frankx-ai-vercel-website · Window: 2026-05-25 → 2026-06-01 (7d)

| Metric | This week | Last week | Δ | Verdict |
|---|---|---|---|---|
| Total deploys | 62 | 83 | −21 | ✅ |
| Production | 24 | 43 | −19 | ✅ |
| Preview | 38 | 40 | −2 | ✅ |
| Skipped (ignoreCommand) | 3 | 0 | +3 | ✅ |
| Errors | 14 | 23 | −9 | 🔴 (≥2) |
| Build duration p50 | 337s | 347s | −10s | 🟡 (271–360s) |
| Build duration p95 | 373s | 367s | +6s | ✅ |
| Total build minutes | 256.5 | 346.2 | −90 | ✅ |

**Verdict: 🔴 RED** — single trigger: `count_error=14` (threshold ≥2). Error count improved from W22=23 but still above threshold. All other metrics GREEN or improving.

---

### Alerts

**🔴 count_error=14 — 5 failure clusters:**
- **PR#93** (Studio Crew freemium chat, 6 errors): ongoing merge-conflict + RAG/gateway rewrite churn on branch `claude/frankx-freemium-experience-hJuk4` — branch still open as of snapshot. Recommend review/merge or close.
- **feat/acos-pillar-9-10-agents** (2 errors): Turbopack MDX `@/` alias regression — fixed and merged as PR#103 ✅
- **PR#96 agentic-builder-lab** (2 errors): route-index + initial build failures — fixed and merged ✅
- **staging/madrid-2026-05-25** (1 error): intentional WIP safety-net branch before Madrid trip per commit message ✅
- **2 production errors**: `/connect` QR landing (#92) hit sitemap-lambda regression before fix landed; `/agents` cold-cache 45-min timeout (retried + succeeded) ✅

**✅ Production site healthy:** Sitemap-lambda regression (PR#91) merged at start of W23 on 2026-05-25, unblocking the 9-day prod freeze. 22 successful production deploys since fix. Week ends at `cb863be9` (PR#103, Pillar 9+10 agents + blog excellence). No production errors in the second half of the window.

**ℹ️ Reduced volume expected:** count_total=62 (−25% vs W22=83) is consistent with the FrankX Madrid trip (2026-05-25 → 2026-06-08). No +30% threshold triggered.

**ℹ️ Build duration stable:** p50=337s (−10s vs W22). Max spike at 432s was a single large commit (email site-wide replace, 33 files) on 2026-05-27 — not a build-system regression. p95=373s, within normal range.

---

### Duration sample
15/45 READY deploys sampled via `get_deployment` (`readyAt − buildingAt`). `total_build_minutes` extrapolated as avg(342s) × 45 ready deploys / 60 = **256.5 min**.

---

Snapshot: `data/observability/vercel-cost/2026-W23.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFkQVATsCbzYHcQnqMdehf)_