### PR TITLE
fix(launch): harden homepage Suno embeds against autoplay-with-sound

### DIFF
--- a/components/home/HomePageElite.tsx
+++ b/components/home/HomePageElite.tsx
@@ -215,7 +215,7 @@ function FeaturedTrack({ track }: { track: FeaturedTrackData }) {
           src={`https://suno.com/embed/${track.sunoId}`}
           className="w-full h-[380px]"
           style={{ border: 'none' }}
-          allow="autoplay; clipboard-write"
+          allow="clipboard-write"
           loading="lazy"
           title={track.title}
         />
@@ -339,7 +339,7 @@ function Hero({ featuredTrack }: { featuredTrack?: FeaturedTrackData }) {
                     src="https://suno.com/embed/9cbad174-9276-427f-9aed-1ba00c7db3db"
                     className="w-full h-[380px]"
                     style={{ border: 'none' }}
-                    allow="autoplay; clipboard-write"
+                    allow="clipboard-write"
                     loading="lazy"
                     title="Vibe OS — Featured Track"
                   />


### PR DESCRIPTION
## What

Strips the `autoplay` Permissions-Policy delegation from the two homepage Suno "Vibe OS" embed iframes:

```diff
- allow="autoplay; clipboard-write"
+ allow="clipboard-write"
```

## Why

For tomorrow's cold-email launch to an enterprise audience, the homepage must not start audible playback on load. Suno's `/embed/` player is click-to-play by default (it doesn't request autoplay on mount), so this is defense-in-depth: it makes it *impossible* for the embed to autoplay sound regardless of any future Suno behavior change. Click-to-play inside the embed still works — a click is a user gesture in the iframe's own browsing context, which doesn't require the delegated `autoplay` permission.

## Scope

- 1 file, 2 lines: `components/home/HomePageElite.tsx`.
- No layout, type, or behavior change beyond the autoplay permission.

## Context

This is a follow-up to the merged launch-hardening PR #107 (Oracle legal-string scrub, honest ACOS skill counts, footer cleanup, softened EMEA bio credential). All of those are already on `main`. This commit is the remaining optional autoplay item.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_