### PR TITLE
polish(excellence): Wave 11 — a11y + footer + OG specs

### DIFF
--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -114,21 +114,21 @@ export default function AgentsPage() {
       />
 
       {/* Hero — honest framing */}
-      <section className="relative overflow-hidden pt-28 pb-16">
+      <section className="relative overflow-hidden pt-28 pb-20 lg:pb-28">
         <div className="absolute inset-0 bg-gradient-to-br from-purple-950/40 via-[#02030b] to-cyan-950/30" />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(161,72,221,0.18),transparent_55%)]" />
         <div className="relative mx-auto max-w-5xl px-6 text-center">
           <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200">
             ACOS · Catalog L{l99.level} · {counts.shipped}/{counts.total} shipped
           </div>
-          <h1 className="text-4xl font-bold leading-tight sm:text-5xl md:text-6xl">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1]">
             <span className="bg-gradient-to-r from-white via-emerald-100 to-cyan-100 bg-clip-text text-transparent">
               99 agents I run on my machine.
             </span>
             <br />
             <span className="text-white/70">Install any pack into yours in 60 seconds.</span>
           </h1>
-          <p className="mx-auto mt-6 max-w-3xl text-lg text-slate-300 sm:text-xl">
+          <p className="mx-auto mt-6 max-w-3xl text-[17px] leading-relaxed text-white/80 sm:text-lg">
             This isn&rsquo;t a SaaS. There&rsquo;s no &ldquo;Orchestrator&rdquo; routing your requests to a hosted runtime.
             It&rsquo;s the same <strong>99-agent operating system</strong> Frank runs to ship music, books, products,
             and frankx.ai &mdash; packaged so you can install it into <strong>your</strong> Claude Code, Cursor, or
@@ -157,19 +157,19 @@ npx @frankx/acos list`}
           <div className="mt-10 flex flex-wrap justify-center gap-3">
             <Link
               href="/agents/packs/meta"
-              className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-5 py-3 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/20"
+              className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-6 py-3 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/20 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               <Download className="h-4 w-4" /> Install the free Meta pack
             </Link>
             <Link
               href="/acos/agents"
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               See every agent <ArrowRight className="h-4 w-4" />
             </Link>
             <a
               href="https://github.com/frankxai/agentic-creator-os"
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -180,10 +180,10 @@ npx @frankx/acos list`}
       </section>
 
       {/* What you actually get */}
-      <section className="border-t border-white/5 bg-[#06060a] py-20">
+      <section className="border-t border-white/5 bg-[#06060a] py-20 lg:py-28">
         <div className="mx-auto max-w-5xl px-6">
-          <h2 className="mb-3 text-center text-3xl font-bold text-white sm:text-4xl">What&rsquo;s inside a pack</h2>
-          <p className="mx-auto mb-12 max-w-2xl text-center text-slate-400">
+          <h2 className="mb-3 text-center text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">What&rsquo;s inside a pack</h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-[17px] leading-relaxed text-white/80">
             Every pack is plain text artifacts your CLI already knows how to use. No vendor lock, no managed runtime.
           </p>
           <div className="grid gap-6 md:grid-cols-3">
@@ -214,11 +214,11 @@ npx @frankx/acos list`}
       </section>
 
       {/* The packs — 11 pillars */}
-      <section className="border-t border-white/5 py-20">
+      <section className="border-t border-white/5 py-20 lg:py-28">
         <div className="mx-auto max-w-6xl px-6">
           <div className="mb-12 text-center">
-            <h2 className="text-3xl font-bold text-white sm:text-4xl">The 11 packs</h2>
-            <p className="mx-auto mt-3 max-w-2xl text-slate-400">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">The 11 packs</h2>
+            <p className="mx-auto mt-3 max-w-2xl text-[17px] leading-relaxed text-white/80">
               One per pillar. Each ships 9 specialists. Buy individual packs, or grab the full bundle (coming).
             </p>
           </div>
@@ -289,9 +289,9 @@ npx @frankx/acos list`}
       </section>
 
       {/* The honest disclaimer */}
-      <section className="border-t border-white/5 bg-[#06060a] py-20">
+      <section className="border-t border-white/5 bg-[#06060a] py-20 lg:py-28">
         <div className="mx-auto max-w-3xl px-6">
-          <h2 className="text-center text-2xl font-bold text-white sm:text-3xl">What this is — and what it isn&rsquo;t</h2>
+          <h2 className="text-center text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">What this is — and what it isn&rsquo;t</h2>
           <div className="mt-10 grid gap-6 md:grid-cols-2">
             <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.04] p-6">
               <div className="text-xs font-semibold uppercase tracking-widest text-emerald-300">What it is</div>
@@ -318,23 +318,23 @@ npx @frankx/acos list`}
       </section>
 
       {/* CTA */}
-      <section className="border-t border-white/5 py-20">
+      <section className="border-t border-white/5 py-20 lg:py-28">
         <div className="mx-auto max-w-3xl px-6 text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">Start with the free Meta pack</h2>
-          <p className="mx-auto mt-3 max-w-xl text-slate-400">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Start with the free Meta pack</h2>
+          <p className="mx-auto mt-3 max-w-xl text-[17px] leading-relaxed text-white/80">
             9 infrastructure agents (router, memory guardian, safety guard, verification loop, EOD capture, handover, sync,
             ACOS score, agentic-jujutsu). No card. Works out of the box if you already have Claude Code or Antigravity installed.
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-3">
             <Link
               href="/agents/packs/meta"
-              className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-6 py-3 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400"
+              className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-6 py-3 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               <Download className="h-4 w-4" /> Get the Meta pack
             </Link>
             <Link
               href="/newsletter?ref=agents-pack"
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               Notify me when paid packs launch
             </Link>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -140,7 +140,7 @@ export default async function BlogPostPage({
   const extractedFaqs = extractFAQFromContent(post.content)
 
   return (
-    <div className="min-h-screen bg-[#0a0a0b] text-white">
+    <main className="min-h-screen bg-[#0a0a0b] text-white">
       <ReadingProgress />
       <JsonLd type="Article" data={articleSchema} />
       {extractedFaqs.length > 0 && (
@@ -343,7 +343,7 @@ export default async function BlogPostPage({
           </div>
         </div>
       </article>
-    </div>
+    </main>
   )
 }
 

--- a/app/inner-circle/page.tsx
+++ b/app/inner-circle/page.tsx
@@ -349,7 +349,7 @@ function FAQItem({ faq, index }: { faq: (typeof FAQS)[0]; index: number }) {
 
 export default function InnerCirclePage() {
   return (
-    <div className="min-h-screen bg-[#0a0a0b] text-white">
+    <main className="min-h-screen bg-[#0a0a0b] text-white">
       {/* Hero Section */}
       <section className="relative flex min-h-[80vh] items-center justify-center overflow-hidden">
         {/* Axi constellation — premium/mystery */}
@@ -661,6 +661,6 @@ export default function InnerCirclePage() {
           </motion.div>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -180,8 +180,8 @@ export default function RootLayout({
             />
           )}
           <a
-            href="#main"
-            className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white focus:text-black focus:px-3 focus:py-2 focus:rounded z-[100]"
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white focus:text-black focus:px-3 focus:py-2 focus:rounded z-[100] focus-visible:outline-2 focus-visible:outline-emerald-400 focus-visible:outline-offset-2"
           >
             Skip to content
           </a>
@@ -196,7 +196,7 @@ export default function RootLayout({
           <HideOnLandingRoutes>
             <NavigationMega />
           </HideOnLandingRoutes>
-          <div id="main" className="relative z-10 min-h-screen overflow-x-hidden">
+          <div id="main-content" className="relative z-10 min-h-screen overflow-x-hidden">
             {children}
           </div>
           <HideOnLandingRoutes>

--- a/app/library/[slug]/page.tsx
+++ b/app/library/[slug]/page.tsx
@@ -244,10 +244,10 @@ export default async function ReviewPage({
             </div>
           )}
           <div>
-            <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white mb-2">
               {review.title}
             </h1>
-            <p className="text-lg text-white/50 mb-3">by {review.author}</p>
+            <p className="text-[17px] leading-relaxed text-white/70 mb-3">by {review.author}</p>
             <StarRating rating={review.rating} />
             <div className="flex flex-wrap gap-2 mt-4">
               {review.categories.map((cat) => (
@@ -288,7 +288,7 @@ export default async function ReviewPage({
           </div>
           <Link
             href="/newsletter"
-            className="shrink-0 inline-flex items-center gap-1.5 rounded-lg bg-emerald-500/15 hover:bg-emerald-500/25 border border-emerald-500/30 px-4 py-2 text-sm font-medium text-emerald-200 transition-colors whitespace-nowrap"
+            className="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-emerald-500/15 hover:bg-emerald-500/25 border border-emerald-500/30 px-4 py-2 text-sm font-medium text-emerald-200 transition-colors whitespace-nowrap focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
           >
             Subscribe free
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
@@ -687,7 +687,7 @@ export default async function ReviewPage({
             href={review.amazonUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-white/5 border border-white/10 text-white/60 text-sm hover:bg-white/10 hover:text-white/80 transition-all"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-white/5 border border-white/10 text-white/60 text-sm hover:bg-white/10 hover:text-white/80 transition-all focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -15,6 +15,8 @@ export default function robots(): MetadataRoute.Robots {
           '/prototype/',
           '/onboarding/',
           '/command-center/',
+          '/tribe/',
+          '/unsubscribe',
         ],
       },
     ],

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -270,6 +270,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: '/learn', priority: 0.7, changeFrequency: 'weekly' as const },
     { url: '/learn/claude-mastery', priority: 0.75, changeFrequency: 'weekly' as const },
     { url: '/learn/gemini-mastery', priority: 0.85, changeFrequency: 'weekly' as const },
+    // LLM Hub — the model intelligence surface (high-priority SEO)
+    { url: '/llm-hub', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/llm-hub/compare', priority: 0.8, changeFrequency: 'weekly' as const },
     { url: '/showcase', priority: 0.7, changeFrequency: 'monthly' as const },
     { url: '/downloads', priority: 0.7, changeFrequency: 'monthly' as const },
     { url: '/changelog', priority: 0.5, changeFrequency: 'weekly' as const },
@@ -666,12 +669,41 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })
   })
 
+  // Routes that must NEVER appear in the sitemap because they're noindex'd
+  // at the page level (robots: index: false) or are private surfaces.
+  // Keep in sync with app/robots.ts disallow list + per-page robots metadata.
+  const noindexRoutes = new Set<string>([
+    '/tribe',
+    '/unsubscribe',
+    '/onboarding',
+    '/dashboard',
+    '/command-center',
+    '/papa/erinnerungen',
+    '/papa/mitmachen',
+  ])
+  const noindexPrefixes = ['/tribe/', '/preview/', '/prototype/', '/admin/', '/api/', '/auth/']
+
+  function isNoindex(pathname: string): boolean {
+    if (noindexRoutes.has(pathname)) return true
+    return noindexPrefixes.some((prefix) => pathname.startsWith(prefix))
+  }
+
   // Auto-discovery safety net — pull every route from the pre-baked
   // data/route-index.json (built from lib/route-enumeration.mjs at prebuild)
   // and add any that the hand-curated arrays above missed. The existing
   // entry wins on collision, so manual priority/changeFrequency settings
   // are preserved.
   const seenUrls = new Set(entries.map((e) => e.url))
+  // Prune any noindex'd routes that the hand-curated arrays accidentally
+  // included (defensive — newer waves may add /tribe etc. to the legacy
+  // arrays without realizing they're noindex'd).
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const pathname = entries[i].url.replace(BASE_URL, '')
+    if (isNoindex(pathname)) {
+      seenUrls.delete(entries[i].url)
+      entries.splice(i, 1)
+    }
+  }
   try {
     const discovered = (routeIndex as { routes: Array<{ href: string; type: string }> }).routes
     // Heuristic priority + frequency by route type — only used for routes that
@@ -695,6 +727,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       legacy: { priority: 0.3, changeFrequency: 'yearly' },
     }
     for (const route of discovered) {
+      if (isNoindex(route.href)) continue
       const url = `${BASE_URL}${route.href}`
       if (seenUrls.has(url)) continue
       seenUrls.add(url)

--- a/app/workshops/for-educators/page.tsx
+++ b/app/workshops/for-educators/page.tsx
@@ -133,7 +133,7 @@ export default function ForEducatorsPage() {
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
       {/* Hero */}
-      <section className="relative pt-28 pb-20 overflow-hidden">
+      <section className="relative pt-28 pb-20 lg:pb-28 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-b from-violet-500/[0.04] to-transparent" />
         <div className="absolute top-10 right-1/3 w-[400px] h-[400px] bg-violet-500/[0.05] rounded-full blur-[120px]" />
 
@@ -154,11 +154,11 @@ export default function ForEducatorsPage() {
               </span>
             </div>
 
-            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-4 tracking-tight">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white mb-4">
               How to Use These Workshops
             </h1>
 
-            <p className="text-lg text-zinc-400 max-w-2xl">
+            <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl">
               Professional AI workshop templates designed for university
               classrooms, corporate training rooms, and bootcamp settings. Pick a
               template, review the agenda, and deliver with confidence.
@@ -168,13 +168,13 @@ export default function ForEducatorsPage() {
       </section>
 
       {/* Benefits Grid */}
-      <section className="pb-20">
+      <section className="py-20 lg:py-28">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <motion.h2
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
-            className="text-2xl font-bold text-white mb-8"
+            className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-10"
           >
             What you get
           </motion.h2>
@@ -187,13 +187,13 @@ export default function ForEducatorsPage() {
       </section>
 
       {/* How It Works */}
-      <section className="pb-20">
+      <section className="py-20 lg:py-28">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <motion.h2
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
-            className="text-2xl font-bold text-white mb-8"
+            className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-10"
           >
             Four steps to a great workshop
           </motion.h2>
@@ -226,13 +226,13 @@ export default function ForEducatorsPage() {
       </section>
 
       {/* Available Templates */}
-      <section className="pb-20">
+      <section className="py-20 lg:py-28">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <motion.h2
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
-            className="text-2xl font-bold text-white mb-6"
+            className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-8"
           >
             Available templates
           </motion.h2>
@@ -282,7 +282,7 @@ export default function ForEducatorsPage() {
       </section>
 
       {/* Custom Workshop CTA */}
-      <section className="pb-28">
+      <section className="py-20 lg:py-28">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -293,16 +293,16 @@ export default function ForEducatorsPage() {
             <GlowCard color="violet">
               <div className="p-8 sm:p-10 text-center">
                 <Mail className="w-10 h-10 text-violet-400 mx-auto mb-4" />
-                <h2 className="text-2xl font-bold text-white mb-3">
+                <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">
                   Request a Custom Workshop
                 </h2>
-                <p className="text-sm text-zinc-400 mb-6 max-w-lg mx-auto">
+                <p className="text-[17px] leading-relaxed text-white/80 mb-6 max-w-lg mx-auto">
                   Need a workshop tailored to your department, industry, or
                   audience level? Reach out and we can design something together.
                 </p>
                 <a
                   href="mailto:frank@frankx.ai?subject=Custom%20Workshop%20Request"
-                  className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-gradient-to-r from-violet-600 to-violet-500 text-white font-medium hover:from-violet-500 hover:to-violet-400 transition-all"
+                  className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-violet-600 to-violet-500 text-white font-medium hover:from-violet-500 hover:to-violet-400 transition-all focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
                 >
                   <Mail className="w-4 h-4" />
                   Contact Frank Riemer

--- a/app/workshops/ikigai-content-studio/page.tsx
+++ b/app/workshops/ikigai-content-studio/page.tsx
@@ -29,7 +29,7 @@ export default function IkigaiContentStudioPage() {
       <CourseSchema workshop={workshop} />
 
       {/* Hero */}
-      <section className="relative pt-28 pb-14 overflow-hidden">
+      <section className="relative pt-28 pb-20 lg:pb-28 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-b from-violet-500/[0.05] to-transparent" />
         <div className="absolute top-24 left-1/3 w-[500px] h-[500px] bg-violet-500/[0.06] rounded-full blur-[140px]" />
 
@@ -65,14 +65,14 @@ export default function IkigaiContentStudioPage() {
               </span>
             </div>
 
-            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-3 tracking-tight">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white mb-3">
               {workshop.title}
             </h1>
-            <p className="text-lg text-zinc-400 mb-6 max-w-2xl">
+            <p className="text-[17px] leading-relaxed text-white/80 mb-6 max-w-2xl">
               {workshop.subtitle}.
             </p>
 
-            <p className="text-sm text-zinc-500 leading-relaxed max-w-3xl mb-8">
+            <p className="text-[15px] leading-relaxed text-white/60 max-w-3xl mb-8">
               {workshop.overview}
             </p>
 
@@ -80,7 +80,7 @@ export default function IkigaiContentStudioPage() {
             <div className="flex flex-wrap items-center gap-3">
               <a
                 href="#intake"
-                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-fuchsia-500 hover:from-violet-400 hover:to-fuchsia-400 transition-all"
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-full text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-fuchsia-500 hover:from-violet-400 hover:to-fuchsia-400 transition-all focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Send className="w-4 h-4" />
                 Request a conversation
@@ -144,8 +144,8 @@ export default function IkigaiContentStudioPage() {
       {/* Agenda */}
       <section className="pb-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold text-white mb-2">Agenda</h2>
-          <p className="text-sm text-zinc-500 mb-6 max-w-2xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">Agenda</h2>
+          <p className="text-[17px] leading-relaxed text-white/80 mb-6 max-w-2xl">
             Five modules. The second half of the session is hands-on — every attendee
             ships something visible before leaving.
           </p>
@@ -164,10 +164,10 @@ export default function IkigaiContentStudioPage() {
             <p className="text-xs font-medium uppercase tracking-wider text-violet-300 mb-2">
               Book this workshop
             </p>
-            <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
               Request a conversation
             </h2>
-            <p className="text-sm text-zinc-400 mt-2 max-w-2xl">
+            <p className="text-[17px] leading-relaxed text-white/80 mt-3 max-w-2xl">
               Tell Frank about your team and context. Dates, pricing, and format are
               scoped on a short first call. Reply within 48h.
             </p>

--- a/components/EmailCapture.tsx
+++ b/components/EmailCapture.tsx
@@ -68,39 +68,52 @@ export default function EmailCapture({
     )
   }
 
+  const errorId = `email-capture-error-${product}`
+
   return (
-    <form onSubmit={handleSubmit} className={`space-y-3 ${className}`}>
+    <form onSubmit={handleSubmit} className={`space-y-3 ${className}`} aria-busy={status === 'loading'}>
       <div className="flex flex-col sm:flex-row gap-3">
+        <label htmlFor={`name-${product}`} className="sr-only">Your name (optional)</label>
         <input
+          id={`name-${product}`}
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Your name (optional)"
+          autoComplete="given-name"
+          aria-label="Your name (optional)"
           className="flex-1 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:border-cyan-500/50 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 transition-all"
           disabled={status === 'loading'}
         />
+        <label htmlFor={`email-${product}`} className="sr-only">Email address</label>
         <input
+          id={`email-${product}`}
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder={placeholder}
           required
+          autoComplete="email"
+          aria-label="Email address"
+          aria-invalid={status === 'error'}
+          aria-describedby={status === 'error' ? errorId : undefined}
           className="flex-1 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:border-cyan-500/50 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 transition-all"
           disabled={status === 'loading'}
         />
         <button
           type="submit"
           disabled={status === 'loading'}
-          className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-6 py-3 font-semibold text-slate-950 transition-all hover:bg-cyan-400 hover:shadow-lg hover:shadow-cyan-500/25 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+          aria-busy={status === 'loading'}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-6 py-3 font-semibold text-slate-950 transition-all hover:bg-cyan-400 hover:shadow-lg hover:shadow-cyan-500/25 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
         >
           {status === 'loading' ? (
             <>
-              <Loader2 className="h-5 w-5 animate-spin" />
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
               Subscribing...
             </>
           ) : (
             <>
-              <Mail className="h-5 w-5" />
+              <Mail className="h-5 w-5" aria-hidden="true" />
               {buttonText}
             </>
           )}
@@ -109,11 +122,14 @@ export default function EmailCapture({
 
       {status === 'error' && (
         <motion.div
+          id={errorId}
+          role="alert"
+          aria-live="polite"
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
           className="flex items-center gap-2 text-sm text-red-400"
         >
-          <AlertCircle className="h-4 w-4" />
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
           {message}
         </motion.div>
       )}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,9 +14,9 @@ export default function Footer() {
         <div className="absolute bottom-0 left-1/2 -translate-x-1/2 h-40 w-72 rounded-full bg-emerald-500/[0.04] blur-[100px]" />
       </div>
       <div className="relative max-w-6xl mx-auto px-4 sm:px-6 py-10 sm:py-12 md:py-16">
-        <div className="grid gap-8 sm:gap-10 md:gap-12 grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+        <div className="grid gap-8 sm:gap-10 md:gap-12 grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
           {/* Brand */}
-          <div className="col-span-2 md:col-span-2 lg:col-span-1">
+          <div className="col-span-2 md:col-span-3 lg:col-span-1">
             <Link href="/" className="inline-flex items-center gap-2 sm:gap-3 mb-4 sm:mb-6 group" aria-label="FrankX.AI — Home">
               <Image src="/images/mascot/axi-v3-icon.png" alt="" width={36} height={36} className="rounded-lg" />
               <div>
@@ -84,14 +84,17 @@ export default function Footer() {
             </nav>
           </div>
 
-          {/* Create */}
-          <nav aria-label="Create">
-            <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Create</h3>
+          {/* Hubs — the ecosystem map */}
+          <nav aria-label="Hubs">
+            <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Hubs</h3>
             <ul className="space-y-2 sm:space-y-3 text-xs sm:text-sm text-white/40">
-              <li><Link href="/music-lab" className="hover:text-white transition-colors">Music Lab</Link></li>
-              <li><Link href="/prompt-library" className="hover:text-white transition-colors">Prompt Library</Link></li>
+              <li><Link href="/library" className="hover:text-white transition-colors">Library</Link></li>
+              <li><Link href="/studio" className="hover:text-white transition-colors">Studio</Link></li>
+              <li><Link href="/research" className="hover:text-white transition-colors">Research</Link></li>
+              <li><Link href="/agents" className="hover:text-white transition-colors">Agents</Link></li>
+              <li><Link href="/os" className="hover:text-white transition-colors">OS</Link></li>
               <li><Link href="/acos" className="hover:text-white transition-colors">ACOS</Link></li>
-              <li><Link href="/templates" className="hover:text-white transition-colors">Templates</Link></li>
+              <li><Link href="/llm-hub" className="hover:text-white transition-colors">LLM Hub</Link></li>
             </ul>
           </nav>
 
@@ -100,11 +103,12 @@ export default function Footer() {
             <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Learn</h3>
             <ul className="space-y-2 sm:space-y-3 text-xs sm:text-sm text-white/40">
               <li><Link href="/blog" className="hover:text-white transition-colors">Blog</Link></li>
+              <li><Link href="/workshops" className="hover:text-white transition-colors">Workshops</Link></li>
               <li><Link href="/courses" className="hover:text-white transition-colors">Courses</Link></li>
               <li><Link href="/guides" className="hover:text-white transition-colors">Guides</Link></li>
-              <li><Link href="/library" className="hover:text-white transition-colors">Library</Link></li>
-              <li><Link href="/students" className="hover:text-white transition-colors">Student Hub</Link></li>
+              <li><Link href="/prompt-library" className="hover:text-white transition-colors">Prompt Library</Link></li>
               <li><Link href="/watch" className="hover:text-white transition-colors">Watch</Link></li>
+              <li><Link href="/music-lab" className="hover:text-white transition-colors">Music Lab</Link></li>
             </ul>
           </nav>
 
@@ -115,36 +119,41 @@ export default function Footer() {
               <li><Link href="/ai-architecture" className="hover:text-white transition-colors">Architecture Hub</Link></li>
               <li><Link href="/ai-architecture/blueprints" className="hover:text-white transition-colors">Blueprints</Link></li>
               <li><Link href="/products" className="hover:text-white transition-colors">Products</Link></li>
-              <li><Link href="/acos" className="hover:text-white transition-colors">ACOS</Link></li>
+              <li><Link href="/templates" className="hover:text-white transition-colors">Templates</Link></li>
               <li><Link href="/ecosystem" className="hover:text-white transition-colors">Ecosystem Map</Link></li>
               <li><Link href="/about" className="hover:text-white transition-colors">About</Link></li>
             </ul>
           </nav>
 
-          {/* Work with me — commercial funnel */}
-          <nav aria-label="Work with Frank">
-            <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Work with me</h3>
+          {/* Connect — community + commercial funnel */}
+          <nav aria-label="Connect">
+            <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Connect</h3>
             <ul className="space-y-2 sm:space-y-3 text-xs sm:text-sm text-white/40">
               <li><Link href="/start" className="hover:text-white transition-colors">Start here</Link></li>
-              <li><Link href="/build" className="hover:text-white transition-colors">Build</Link></li>
-              <li><Link href="/coaching" className="hover:text-white transition-colors">Coaching</Link></li>
-              <li><Link href="/work-with-me" className="hover:text-white transition-colors">Studio</Link></li>
               <li><Link href="/newsletter" className="hover:text-white transition-colors">Newsletter</Link></li>
+              <li><Link href="/inner-circle" className="hover:text-white transition-colors">Inner Circle</Link></li>
+              <li><Link href="/tribe" className="hover:text-white transition-colors">Tribe</Link></li>
+              <li><Link href="/coaching" className="hover:text-white transition-colors">Coaching</Link></li>
+              <li><Link href="/work-with-me" className="hover:text-white transition-colors">Work with me</Link></li>
+              <li><Link href="/connect" className="hover:text-white transition-colors">Connect</Link></li>
               <li><Link href="/contact" className="hover:text-white transition-colors">Contact</Link></li>
             </ul>
           </nav>
         </div>
 
-        {/* Newsletter — Aurora accent */}
+        {/* Newsletter — Aurora accent (pre-launch wait list) */}
         <div className="relative mt-8 sm:mt-12 pt-6 sm:pt-8 border-t border-white/5">
           <div className="absolute inset-0 -mx-4 sm:-mx-6 rounded-2xl bg-gradient-to-r from-cyan-950/20 via-transparent to-violet-950/20 pointer-events-none" aria-hidden />
           <div className="relative flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6">
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-white">Weekly dispatch — AI architecture & creative systems</p>
-              <p className="text-xs text-white/40">One email per week. Unsubscribe anytime.</p>
+              <p className="text-xs text-white/40">
+                Join the wait list. One email per Friday once we launch.{' '}
+                <Link href="/unsubscribe" className="underline decoration-white/20 hover:decoration-white/60 hover:text-white/60 transition-colors">Unsubscribe</Link> anytime.
+              </p>
             </div>
             <div className="w-full sm:w-auto sm:min-w-[300px]">
-              <EmailSignup listType="newsletter" placeholder="your@email.com" buttonText="Subscribe" compact />
+              <EmailSignup listType="newsletter" placeholder="your@email.com" buttonText="Join the wait list" compact />
             </div>
           </div>
         </div>
@@ -156,6 +165,8 @@ export default function Footer() {
             <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
             <span className="text-white/30">·</span>
             <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
+            <span className="text-white/30">·</span>
+            <Link href="/legal/refund" className="hover:text-white transition-colors">Refund</Link>
             <span className="text-white/30">·</span>
             <Link href="/legal" className="hover:text-white transition-colors">Legal</Link>
           </nav>

--- a/components/NavigationMega.tsx
+++ b/components/NavigationMega.tsx
@@ -469,7 +469,7 @@ export default function NavigationMega() {
             : 'border-white/5 bg-[#030712]/90 backdrop-blur-xl'
         )}
       >
-        <nav className="mx-auto flex h-14 sm:h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
+        <nav aria-label="Primary" className="mx-auto flex h-14 sm:h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
           <Logo />
 
           <NavigationMenu.Root
@@ -490,6 +490,7 @@ export default function NavigationMega() {
               <NavigationMenu.Item>
                 <Link
                   href="/blog"
+                  aria-current={isActive('/blog') ? 'page' : undefined}
                   className={cn(
                     'rounded-md px-2.5 py-1.5 text-[13px] font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]',
                     isActive('/blog')
@@ -612,7 +613,7 @@ export default function NavigationMega() {
         aria-label="Site navigation"
       >
         <div className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
-          <nav className="space-y-1">
+          <nav aria-label="Mobile primary" className="space-y-1">
             {desktopSections.map((section) => {
               const data = navigation[section]
               const expanded = mobileExpanded === section
@@ -690,6 +691,7 @@ export default function NavigationMega() {
             <Link
               href="/blog"
               onClick={() => setIsOpen(false)}
+              aria-current={isActive('/blog') ? 'page' : undefined}
               className={cn(
                 'flex min-h-[52px] items-center rounded-xl px-4 py-3 text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/50',
                 isActive('/blog') ? 'bg-white/10 text-white' : 'text-slate-200 hover:bg-white/5 hover:text-white'

--- a/components/email-signup.tsx
+++ b/components/email-signup.tsx
@@ -79,7 +79,7 @@ export function EmailSignup({
 
   if (compact) {
     return (
-      <form onSubmit={handleSubmit} className={cn('relative', className)} noValidate>
+      <form onSubmit={handleSubmit} className={cn('relative', className)} aria-busy={status === 'loading'} noValidate>
         <div className="flex gap-2">
           <label htmlFor="email-compact" className="sr-only">Email address</label>
           <input
@@ -88,6 +88,7 @@ export function EmailSignup({
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder={placeholder}
+            autoComplete="email"
             aria-label="Email address"
             aria-invalid={status === 'error'}
             aria-describedby={status === 'error' ? 'email-compact-error' : status === 'success' ? 'email-compact-success' : undefined}
@@ -98,6 +99,7 @@ export function EmailSignup({
           <button
             type="submit"
             disabled={status === 'loading' || status === 'success'}
+            aria-busy={status === 'loading'}
             className="px-6 py-2 bg-gradient-to-r from-emerald-600 to-cyan-600 text-white font-semibold rounded-lg hover:from-emerald-500 hover:to-cyan-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
           >
             {status === 'loading' ? 'Subscribing...' : status === 'success' ? '✓' : buttonText}
@@ -138,7 +140,7 @@ export function EmailSignup({
 
   return (
     <div className={cn('w-full max-w-md', className)}>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4" aria-busy={status === 'loading'} noValidate>
         {showName && (
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-slate-300 mb-2">
@@ -150,6 +152,7 @@ export function EmailSignup({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Your first name"
+              autoComplete="given-name"
               disabled={status === 'loading' || status === 'success'}
               className="w-full px-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50 transition-all"
             />
@@ -166,8 +169,11 @@ export function EmailSignup({
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder={placeholder}
+            autoComplete="email"
             disabled={status === 'loading' || status === 'success'}
             required
+            aria-invalid={status === 'error'}
+            aria-describedby={status === 'error' ? 'email-error' : status === 'success' ? 'email-success' : undefined}
             className="w-full px-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50 transition-all"
           />
         </div>
@@ -175,11 +181,12 @@ export function EmailSignup({
         <button
           type="submit"
           disabled={status === 'loading' || status === 'success'}
+          aria-busy={status === 'loading'}
           className={cn(
-            "w-full px-6 py-3 font-semibold rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed",
+            "w-full px-6 py-3 font-semibold rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]",
             status === 'success'
-              ? "bg-emerald-600 text-white"
-              : "bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:from-blue-500 hover:to-purple-500"
+              ? "bg-emerald-600 text-white focus-visible:ring-emerald-400/70"
+              : "bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:from-blue-500 hover:to-purple-500 focus-visible:ring-purple-400/70"
           )}
         >
           {status === 'loading' && 'Subscribing...'}
@@ -191,6 +198,7 @@ export function EmailSignup({
         <AnimatePresence>
           {status === 'error' && errorMessage && (
             <motion.div
+              id="email-error"
               role="alert"
               aria-live="polite"
               initial={{ opacity: 0, y: -10 }}
@@ -203,6 +211,7 @@ export function EmailSignup({
           )}
           {status === 'success' && (
             <motion.div
+              id="email-success"
               role="status"
               aria-live="polite"
               initial={{ opacity: 0, y: -10 }}

--- a/components/newsletter/NewsletterCTA.tsx
+++ b/components/newsletter/NewsletterCTA.tsx
@@ -9,7 +9,7 @@ export default function NewsletterCTA() {
   return (
     <>
       {/* How it works — Aurora accented */}
-      <section className="relative border-t border-white/5 py-16 overflow-hidden">
+      <section className="relative border-t border-white/5 py-20 lg:py-28 overflow-hidden">
         <div className="absolute inset-0 pointer-events-none" aria-hidden>
           <div className="absolute top-0 right-0 h-56 w-72 rounded-full bg-cyan-500/[0.05] blur-[120px]" />
           <div className="absolute bottom-0 left-0 h-48 w-60 rounded-full bg-violet-500/[0.04] blur-[100px]" />
@@ -21,10 +21,10 @@ export default function NewsletterCTA() {
             viewport={{ once: true }}
             className="mb-12 text-center"
           >
-            <h2 className="mb-3 text-2xl font-bold text-white sm:text-3xl">
+            <h2 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
               How it works
             </h2>
-            <p className="text-slate-400">
+            <p className="text-[17px] leading-relaxed text-white/80">
               Each stream is independent. Subscribe to what matters.
             </p>
           </motion.div>
@@ -53,7 +53,7 @@ export default function NewsletterCTA() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: i * 0.1 }}
-                className="rounded-xl border border-white/[0.08] bg-white/[0.03] p-6"
+                className="rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl p-6"
               >
                 <div className="mb-3 text-2xl font-bold text-white/10">
                   {item.step}
@@ -67,7 +67,7 @@ export default function NewsletterCTA() {
       </section>
 
       {/* Final CTA */}
-      <section className="py-16">
+      <section className="py-20 lg:py-28">
         <div className="mx-auto max-w-3xl px-6">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -82,10 +82,10 @@ export default function NewsletterCTA() {
             <div className="relative mx-auto mb-6">
               <FrankOmega variant="pixar-blue" size="sm" glow rounded />
             </div>
-            <h2 className="relative mb-3 text-2xl font-bold text-white sm:text-3xl">
+            <h2 className="relative mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
               Not sure which stream?
             </h2>
-            <p className="relative mx-auto mb-4 max-w-md text-slate-400">
+            <p className="relative mx-auto mb-4 max-w-md text-[17px] leading-relaxed text-white/80">
               Start with Creation Chronicles — it covers everything and
               you&apos;ll see what resonates.
             </p>
@@ -95,7 +95,7 @@ export default function NewsletterCTA() {
             <div className="relative flex flex-wrap justify-center gap-4">
               <a
                 href="#creation-chronicles"
-                className="group flex items-center gap-2 rounded-full bg-white px-6 py-3 font-semibold text-slate-900 transition-all hover:-translate-y-0.5"
+                className="group flex items-center gap-2 rounded-full bg-white px-6 py-3 font-semibold text-slate-900 transition-all hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Mail className="h-4 w-4" />
                 Start with the main stream
@@ -103,7 +103,7 @@ export default function NewsletterCTA() {
               </a>
               <Link
                 href="/blog"
-                className="flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/5"
+                className="flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 Read the blog first
               </Link>

--- a/components/newsletter/NewsletterHero.tsx
+++ b/components/newsletter/NewsletterHero.tsx
@@ -59,7 +59,7 @@ export default function NewsletterHero({
   }
 
   return (
-    <section className="relative overflow-hidden pb-16 pt-32">
+    <section className="relative overflow-hidden py-20 lg:py-28 pt-32">
       {/* Nature-tech constellation background */}
       <div className="pointer-events-none absolute inset-0 -z-10">
         <Image
@@ -123,7 +123,7 @@ export default function NewsletterHero({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.15 }}
-          className="mb-6 text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl"
+          className="mb-6 text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white"
         >
           Subscribe to what
           <span className="mt-2 block bg-gradient-to-r from-violet-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent">
@@ -135,7 +135,7 @@ export default function NewsletterHero({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-slate-400"
+          className="mx-auto mb-10 max-w-2xl text-[17px] leading-relaxed text-white/80"
         >
           AI architecture, music production, investing, worldbuilding — each
           stream has its own voice, cadence, and depth. Subscribe to one or all.
@@ -173,12 +173,12 @@ export default function NewsletterHero({
                   onChange={(e) => setAllEmail(e.target.value)}
                   placeholder="your@email.com"
                   disabled={allStatus === 'loading'}
-                  className="min-w-0 flex-1 rounded-xl border border-white/10 bg-white/5 px-5 py-4 text-white placeholder-slate-500 outline-none transition-all focus:border-violet-500/30 disabled:opacity-50"
+                  className="min-w-0 flex-1 rounded-full border border-white/10 bg-white/5 px-5 py-4 text-white placeholder-slate-500 outline-none transition-all focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] disabled:opacity-50"
                 />
                 <button
                   type="submit"
                   disabled={allStatus === 'loading'}
-                  className="group flex items-center gap-2 rounded-xl bg-gradient-to-r from-violet-600 to-cyan-600 px-6 py-4 font-semibold text-white transition-all hover:from-violet-500 hover:to-cyan-500 disabled:opacity-50"
+                  className="group flex items-center gap-2 rounded-full bg-gradient-to-r from-violet-600 to-cyan-600 px-6 py-4 font-semibold text-white transition-all hover:from-violet-500 hover:to-cyan-500 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] disabled:opacity-50"
                 >
                   {allStatus === 'loading' ? '...' : 'Get All'}
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />

--- a/components/newsletter/StreamCompare.tsx
+++ b/components/newsletter/StreamCompare.tsx
@@ -28,7 +28,7 @@ export default function StreamCompare({
   streams: NewsletterStream[]
 }) {
   return (
-    <section className="border-t border-white/5 py-16">
+    <section className="border-t border-white/5 py-20 lg:py-28">
       <div className="mx-auto max-w-5xl px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -36,10 +36,10 @@ export default function StreamCompare({
           viewport={{ once: true }}
           className="mb-10 text-center"
         >
-          <h2 className="mb-3 text-2xl font-bold text-white sm:text-3xl">
+          <h2 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
             Compare streams at a glance
           </h2>
-          <p className="text-slate-400">
+          <p className="text-[17px] leading-relaxed text-white/80">
             Each stream is independent — subscribe to what matters.
           </p>
         </motion.div>

--- a/components/newsletter/StreamShowcase.tsx
+++ b/components/newsletter/StreamShowcase.tsx
@@ -326,7 +326,7 @@ function StreamCard({
             </div>
 
             {/* Description */}
-            <p className="mb-4 text-sm leading-relaxed text-slate-400">
+            <p className="mb-4 text-[15px] leading-relaxed text-white/70">
               {stream.description}
             </p>
 
@@ -373,12 +373,12 @@ function StreamCard({
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="your@email.com"
                   disabled={status === 'loading'}
-                  className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white placeholder-slate-500 outline-none transition-all focus:border-white/20 disabled:opacity-50"
+                  className="min-w-0 flex-1 rounded-full border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder-slate-500 outline-none transition-all focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] disabled:opacity-50"
                 />
                 <button
                   type="submit"
                   disabled={status === 'loading'}
-                  className="flex-shrink-0 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-all hover:brightness-110 disabled:opacity-50"
+                  className="flex-shrink-0 rounded-full px-5 py-2.5 text-sm font-semibold text-white transition-all hover:brightness-110 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] disabled:opacity-50"
                   style={{
                     background: `linear-gradient(135deg, ${stream.accentHex}, ${stream.accentHex}cc)`,
                   }}
@@ -400,7 +400,7 @@ export default function StreamShowcase({
   streams: NewsletterStream[]
 }) {
   return (
-    <section className="py-16">
+    <section className="py-20 lg:py-28">
       <div className="mx-auto max-w-5xl space-y-8 px-6">
         {streams.map((stream, i) => (
           <div key={stream.id} id={stream.id}>

--- a/public/images/build/build-og.spec.md
+++ b/public/images/build/build-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /build
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/build/build-og.spec.md`
+**Used by:** `app/build/page.tsx` metadata (currently inherits global `/hero-homepage.png` fallback)
+
+## Palette
+- Emerald primary: #10b981
+- Tech cyan: #06b6d4
+- Soul amber: #f59e0b (sparingly, for warmth)
+- Void background: #0a0a0b
+- Space surface: #111113
+
+## Composition
+
+Wide cinematic workshop scene, viewed slightly from above at a 15° angle. Foreground: a clean dark walnut workbench with three discrete objects laid out left-to-right in clear hierarchy — (1) a single sheet of architectural blueprint paper showing a sparse agent flow diagram with emerald nodes connected by thin cyan lines, (2) a closed silver laptop on a stand with a soft emerald glow leaking from the seam, (3) a stack of three slim hardback books labeled only by spine emboss. Mid-ground: shallow depth-of-field fall-off. Background: a dark, almost-black wall holding a single horizontal LED strip casting cool emerald-cyan light from the right edge. Editorial product photography, restrained, no people. Tokens: void background, tech-primary emerald accents, ink-muted body suggestion. The composition reads "this is where a team ships one working agent in a day" — not a hype reel.
+
+## Type
+- Headline: "Build with Frank" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Workshops · Sprints · The Agentic Template Pack" (Poppins, ~32px, weight 500, white at 65%)
+
+Headline anchored bottom-left at 80px padding. Subtitle directly beneath, same left margin.
+
+## Symbols / Iconography
+- Architectural blueprint (one agent flow, not a wall of nodes — restraint)
+- Single laptop with emerald glow (the working agent shipping)
+- Three books (workshop / sprint / template pack — the three offers)
+- LED light bar (the AI substrate, ambient not loud)
+
+## Variants
+- v1: The three-object workbench described above — restrained, premium, editorial.
+- v2: Overhead flat-lay of an open notebook showing a hand-sketched agent architecture with emerald ink, surrounded by a fountain pen, a stopwatch (frozen at "1 day"), and a single USB drive. Magazine-cover aesthetic.
+- v3: Architectural / symbolic — a single emerald keystone arch floating above a void plane, three thin cyan support columns rising to meet it. Reads as "the structure that holds — workshop, sprint, templates."
+
+## Rationale
+
+The `/build` page sells three precise offers (Workshop, Sprint, Template Pack) to teams — the OG image must signal craft, restraint, and "shipping things that work" without devolving into generic "AI builder" iconography. Editorial product photography matches the page's tone of one-day workshops, not a SaaS landing page. Emerald is the primary signal; cyan adds intelligence without taking over.

--- a/public/images/products/bv-kit/bv-kit-og.spec.md
+++ b/public/images/products/bv-kit/bv-kit-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /products/bv-kit
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/bv-kit/bv-kit-og.spec.md`
+**Used by:** `app/products/bv-kit/page.tsx` metadata
+
+## Palette
+- Emerald primary: #10b981 (the "go" / KvK green)
+- Soul amber: #f59e0b (warmth, Dutch sun, document seal)
+- Void background: #0a0a0b
+- Walnut accent: deep brown wood tone
+
+## Composition
+
+Overhead flat-lay, magazine quality, slightly off-center to the right. On a deep walnut wooden desk surface: a single cream-colored manila folder, half-open, revealing the corner of an official-looking Dutch document (visible text suggestion only — no real legal copy). On top of the folder: a small wax seal in emerald with an embossed "BV" mark, an antique brass key, and a fountain pen lying diagonally. To the left: a tiny Dutch flag pin and a single sprig of olive leaves. Soft directional light from upper-left, casting long Dutch-window shadows. Premium stationery photography, slight film grain. The whole scene reads "a serious document that protects something serious." No people, no hands.
+
+## Type
+- Headline: "Creator BV Kit" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Launch your Dutch BV in 30 days" (Poppins, ~32px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Emerald micro-line above the headline (4px × 80px).
+
+## Symbols / Iconography
+- Manila folder + Dutch document — the legal substrate
+- Emerald wax seal with "BV" — the protection layer
+- Antique brass key — sovereignty / digital haven
+- Olive sprig — Mediterranean creator nomad tone
+- Tiny Dutch flag pin — anchor to Netherlands without flag-waving
+
+## Variants
+- v1: Overhead flat-lay described above — premium, restrained, magazine-cover.
+- v2: Three-quarter desk view — laptop closed at left, manila folder open in center, espresso cup at right. Late-afternoon Amsterdam window light. More "creator at work" energy.
+- v3: Architectural / symbolic — a single emerald shield outlined in fine gold filament, floating in deep space with a soft amber halo behind it. Inside the shield: a stylized canal-house silhouette in cyan-edged dark. Minimal, premium, no text in the image. Reads "legal protection as architecture."
+
+## Rationale
+
+The BV Kit sells legal sovereignty to creators — not a SaaS product. The OG must read "serious enough to trust with your business, premium enough to match a €97 price point." Stationery photography matches the tone of templates, contracts, and checklists; the emerald wax seal carries the Dutch BV symbolism without resorting to literal KvK logos. Olive + Dutch flag pin signals the nomad-creator audience without being kitsch.

--- a/public/images/products/creation-chronicles/creation-chronicles-og.spec.md
+++ b/public/images/products/creation-chronicles/creation-chronicles-og.spec.md
@@ -1,0 +1,38 @@
+# OG Image Spec — /products/creation-chronicles
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/creation-chronicles/creation-chronicles-og.spec.md`
+**Used by:** `app/products/creation-chronicles/page.tsx` metadata
+
+## Palette
+- Soul amber: #f59e0b (primary — this is a Storyteller-Poets product, soul-spectrum dominant)
+- Soul gold: #fbbf24 (highlights)
+- Emerald accent: #10b981 (sparingly — represents the system/structure behind the story)
+- Void background: #0a0a0b
+- Warm walnut surface
+
+## Composition
+
+A leather-bound chronicle book lies open at the center, slightly off-axis (rotated 8° clockwise), photographed from above-three-quarter angle. The open spread reveals two pages: the left page filled with cursive handwriting (illegible — abstract pattern of warm-toned ink strokes), the right page showing a hand-drawn timeline with five amber dots connected by a thin ink line, each dot marked with a small icon (eye, heart, hand, mountain, sun — symbolic only). To the side: a single brass fountain pen, an inkwell with amber-glowing ink, and a small stack of three folded letters tied with a thin emerald ribbon. Warm window light from upper-right, golden-hour quality. Background is deep void with a barely-visible bokeh of distant candles. Editorial book photography, slight grain, museum-archive aesthetic.
+
+## Type
+- Headline: "Creation Chronicles" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "From fragmented content to a unified narrative system" (Poppins, ~30px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Amber underline-glow beneath the headline.
+
+## Symbols / Iconography
+- Open leather chronicle book — the narrative substrate
+- Hand-drawn timeline with five dots — the repeatable production system
+- Five small icons (eye, heart, hand, mountain, sun) — the storyteller's archetypes
+- Fountain pen + inkwell — the craft, not AI generation
+- Emerald ribbon — the system/structure tying the soul-spectrum work together
+
+## Variants
+- v1: The open chronicle described above — soul-spectrum dominant, narrative-warm.
+- v2: Three-quarter desk view — a single hand-written page in foreground with the chronicle book closed behind it, a candle in soft focus to the right. More intimate, more "the writer's desk at night."
+- v3: Architectural / symbolic — a single golden spiral (the narrative arc) rising out of a deep amber pool, with smaller spirals branching off at three points (the chapters / repeatable production cycles). Reads "story as system, not slogan."
+
+## Rationale
+
+Creation Chronicles is the Storyteller-Poets tier — the product audience writes for a living and is allergic to AI-generated content imagery. The OG must feel like literature, not software. Handwriting and leather signal craft; the timeline with five marked dots signals the underlying production system (the actual product) without resorting to dashboard screenshots. Soul amber is dominant; emerald appears only on the binding ribbon to whisper "system behind the soul."

--- a/public/images/products/creative-ai-toolkit/creative-ai-toolkit-og.spec.md
+++ b/public/images/products/creative-ai-toolkit/creative-ai-toolkit-og.spec.md
@@ -1,0 +1,36 @@
+# OG Image Spec — /products/creative-ai-toolkit
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/creative-ai-toolkit/creative-ai-toolkit-og.spec.md`
+**Used by:** `app/products/creative-ai-toolkit/page.tsx` metadata
+
+## Palette
+- Emerald primary: #10b981 (tech-spectrum dominant — this is the workflow product)
+- Tech cyan: #06b6d4 (highlights, the "100+ prompts" pulse)
+- Soul amber: #f59e0b (accent — protects the creator's voice through the workflow)
+- Void background: #0a0a0b
+
+## Composition
+
+A clean dark workbench viewed from slightly above. At the center: a slim leather toolbelt unfurled flat, holding twelve precise pockets each containing one symbolic tool — an emerald-handled scalpel, a cyan-tipped fountain pen, a small brass compass, a folded blueprint, a tiny analog timer, a magnifying loupe, a wax stamp, a stack of index cards, a small notebook, a brass key, a soft brush, and a tuning fork. Each tool is positioned with surgical precision. Above the toolbelt, floating just out of focus: a translucent amber filament tracing a soft loop (the creator's voice, the protected signal). To the left: a single closed dark notebook with an emerald bookmark. Editorial product photography, cool top-down light with a warm secondary glow from upper-right. Premium, restrained, no people.
+
+## Type
+- Headline: "Creative AI Toolkit" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "100+ prompts. 12 automations. Your voice intact." (Poppins, ~30px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Emerald-to-cyan 1px gradient line above the headline (80px wide).
+
+## Symbols / Iconography
+- Twelve precise tools in a leather belt — the 12 automations + the craft tone
+- Each tool color-coded (emerald handles dominant, cyan tips, brass for the legacy elements) — the workflow categories
+- The amber filament loop — the creator's voice, protected as it passes through the system
+- Closed notebook with emerald bookmark — the "trusted daily ritual" promise
+
+## Variants
+- v1: The unfurled toolbelt described above — premium, surgical, "battle-tested."
+- v2: Three-quarter desk view — laptop open at left showing a single clean terminal window with emerald text, the toolbelt at center, espresso to the right. More "creator at work."
+- v3: Architectural / symbolic — twelve thin emerald lines flowing from left to right, with one amber line woven among them maintaining its independent shape (the voice protected through the workflow). Minimal, abstract, premium. Reads "the system that preserves what makes you, you."
+
+## Rationale
+
+Creative AI Toolkit is the workflow-velocity product — the audience is creators drowning in AI hype who need proven, restrained tooling. The image must signal craftsmanship and precision, not "100 prompts!" copy-energy. The amber thread woven through the emerald tools is the entire product thesis in one visual element: AI workflow that protects creator voice. Editorial product photography matches the page's "battle-tested" tone.

--- a/public/images/products/generative-creator-os/generative-creator-os-og.spec.md
+++ b/public/images/products/generative-creator-os/generative-creator-os-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /products/generative-creator-os
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/generative-creator-os/generative-creator-os-og.spec.md`
+**Used by:** `app/products/generative-creator-os/page.tsx` metadata
+**Product:** "Creator Studio OS" — custom multi-modal studio, 2-week sprint deployment
+
+## Palette
+- Emerald primary: #10b981 (the OS substrate)
+- Tech cyan: #06b6d4 (the multi-channel distribution layer)
+- Soul amber: #f59e0b (the protected voice / director's chair)
+- Void background: #0a0a0b
+
+## Composition
+
+A wide cinematic studio control room view, photographed slightly off-axis. Foreground center: a single director's chair (low silhouette, deep walnut + emerald leather) facing away from the viewer, oriented toward a curved wall of soft displays. The displays form a gentle arc — four panels, each showing a different distribution channel (suggested abstractly: one with vertical motion-bars for video, one with a sound waveform, one with a grid of square thumbnails, one with stacked horizontal text-blocks). All panels glow in cool emerald-cyan light; the director's chair is warmed by a single overhead amber spot. Behind the displays: deep void with a faint cyan grid pattern barely visible. The composition reads "one director, many channels, one voice." Cinematic depth, restrained lighting, no people seated in the chair (the chair is for the operator — the viewer).
+
+## Type
+- Headline: "Creator Studio OS" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Multiply output. Protect voice. Stay in the chair." (Poppins, ~30px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Subtle emerald-cyan gradient underline beneath the headline.
+
+## Symbols / Iconography
+- Empty director's chair — the operator is the viewer, in command, not displaced
+- Four channel-panels (video / audio / image / text) — the multi-modal output surface
+- Overhead amber spotlight on the chair — the voice protected
+- Cyan grid in background — the OS substrate underneath
+
+## Variants
+- v1: The studio control room described above — cinematic, premium, "director in the chair."
+- v2: Overhead top-down view of a sleek desk: closed laptop center, four small physical objects radiating outward (a film clapperboard, a microphone, a paintbrush, a fountain pen — each in a different cardinal direction). A single amber line traces from the laptop to each object. More flat-lay editorial.
+- v3: Architectural / symbolic — a single emerald cube floating center-frame with four cyan beams emerging from each face, terminating in soft glow-points. One amber filament wraps the cube core, holding shape regardless of which beam fires. Minimal, abstract, "the OS that holds your voice while scaling your output."
+
+## Rationale
+
+Generative Creator OS (Creator Studio OS) is the most ambitious product on the site — a 2-week custom build sprint with a substantial price tag. The OG must signal cinema-grade craft, not SaaS-dashboard energy. The empty director's chair is the visual hook: the buyer stays in command, the OS handles the multiplication. The amber spotlight + cyan grid duality is the entire product thesis — soul-spectrum voice on a tech-spectrum substrate.

--- a/public/images/products/prompt-vault/prompt-vault-og.spec.md
+++ b/public/images/products/prompt-vault/prompt-vault-og.spec.md
@@ -1,0 +1,38 @@
+# OG Image Spec — /products/prompt-vault
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/prompt-vault/prompt-vault-og.spec.md`
+**Used by:** `app/products/prompt-vault/page.tsx` metadata
+**Product:** Creator Prompt Vault — 66 production-grade prompts, 14 categories, €19
+
+## Palette
+- Emerald primary: #10b981 (the vault material, the lock)
+- Tech cyan: #06b6d4 (the index light, the structure inside)
+- Soul amber: #f59e0b (the warmth inside the vault — these prompts ship work, not theory)
+- Void background: #0a0a0b
+
+## Composition
+
+A premium vault door, slightly ajar, photographed at three-quarter angle from the right side. The door is matte dark steel with an emerald inlay forming a single subtle circular ring around the central mechanism. Through the partially-open door: warm amber light spills outward, revealing the interior — fourteen narrow vertical shelves visible at varying depths, each shelf holding small stacked card-like objects (the prompts), each shelf softly underlit in cyan. A single brass key still hangs in the lock. Outside the door, on a dark stone floor: one card has been pulled out and lies face-down, with emerald edge-glow. Cinematic, restrained, no people. Editorial product photography quality with shallow depth of field on the foreground card.
+
+## Type
+- Headline: "Creator Prompt Vault" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "66 battle-tested prompts. 14 categories. From the creator who ships." (Poppins, ~28px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. A small emerald lock-icon glyph (12px) sits to the left of the subtitle.
+
+## Symbols / Iconography
+- Vault door — the production-grade quality, the curation, the "earned" feel
+- Fourteen shelves — the 14 categories, made structural not listed
+- Single brass key in the lock — accessible at €19 (warm price-anchor, not gatekept)
+- Cards on shelves with cyan underlight — the prompts themselves, organized
+- The single pulled-out card with emerald edge-glow — "this one is ready for you"
+
+## Variants
+- v1: The vault door described above — cinematic, premium, "production-grade."
+- v2: Overhead flat-lay of 14 small card-stacks arranged in a 7×2 grid on dark walnut, each stack labeled only by a small emerald icon (representing the 14 categories: writing, music, image, ideation, coding, AI architecture, agents, business, social, etc.). A single card from one stack is partially fanned out. Magazine-grid aesthetic.
+- v3: Architectural / symbolic — a tall narrow library of 66 thin spines viewed straight-on, each spine in a different shade of emerald/cyan/amber, with one spine pulled slightly forward. Reads "a curated library, not a content dump."
+
+## Rationale
+
+Prompt Vault is a low-priced, high-volume product (€19) that risks reading as commodity in OG previews. The vault door imagery does the opposite work — it signals curation, restraint, and "these are the ones that actually work." The warm amber spill from inside is critical: it signals practical warmth, not cold gatekeeping. The brass key in the lock signals accessibility ("you can have this") at a premium-feel without resorting to "$19!" copy.

--- a/public/images/products/suno-prompt-library/suno-prompt-library-og.spec.md
+++ b/public/images/products/suno-prompt-library/suno-prompt-library-og.spec.md
@@ -1,0 +1,39 @@
+# OG Image Spec — /products/suno-prompt-library
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/suno-prompt-library/suno-prompt-library-og.spec.md`
+**Used by:** `app/products/suno-prompt-library/page.tsx` metadata
+**Product:** Suno Prompt Library Pack — 100+ prompts, 500+ tracks worth of proof
+
+## Palette
+- Soul amber: #f59e0b (primary — this is a music product, soul-spectrum dominant)
+- Soul gold: #fbbf24 (highlights, warmth of sound)
+- Bridge magenta accent: #E040FB (sparingly — the genre-spread, the energy)
+- Emerald accent: #10b981 (the curation system)
+- Void background: #0a0a0b
+
+## Composition
+
+A dark vinyl record studio scene viewed at three-quarter angle from above. Center: a single 12-inch vinyl record on a dark walnut turntable, the record's grooves catching warm amber light from upper-right and forming concentric ring-glows. The label at the record's center is a deep emerald with a small gold "100+" embossed mark. Around the turntable, arranged in a soft semicircle: five small genre-marker cards lying flat (electronic, hip-hop, cinematic, ambient, world music — each card visually distinct by color-coded edge: cyan, magenta, deep blue, amber, gold). Behind the turntable, slightly out of focus: a wall of dark studio acoustic panels with thin amber light strips between them. No people. Editorial music-magazine photography, cinematic depth, warm but restrained.
+
+## Type
+- Headline: "Suno Prompt Library" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "100+ proven prompts. 500+ tracks of evidence." (Poppins, ~30px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. A small amber soundwave glyph (12px) sits to the left of the subtitle.
+
+## Symbols / Iconography
+- Vinyl record on turntable — music heritage, craft, "this is real sound work"
+- Emerald record label — the FrankX curation system inside the soul-spectrum work
+- Five genre cards in semicircle — the genre coverage (no need to label, the colors carry it)
+- Acoustic panels — the studio context, "professional output"
+- Warm amber rim-light — the soul-spectrum mood without going twee
+
+## Variants
+- v1: The vinyl + turntable described above — premium, music-magazine editorial.
+- v2: Overhead flat-lay of a music notebook open to a page of hand-written lyric fragments + waveform sketches, surrounded by five small instrument silhouettes (synthesizer key, guitar pick, drum stick, microphone, headphones). Warm light from one side, single emerald pencil resting on the notebook. More songwriter-desk energy.
+- v3: Architectural / symbolic — a single tall amber sine-wave traveling left-to-right across the frame, fragmenting at five points into different waveform shapes (each representing a genre). A thin emerald baseline runs underneath holding everything in tune. Minimal, abstract, "the prompts that hold pitch across genres."
+
+## Rationale
+
+Suno Prompt Library is the most soul-spectrum-dominant product on the site (Frank's 12,000+ AI songs is the proof). The OG must read like a music release, not a SaaS product page. Vinyl + turntable signals heritage craft; the genre-card semicircle does the cover-coverage work without listing genres in text. Emerald appears only on the record label and baseline — the curation/system that organizes the soul-spectrum output. No magenta dominance — magenta is the energy accent, not the brand.

--- a/public/images/products/trinity-ai/trinity-ai-og.spec.md
+++ b/public/images/products/trinity-ai/trinity-ai-og.spec.md
@@ -1,0 +1,45 @@
+# OG Image Spec — /products/trinity-ai
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/products/trinity-ai/trinity-ai-og.spec.md`
+**Used by:** `app/products/trinity-ai/page.tsx` metadata
+**Product:** Trinity AI — Conscious Operating System for Human Potential, five system layers
+
+## Palette
+- Emerald primary: #10b981 (the mind layer)
+- Soul amber: #f59e0b (the body layer)
+- Bridge violet: #7C3AED (the consciousness / arcanea-glow layer, sparingly)
+- Tech cyan: #06b6d4 (the substrate / signal layer)
+- Void background: #0a0a0b
+
+## Composition
+
+Architectural / symbolic — viewed straight-on. Three concentric architectural forms float at the center of a vast deep-void space, suggesting a single unified system viewed in cross-section:
+
+- Outer ring: a fine cyan filament forming a perfect circle (the substrate / signal layer — what reads the body).
+- Middle ring: a slightly thicker emerald filament forming a triangle inscribed inside the cyan circle (the mind layer — clear, structural).
+- Inner core: a small warm amber sphere at the geometric center, with a soft violet halo barely visible behind it (the body + consciousness layer — the living core).
+
+Three thin gold lines connect the inner sphere to the three vertices of the emerald triangle — the trinity made visible. Light radiates softly from the core in concentric pulses, dissipating into the void. Background: deep charcoal void with a barely-visible grid of cool blue stars and a single horizon-line of distant amber glow at the very bottom edge. Editorial render quality, calm, premium, cosmic but restrained.
+
+## Type
+- Headline: "Trinity AI" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "A conscious operating system for human potential." (Poppins, ~30px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. A tiny three-point glyph (cyan / emerald / amber dots connected by thin gold lines) sits to the left of the subtitle.
+
+## Symbols / Iconography
+- Three concentric forms (circle / triangle / sphere) — the three layers (signal / mind / body+consciousness) made geometric
+- Cyan outer ring — the substrate that reads the body
+- Emerald triangle — the mind layer, structural and clear
+- Amber sphere + violet halo — body sensation + consciousness as one living core
+- Three connecting gold lines — the integration, the trinity made visible
+
+## Variants
+- v1: The concentric-trinity symbol described above — minimal, cosmic, premium.
+- v2: A subtle architectural cross-section of a five-layer cake — five thin horizontal bands (cyan / emerald / gold / amber / violet from bottom to top) floating in void, each band catching different light angles. More "five system layers" literal.
+- v3: A single warm sphere at center frame with three thin filaments orbiting it at different angles (one cyan, one emerald, one amber), with their orbital paths leaving soft trail-glows. Very minimal, "the living layer that compounds everything you are."
+
+## Rationale
+
+Trinity AI is the most philosophically ambitious product on the site — a "conscious operating system for human potential" demands an OG image that earns the claim without resorting to spiritual kitsch (no chakras, no lotus flowers, no glowing humans). The concentric geometric architecture treats consciousness with the same restraint as the rest of the brand — it's structural, not mystical. The four-color palette is the entire product thesis: tech substrate + mind structure + body warmth + consciousness halo. Violet appears only as a barely-visible halo — a whisper, not a shout.


### PR DESCRIPTION
Wave 11 of overnight excellence campaign. 3 commits.

## What ships

- **a11y deep audit** (commit `025b7f2f`): `<main>` landmarks on /inner-circle + /blog/[slug], skip-link target fixed, NavigationMega `aria-current` on active route + `aria-label='Primary'`/`'Mobile primary'` on navs, EmailCapture full a11y (`aria-busy`, `aria-invalid`, sr-only labels, autoComplete, focus rings), email-signup same treatment. Verified Footer/FunnelCTA/BlogCard/HomePageElite already AA-compliant.
- **Footer ecosystem map** (commit `2e5c35ae`): added `/llm-hub` to Hubs column, `/tribe`+`/inner-circle`+`/workshops` to Connect/Learn columns, `/unsubscribe` to newsletter footer (GDPR compliance). Renamed 'Create' → 'Hubs' to match real nav. Wait-list voice on newsletter CTA. Grid 6→5 columns post-consolidation.
- **OG image generation specs** (commit `53b7a019`): 8 NB2-ready specs at `public/images/.../*-og.spec.md` for /build, /products/bv-kit, /products/creation-chronicles, /products/creative-ai-toolkit, /products/generative-creator-os, /products/prompt-vault, /products/suno-prompt-library, /products/trinity-ai. Each has palette, composition, typography (Poppins per design.md), symbols, 3 variants. Frank can batch-generate via `node scripts/nb-generate.mjs --spec <path>` when ready. Default /hero-homepage.png remains fallback until then.

## Pre-flight gates
- `npx tsc --noEmit` → 0 errors ✓
- `node scripts/check-internal-links.mjs --warn` → 0 broken (1,604 files) ✓
- All 3 commits clean

🤖 Generated overnight by Claude Code Opus 4.7