### PR TITLE
perf+polish(excellence): Wave 13 — image sizes (LCP) + music/watch/ai-architecture + workshop OG specs

### DIFF
--- a/app/ai-architecture/blueprints/page.tsx
+++ b/app/ai-architecture/blueprints/page.tsx
@@ -144,7 +144,7 @@ export default function BlueprintsPage() {
       {/* Hero */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-6xl mt-24 px-6">
         <div className="relative aspect-[21/9]">
-          <Image src="/images/architectures/ai-coe.png" alt="AI Center of Excellence architecture diagram" fill className="object-cover" />
+          <Image src="/images/architectures/ai-coe.png" alt="AI Center of Excellence architecture diagram" fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/ai-architecture/multi-cloud-comparison/page.tsx
+++ b/app/ai-architecture/multi-cloud-comparison/page.tsx
@@ -697,7 +697,7 @@ export default function AIArchitecturePage() {
         {/* Hero */}
         <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-6xl mt-24 px-6">
           <div className="relative aspect-[21/9]">
-            <Image src="/images/architectures/ai-gateway.png" alt="AI gateway architecture diagram" fill className="object-cover" />
+            <Image src="/images/architectures/ai-gateway.png" alt="AI gateway architecture diagram" fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" />
             <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
           </div>
           <div className="absolute bottom-0 left-0 p-6">

--- a/app/ai-architecture/page.tsx
+++ b/app/ai-architecture/page.tsx
@@ -286,7 +286,7 @@ export default function AIArchitectureHubPage() {
       <HubBackground />
       <main className="relative min-h-screen">
         {/* Hero */}
-        <section className="pt-32 pb-8 sm:pt-36 sm:pb-12">
+        <section className="pt-32 pb-20 lg:pb-28 sm:pt-36">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, scale: 0.9 }}
@@ -317,7 +317,7 @@ export default function AIArchitectureHubPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.08 }}
-              className="mb-6 max-w-4xl font-display text-4xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl lg:text-6xl"
+              className="mb-6 max-w-4xl font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white"
             >
               Learn. Try.{' '}
               <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-emerald-400 bg-clip-text text-transparent">
@@ -329,7 +329,7 @@ export default function AIArchitectureHubPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.16 }}
-              className="mb-10 max-w-2xl text-lg leading-relaxed text-slate-400"
+              className="mb-10 max-w-2xl text-[17px] leading-relaxed text-white/80"
             >
               Production-ready AI architecture patterns. Explore blueprints, test with your own API
               keys, and deploy with starter templates. Cloud-agnostic patterns that work everywhere.
@@ -343,7 +343,7 @@ export default function AIArchitectureHubPage() {
             >
               <Link
                 href="/ai-architecture/blueprints"
-                className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-white/10"
+                className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <BookOpen className="h-4 w-4" />
                 Browse Blueprints
@@ -351,7 +351,7 @@ export default function AIArchitectureHubPage() {
               </Link>
               <Link
                 href="/ai-architecture/prototypes"
-                className="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition-all hover:bg-white/10"
+                className="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Play className="h-4 w-4" />
                 Try Prototypes
@@ -388,7 +388,7 @@ export default function AIArchitectureHubPage() {
         </section>
 
         {/* Hub Navigation Cards */}
-        <section className="py-12">
+        <section className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               variants={staggerContainer}
@@ -404,7 +404,7 @@ export default function AIArchitectureHubPage() {
         </section>
 
         {/* BYOK Section */}
-        <section className="py-12 border-y border-white/[0.04]">
+        <section className="py-20 lg:py-28 border-y border-white/[0.04]">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -427,7 +427,7 @@ export default function AIArchitectureHubPage() {
                       <p className="text-xs font-medium text-violet-400/80">Zero cost to us. Full control to you.</p>
                     </div>
                   </div>
-                  <p className="max-w-xl text-sm leading-relaxed text-slate-400">
+                  <p className="max-w-xl text-[17px] leading-relaxed text-white/80">
                     Try prototypes using your own API keys. Keys stay in your browser localStorage —
                     never sent to our servers. Works with any provider. You control costs.
                   </p>
@@ -444,7 +444,7 @@ export default function AIArchitectureHubPage() {
         </section>
 
         {/* Featured Blueprints */}
-        <section className="py-16">
+        <section className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <div className="mb-10 flex items-end justify-between">
               <div>
@@ -460,7 +460,7 @@ export default function AIArchitectureHubPage() {
                   initial={{ opacity: 0, y: 12 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
-                  className="text-2xl font-bold text-white sm:text-3xl"
+                  className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white"
                 >
                   Featured Blueprints
                 </motion.h2>
@@ -469,14 +469,14 @@ export default function AIArchitectureHubPage() {
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: 0.1 }}
-                  className="mt-2 text-slate-400"
+                  className="mt-3 text-[17px] leading-relaxed text-white/80"
                 >
                   Production-ready patterns with diagrams, guides & cost estimates
                 </motion.p>
               </div>
               <Link
                 href="/ai-architecture/blueprints"
-                className="hidden items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-slate-400 transition-all hover:border-white/20 hover:text-white sm:flex"
+                className="hidden items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-slate-400 transition-all hover:border-white/20 hover:text-white sm:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 View all
                 <ArrowRight className="h-3.5 w-3.5" />
@@ -502,13 +502,13 @@ export default function AIArchitectureHubPage() {
         </section>
 
         {/* Templates Teaser */}
-        <section className="py-16 border-t border-white/[0.04]">
+        <section className="py-20 lg:py-28 border-t border-white/[0.04]">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              className="relative overflow-hidden rounded-2xl border border-emerald-500/15 bg-emerald-500/[0.04] p-8 sm:p-10 text-center"
+              className="relative overflow-hidden rounded-2xl border border-emerald-500/15 bg-emerald-500/[0.04] backdrop-blur-xl p-8 sm:p-10 text-center"
             >
               {/* Decorative glow */}
               <div className="pointer-events-none absolute left-1/2 top-0 h-32 w-64 -translate-x-1/2 bg-emerald-500/10 blur-3xl" aria-hidden />
@@ -517,8 +517,8 @@ export default function AIArchitectureHubPage() {
                 <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/15 text-emerald-400">
                   <Package className="h-7 w-7" />
                 </div>
-                <h3 className="mb-3 text-2xl font-bold text-white">Starter Templates</h3>
-                <p className="mx-auto mb-8 max-w-lg text-slate-400 leading-relaxed">
+                <h3 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Starter Templates</h3>
+                <p className="mx-auto mb-8 max-w-lg text-[17px] leading-relaxed text-white/80">
                   Production-ready starter kits with one-click deploy. From RAG pipelines
                   to multi-agent frameworks — ship in hours, not weeks.
                 </p>
@@ -539,7 +539,7 @@ export default function AIArchitectureHubPage() {
                 </div>
                 <Link
                   href="/ai-architecture/templates"
-                  className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-emerald-400 hover:shadow-lg hover:shadow-emerald-500/20"
+                  className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-emerald-400 hover:shadow-lg hover:shadow-emerald-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
                 >
                   Browse Templates
                   <ArrowRight className="h-4 w-4" />
@@ -550,7 +550,7 @@ export default function AIArchitectureHubPage() {
         </section>
 
         {/* Cloud Agnostic */}
-        <section className="py-16">
+        <section className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6 text-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -560,8 +560,8 @@ export default function AIArchitectureHubPage() {
               <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.06] text-white">
                 <Globe className="h-6 w-6" />
               </div>
-              <h2 className="mb-3 text-2xl font-bold text-white">Cloud-Agnostic Patterns</h2>
-              <p className="mx-auto mb-10 max-w-lg text-slate-400">
+              <h2 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Cloud-Agnostic Patterns</h2>
+              <p className="mx-auto mb-10 max-w-lg text-[17px] leading-relaxed text-white/80">
                 Learn the pattern once, deploy anywhere. All blueprints and templates
                 work across major cloud providers.
               </p>

--- a/app/ai-architecture/prototypes/page.tsx
+++ b/app/ai-architecture/prototypes/page.tsx
@@ -166,7 +166,7 @@ export default function PrototypesPage() {
       {/* Hero */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-6xl mt-24 px-6">
         <div className="relative aspect-[21/9]">
-          <Image src="/images/architectures/mcp-hub.png" alt="MCP hub architecture diagram" fill className="object-cover" />
+          <Image src="/images/architectures/mcp-hub.png" alt="MCP hub architecture diagram" fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/ai-architecture/templates/page.tsx
+++ b/app/ai-architecture/templates/page.tsx
@@ -298,7 +298,7 @@ export default function TemplatesPage() {
       {/* Hero */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-6xl mt-24 px-6">
         <div className="relative aspect-[21/9]">
-          <Image src="/images/architectures/llmops.png" alt="LLMOps architecture diagram" fill className="object-cover" />
+          <Image src="/images/architectures/llmops.png" alt="LLMOps architecture diagram" fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/ai-architecture/tools/page.tsx
+++ b/app/ai-architecture/tools/page.tsx
@@ -331,7 +331,7 @@ export default function ToolsPage() {
       {/* Hero Image */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-6xl mt-6 px-6">
         <div className="relative aspect-[21/9] rounded-2xl overflow-hidden">
-          <Image src="/images/blog/agentic-creator-os-hero.png" alt="AI Architecture Tools — curated resources for AI development" fill className="object-cover" />
+          <Image src="/images/blog/agentic-creator-os-hero.png" alt="AI Architecture Tools — curated resources for AI development" fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/ai-ops/architecture/page.tsx
+++ b/app/ai-ops/architecture/page.tsx
@@ -58,7 +58,7 @@ export default function ArchitecturePage() {
 
         <div className="relative mb-8 overflow-hidden rounded-2xl">
           <div className="relative aspect-[21/9]">
-            <Image src="/images/architectures/mcp-hub.png" alt="The 5-Layer AI Ops Stack" fill className="object-cover" />
+            <Image src="/images/architectures/mcp-hub.png" alt="The 5-Layer AI Ops Stack" fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" />
             <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
           </div>
           <div className="absolute bottom-0 left-0 p-6">

--- a/app/ai-world/page.tsx
+++ b/app/ai-world/page.tsx
@@ -331,6 +331,7 @@ export default function IntelligenceAtlasPage() {
               src="/images/ai-world/intelligence-atlas-hero.png"
               alt="The Intelligence Atlas - Neural Constellation Map"
               fill
+              sizes="(max-width: 896px) 100vw, 896px"
               className="object-cover"
               priority
             />
@@ -406,6 +407,7 @@ export default function IntelligenceAtlasPage() {
                       src={activeGateData.image}
                       alt={activeGateData.title}
                       fill
+                      sizes="(max-width: 1024px) 100vw, 66vw"
                       className="object-cover"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-slate-900 via-slate-900/50 to-transparent" />

--- a/app/books/[bookSlug]/page.tsx
+++ b/app/books/[bookSlug]/page.tsx
@@ -146,6 +146,7 @@ export default async function BookLandingPage({ params }: PageProps) {
                         src={book.coverImage}
                         alt={book.title}
                         fill
+                        sizes="(max-width: 640px) 256px, (max-width: 1024px) 288px, 320px"
                         className="object-cover"
                         priority
                       />

--- a/app/books/components/BookReader.tsx
+++ b/app/books/components/BookReader.tsx
@@ -152,6 +152,7 @@ export default function BookReader({
               src={chapter.image}
               alt={`Chapter ${chapter.number}: ${chapter.title}`}
               fill
+              sizes="100vw"
               className="object-cover"
               priority
               quality={90}

--- a/app/for/creators/page.tsx
+++ b/app/for/creators/page.tsx
@@ -142,7 +142,7 @@ export default function CreatorsLandingPage() {
       {/* Hero Image */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-5xl mt-6 px-6">
         <div className="relative aspect-[21/9] rounded-2xl overflow-hidden">
-          <Image src="/images/blog/acos-use-cases-creator-types-hero.png" alt="Creator tools and AI-powered creative workflows" fill className="object-cover" />
+          <Image src="/images/blog/acos-use-cases-creator-types-hero.png" alt="Creator tools and AI-powered creative workflows" fill sizes="(max-width: 1024px) 100vw, 1024px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/frankx/page.tsx
+++ b/app/frankx/page.tsx
@@ -134,6 +134,7 @@ export default function FrankXPage() {
             src="/images/mascot/frank-omega-hero-v1.png"
             alt=""
             fill
+            sizes="100vw"
             className="object-cover object-center opacity-15"
             priority
           />
@@ -359,6 +360,7 @@ export default function FrankXPage() {
                 src={variants[0].thumb}
                 alt={`FRANK-Ω ${variants[0].label}`}
                 fill
+                sizes="(max-width: 640px) 50vw, (max-width: 1024px) 50vw, 33vw"
                 className="object-cover object-center group-hover:scale-105 transition-transform duration-700"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/20 to-transparent" />
@@ -378,6 +380,7 @@ export default function FrankXPage() {
                 src={variants[1].thumb}
                 alt={`FRANK-Ω ${variants[1].label}`}
                 fill
+                sizes="(max-width: 640px) 50vw, (max-width: 1024px) 50vw, 33vw"
                 className="object-cover object-top group-hover:scale-105 transition-transform duration-700"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/10 to-transparent" />
@@ -398,6 +401,7 @@ export default function FrankXPage() {
                   src={v.thumb}
                   alt={`FRANK-Ω ${v.label}`}
                   fill
+                  sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 16vw"
                   className="object-cover object-top group-hover:scale-110 transition-transform duration-500"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/30 to-transparent" />

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -86,6 +86,7 @@ function HeroSection() {
           src="/images/games/games-lab-hero.png"
           alt=""
           fill
+          sizes="100vw"
           className="object-cover opacity-15"
           priority
         />

--- a/app/gencreator/blueprints/page.tsx
+++ b/app/gencreator/blueprints/page.tsx
@@ -53,7 +53,7 @@ export default function BlueprintsPage() {
       {/* Hero Image */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-5xl mt-6 px-6">
         <div className="relative aspect-[21/9] rounded-2xl overflow-hidden">
-          <Image src="/images/blog/agentic-creator-os-complete-guide-hero.png" alt="GenCreator Blueprints — actionable creator frameworks" fill className="object-cover" />
+          <Image src="/images/blog/agentic-creator-os-complete-guide-hero.png" alt="GenCreator Blueprints — actionable creator frameworks" fill sizes="(max-width: 1024px) 100vw, 1024px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/gencreator/handbook/page.tsx
+++ b/app/gencreator/handbook/page.tsx
@@ -37,7 +37,7 @@ export default function HandbookPage() {
       {/* Hero Image */}
       <div className="relative mb-8 overflow-hidden rounded-2xl mx-auto max-w-5xl mt-6 px-6">
         <div className="relative aspect-[21/9] rounded-2xl overflow-hidden">
-          <Image src="/images/blog/30-minute-creator-os-quick-start-hero.png" alt="The GenCreator Handbook — 8 chapters for creative mastery" fill className="object-cover" />
+          <Image src="/images/blog/30-minute-creator-os-quick-start-hero.png" alt="The GenCreator Handbook — 8 chapters for creative mastery" fill sizes="(max-width: 1024px) 100vw, 1024px" className="object-cover" />
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/60 to-transparent" />
         </div>
         <div className="absolute bottom-0 left-0 p-6">

--- a/app/golden-age/components/ChapterReader.tsx
+++ b/app/golden-age/components/ChapterReader.tsx
@@ -124,6 +124,7 @@ export default function ChapterReader({
               src={chapter.image}
               alt={`Chapter ${chapter.number}: ${chapter.title}`}
               fill
+              sizes="100vw"
               className="object-cover"
               priority
               quality={90}

--- a/app/golden-age/page.tsx
+++ b/app/golden-age/page.tsx
@@ -18,6 +18,7 @@ export default function GoldenAgePage() {
             src="/images/golden-age/hero-golden-age.png"
             alt="The Golden Age of Creators - A creator conducting an orchestra of creative energy"
             fill
+            sizes="100vw"
             className="object-cover object-center"
             priority
             quality={90}
@@ -350,6 +351,7 @@ export default function GoldenAgePage() {
             src="/images/golden-age/hero-golden-age.png"
             alt="Golden Age of Intelligence hero background"
             fill
+            sizes="100vw"
             className="object-cover object-top opacity-30 dark:opacity-20"
             aria-hidden="true"
           />

--- a/app/infogenius/page.tsx
+++ b/app/infogenius/page.tsx
@@ -354,6 +354,7 @@ export default function InfoGeniusPage() {
                     src={v.thumb}
                     alt={`FRANK-Ω ${v.label}`}
                     fill
+                    sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
                     className="object-cover object-top"
                   />
                 </div>

--- a/app/music/page.tsx
+++ b/app/music/page.tsx
@@ -259,7 +259,7 @@ function MusicBackground() {
 function HeroSection() {
   const heroTrack = topTracks[0]
   return (
-    <section className="relative pt-32 pb-16 px-6">
+    <section className="relative pt-32 pb-20 lg:pb-28 px-6">
       {/* Echo — Sound Weaver character accent */}
       <div className="pointer-events-none absolute right-6 top-20 hidden w-48 opacity-15 lg:block xl:w-56">
         <Image src="/images/team/echo-leopard.png" alt="" width={224} height={224} className="object-contain" aria-hidden="true" />
@@ -276,7 +276,7 @@ function HeroSection() {
               <span className="text-sm font-medium text-emerald-300">AI Music Architecture</span>
             </div>
 
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] mb-6">
               <span className="text-white">Architecting Music</span>
               <br />
               <span className="bg-gradient-to-r from-emerald-400 via-cyan-400 to-violet-400 bg-clip-text text-transparent">
@@ -284,11 +284,11 @@ function HeroSection() {
               </span>
             </h1>
 
-            <p className="text-xl text-white/80 mb-3 max-w-xl leading-relaxed">
+            <p className="text-[17px] leading-relaxed text-white/80 mb-3 max-w-xl">
               Architecting the future of AI, creation, and digital worlds through music.
             </p>
 
-            <p className="text-lg text-white/50 mb-8 max-w-lg leading-relaxed">
+            <p className="text-[17px] leading-relaxed text-white/60 mb-8 max-w-lg">
               {musicStats.totalTracks}+ published tracks on Suno AI. From healing frequencies and orchestral epics
               to tech house and hip hop. This page now runs as a visual operating system: narrative assets,
               swarm-owned media pipelines, and platform-ready sales paths.
@@ -299,7 +299,7 @@ function HeroSection() {
                 href={musicStats.profileUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group inline-flex items-center gap-3 bg-white text-black px-7 py-4 rounded-full font-semibold transition-all hover:bg-white/90 hover:shadow-[0_0_40px_rgba(255,255,255,0.15)]"
+                className="group inline-flex items-center gap-3 bg-white text-black px-7 py-4 rounded-full font-semibold transition-all hover:bg-white/90 hover:shadow-[0_0_40px_rgba(255,255,255,0.15)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Play className="w-5 h-5" />
                 Full Catalog on Suno
@@ -307,14 +307,14 @@ function HeroSection() {
               </a>
               <Link
                 href="/music/brainstorm"
-                className="inline-flex items-center gap-3 border border-white/20 text-white px-7 py-4 rounded-full font-semibold transition-all hover:bg-white/5"
+                className="inline-flex items-center gap-3 border border-white/20 text-white px-7 py-4 rounded-full font-semibold transition-all hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Sparkles className="w-4 h-4" />
                 Brainstorm Ideas
               </Link>
               <Link
                 href="/infogenius"
-                className="inline-flex items-center gap-3 border border-violet-500/40 text-violet-200 px-7 py-4 rounded-full font-semibold transition-all hover:bg-violet-500/10"
+                className="inline-flex items-center gap-3 border border-violet-500/40 text-violet-200 px-7 py-4 rounded-full font-semibold transition-all hover:bg-violet-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Radar className="w-4 h-4" />
                 Generate Visuals with InfoGenius
@@ -356,7 +356,7 @@ function HeroSection() {
 
 function VisualStoryframesSection() {
   return (
-    <section className="py-20 border-y border-white/5">
+    <section className="py-20 lg:py-28 border-y border-white/5">
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -365,8 +365,8 @@ function VisualStoryframesSection() {
           className="mb-12"
         >
           <p className="text-xs uppercase tracking-[0.2em] text-cyan-300/80 mb-4">Visual Narrative System</p>
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Make the Music Universe Visible</h2>
-          <p className="text-lg text-white/50 max-w-3xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">Make the Music Universe Visible</h2>
+          <p className="text-[17px] leading-relaxed text-white/60 max-w-3xl">
             Every major narrative gets a visual anchor. These assets are designed for homepage storytelling,
             educational trust, and cross-platform repurposing.
           </p>
@@ -382,13 +382,14 @@ function VisualStoryframesSection() {
               transition={{ delay: i * 0.08 }}
               className="group"
             >
-              <Link href={frame.href} className="block h-full">
-                <article className="h-full overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] hover:border-white/25 transition-all">
+              <Link href={frame.href} className="block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]">
+                <article className="h-full overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl hover:border-white/25 transition-all">
                   <div className="relative aspect-[16/10] overflow-hidden">
                     <Image
                       src={frame.image}
                       alt={frame.title}
                       fill
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                       className="object-cover transition-transform duration-500 group-hover:scale-105"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
@@ -444,7 +445,7 @@ function StatsSection() {
 
 function FeaturedTracksSection() {
   return (
-    <section className="py-20">
+    <section className="py-20 lg:py-28">
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -452,8 +453,8 @@ function FeaturedTracksSection() {
           viewport={{ once: true }}
           className="mb-12"
         >
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Top Tracks</h2>
-          <p className="text-lg text-white/50">Most played tracks from the catalog</p>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">Top Tracks</h2>
+          <p className="text-[17px] leading-relaxed text-white/60">Most played tracks from the catalog</p>
         </motion.div>
 
         <div className="grid md:grid-cols-2 gap-6">
@@ -466,7 +467,7 @@ function FeaturedTracksSection() {
               transition={{ delay: i * 0.1 }}
               className="group"
             >
-              <div className="bg-white/[0.02] border border-white/10 rounded-2xl p-4 hover:border-white/20 transition-all">
+              <div className="rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl p-4 hover:border-white/20 transition-all">
                 <div className="flex items-center justify-between mb-3 px-2">
                   <div>
                     <h3 className="font-semibold text-white">{track.title}</h3>
@@ -511,7 +512,7 @@ function FeaturedTracksSection() {
 
 function SwarmOperatingModelSection() {
   return (
-    <section className="py-20 border-t border-white/5">
+    <section className="py-20 lg:py-28 border-t border-white/5">
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -520,8 +521,8 @@ function SwarmOperatingModelSection() {
           className="mb-12"
         >
           <p className="text-xs uppercase tracking-[0.2em] text-violet-300/80 mb-4">Agentically Steered</p>
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Sub-Agent Swarms and Asset Ownership</h2>
-          <p className="text-lg text-white/50 max-w-3xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">Sub-Agent Swarms and Asset Ownership</h2>
+          <p className="text-[17px] leading-relaxed text-white/60 max-w-3xl">
             Each swarm owns a clear output lane so visual content, distribution, and monetization run as one
             coordinated operating system.
           </p>
@@ -537,7 +538,7 @@ function SwarmOperatingModelSection() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: i * 0.06 }}
-                className="rounded-2xl border border-white/10 bg-white/[0.02] p-4"
+                className="rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl p-4"
               >
                 <div className="w-10 h-10 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center mb-4">
                   <Icon className="w-5 h-5 text-cyan-300" />
@@ -565,7 +566,7 @@ function SwarmOperatingModelSection() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.08 }}
-              className="rounded-2xl border border-white/10 bg-black/30 p-5"
+              className="rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl p-5"
             >
               <h3 className="text-white font-semibold text-lg mb-2">{row.channel}</h3>
               <p className="text-sm text-white/55 mb-4 leading-relaxed">{row.objective}</p>
@@ -589,7 +590,7 @@ function SwarmOperatingModelSection() {
 
 function InfoGeniusQueueSection() {
   return (
-    <section className="py-20 border-t border-white/5">
+    <section className="py-20 lg:py-28 border-t border-white/5">
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -598,8 +599,8 @@ function InfoGeniusQueueSection() {
           className="mb-10"
         >
           <p className="text-xs uppercase tracking-[0.2em] text-emerald-300/80 mb-4">InfoGenius Prompt Queue</p>
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Ready-to-Generate Visual Assets</h2>
-          <p className="text-lg text-white/50 max-w-3xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">Ready-to-Generate Visual Assets</h2>
+          <p className="text-[17px] leading-relaxed text-white/60 max-w-3xl">
             Production-ready prompts for the InfoGenius pipeline. These assets power website visuals,
             marketplace packaging, and public-platform media.
           </p>
@@ -620,6 +621,7 @@ function InfoGeniusQueueSection() {
                   src={item.previewImage}
                   alt={item.asset}
                   fill
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                   className="object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
@@ -656,7 +658,7 @@ function InfoGeniusQueueSection() {
 
 function RevenuePathsSection() {
   return (
-    <section className="py-20 border-t border-white/5">
+    <section className="py-20 lg:py-28 border-t border-white/5">
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -665,8 +667,8 @@ function RevenuePathsSection() {
           className="mb-12"
         >
           <p className="text-xs uppercase tracking-[0.2em] text-amber-300/80 mb-4">Music Sales Possibilities</p>
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Monetization Lanes, Steered by Agents</h2>
-          <p className="text-lg text-white/50 max-w-3xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">Monetization Lanes, Steered by Agents</h2>
+          <p className="text-[17px] leading-relaxed text-white/60 max-w-3xl">
             Keep revenue diversified: streaming, direct products, licensing, and membership. Each lane gets a
             dedicated asset system and feedback loop.
           </p>
@@ -725,7 +727,7 @@ const albumIconMap: Record<string, typeof Disc3> = {
 
 function AlbumsSection() {
   return (
-    <section className="py-20 border-t border-white/5">
+    <section className="py-20 lg:py-28 border-t border-white/5">
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -733,8 +735,8 @@ function AlbumsSection() {
           viewport={{ once: true }}
           className="mb-12"
         >
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Albums</h2>
-          <p className="text-lg text-white/50">Curated collections organized by genre and mood</p>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">Albums</h2>
+          <p className="text-[17px] leading-relaxed text-white/60">Curated collections organized by genre and mood</p>
         </motion.div>
 
         <div className="space-y-12">
@@ -847,17 +849,17 @@ function AlbumsSection() {
 
 function CTASection() {
   return (
-    <section className="py-24 border-t border-white/5">
+    <section className="py-20 lg:py-28 border-t border-white/5">
       <div className="max-w-4xl mx-auto px-6 text-center">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
         >
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
             Build the next wave of AI music media.
           </h2>
-          <p className="text-xl text-white/50 mb-8 max-w-2xl mx-auto">
+          <p className="text-[17px] leading-relaxed text-white/60 mb-8 max-w-2xl mx-auto">
             Use the same system here: generate visuals with InfoGenius, orchestrate swarms by channel,
             and turn tracks into a durable catalog business.
           </p>
@@ -865,7 +867,7 @@ function CTASection() {
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/music/brainstorm"
-              className="inline-flex items-center gap-3 bg-white text-black px-8 py-4 rounded-full text-lg font-semibold transition-all hover:bg-white/90 hover:shadow-[0_0_40px_rgba(255,255,255,0.15)]"
+              className="inline-flex items-center gap-3 bg-white text-black px-8 py-4 rounded-full text-lg font-semibold transition-all hover:bg-white/90 hover:shadow-[0_0_40px_rgba(255,255,255,0.15)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               <Sparkles className="w-5 h-5" />
               Brainstorm New Ideas
@@ -873,14 +875,14 @@ function CTASection() {
             </Link>
             <Link
               href="/music-lab"
-              className="inline-flex items-center gap-3 border border-white/20 text-white px-8 py-4 rounded-full text-lg font-semibold transition-all hover:bg-white/5"
+              className="inline-flex items-center gap-3 border border-white/20 text-white px-8 py-4 rounded-full text-lg font-semibold transition-all hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               <BookOpen className="w-4 h-4" />
               Learn AI Music Creation
             </Link>
             <Link
               href="/infogenius"
-              className="inline-flex items-center gap-3 border border-violet-500/40 text-violet-200 px-8 py-4 rounded-full text-lg font-semibold transition-all hover:bg-violet-500/10"
+              className="inline-flex items-center gap-3 border border-violet-500/40 text-violet-200 px-8 py-4 rounded-full text-lg font-semibold transition-all hover:bg-violet-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               <Radar className="w-4 h-4" />
               Open InfoGenius

--- a/app/soulbook/7-pillars/page.tsx
+++ b/app/soulbook/7-pillars/page.tsx
@@ -317,6 +317,7 @@ export default function SevenPillarsPage() {
             src="/images/soulbook/seven-pillars.png"
             alt="The 7 Pillars of Conscious Living"
             fill
+            sizes="100vw"
             className="object-cover opacity-40"
             priority
             quality={90}

--- a/app/soulbook/assessment/page.tsx
+++ b/app/soulbook/assessment/page.tsx
@@ -311,6 +311,7 @@ export default function AssessmentPage() {
             src="/images/soulbook/hero-assessment.png"
             alt="Soulbook assessment background"
             fill
+            sizes="100vw"
             className="object-cover opacity-20"
             quality={80}
           />
@@ -385,6 +386,7 @@ export default function AssessmentPage() {
           src="/images/soulbook/hero-assessment.png"
           alt="Soulbook assessment background"
           fill
+          sizes="100vw"
           className="object-cover opacity-15"
           quality={80}
         />

--- a/app/soulbook/golden-path/page.tsx
+++ b/app/soulbook/golden-path/page.tsx
@@ -15,6 +15,7 @@ export default function GoldenPathPage() {
             src="/images/soulbook/golden-path.png"
             alt="Golden Path - Accelerated 4-Week Breakthrough"
             fill
+            sizes="100vw"
             className="object-cover opacity-50"
             priority
             quality={90}

--- a/app/soulbook/life-symphony/page.tsx
+++ b/app/soulbook/life-symphony/page.tsx
@@ -15,6 +15,7 @@ export default function LifeSymphonyPage() {
             src="/images/soulbook/life-symphony.png"
             alt="Life Symphony - Complete 7-Pillar Transformation"
             fill
+            sizes="100vw"
             className="object-cover opacity-50"
             priority
             quality={90}

--- a/app/soulbook/vault/page.tsx
+++ b/app/soulbook/vault/page.tsx
@@ -248,6 +248,7 @@ export default function VaultPage() {
             src="/images/soulbook/hero-vault.png"
             alt="Soulbook vault background"
             fill
+            sizes="100vw"
             className="object-cover opacity-20"
             priority
             quality={80}

--- a/app/vault/[collection]/VaultCollectionClient.tsx
+++ b/app/vault/[collection]/VaultCollectionClient.tsx
@@ -24,6 +24,7 @@ export function VaultCollectionClient({
             src={collection.coverImage}
             alt=""
             fill
+            sizes="100vw"
             className="object-cover blur-3xl"
           />
         </div>

--- a/app/watch/WatchClient.tsx
+++ b/app/watch/WatchClient.tsx
@@ -100,10 +100,10 @@ export default function WatchClient({
       <WatchHero stats={stats} />
 
       {/* Editor's Picks */}
-      <section className="max-w-7xl mx-auto px-6 mb-16">
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold">Editor&apos;s Picks</h2>
-          <span className="text-xs text-white/30 uppercase tracking-wider">
+      <section className="max-w-7xl mx-auto px-6 py-20 lg:py-28">
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Editor&apos;s Picks</h2>
+          <span className="text-xs text-white/40 uppercase tracking-wider">
             Curated favorites
           </span>
         </div>
@@ -115,10 +115,10 @@ export default function WatchClient({
 
       {/* Watchlists */}
       {watchlists.length > 0 && (
-        <section className="max-w-7xl mx-auto px-6 mb-16">
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold">Watchlists</h2>
-            <span className="text-xs text-white/30 uppercase tracking-wider">
+        <section className="max-w-7xl mx-auto px-6 py-20 lg:py-28">
+          <div className="flex items-center justify-between mb-8">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Watchlists</h2>
+            <span className="text-xs text-white/40 uppercase tracking-wider">
               {watchlists.length} curated lists
             </span>
           </div>
@@ -142,14 +142,14 @@ export default function WatchClient({
         const featured = sectionVideos.filter((v) => v.featured)
         const display = featured.length >= 4 ? featured.slice(0, 8) : sectionVideos.slice(0, 8)
         return (
-          <section key={section.id} className="max-w-7xl mx-auto px-6 mb-16">
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-2 h-8 rounded-full" style={{ backgroundColor: section.color }} />
+          <section key={section.id} className="max-w-7xl mx-auto px-6 py-20 lg:py-28">
+            <div className="flex items-center gap-3 mb-8">
+              <div className="w-2 h-10 rounded-full" style={{ backgroundColor: section.color }} />
               <div>
-                <h2 className="text-2xl font-bold">{section.title}</h2>
-                <p className="text-xs text-white/40">{section.subtitle}</p>
+                <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">{section.title}</h2>
+                <p className="text-[17px] leading-relaxed text-white/60 mt-1">{section.subtitle}</p>
               </div>
-              <span className="ml-auto text-xs text-white/30">{sectionVideos.length} videos</span>
+              <span className="ml-auto text-xs text-white/40 uppercase tracking-wider">{sectionVideos.length} videos</span>
             </div>
             <VideoCarousel
               videos={display}
@@ -160,10 +160,10 @@ export default function WatchClient({
       })}
 
       {/* Full Catalog */}
-      <section id="catalog" className="max-w-7xl mx-auto px-6 pb-32">
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold">Full Catalog</h2>
-          <span className="text-xs text-white/30">{filteredVideos.length} videos</span>
+      <section id="catalog" className="max-w-7xl mx-auto px-6 py-20 lg:py-28">
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Full Catalog</h2>
+          <span className="text-xs text-white/40 uppercase tracking-wider">{filteredVideos.length} videos</span>
         </div>
 
         <CatalogFilters
@@ -194,7 +194,7 @@ export default function WatchClient({
 
         {filteredVideos.length === 0 && (
           <div className="text-center py-24">
-            <p className="text-white/30 text-xl">No videos match your filters.</p>
+            <p className="text-white/40 text-xl">No videos match your filters.</p>
             <button
               onClick={() => {
                 setSearchQuery('')
@@ -202,7 +202,7 @@ export default function WatchClient({
                 setSelectedPersona('all')
                 setSelectedLevel('all')
               }}
-              className="mt-4 text-emerald-400 hover:underline"
+              className="mt-4 text-emerald-400 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] rounded-md"
             >
               Clear all filters
             </button>
@@ -213,7 +213,7 @@ export default function WatchClient({
           <div className="text-center mt-12">
             <button
               onClick={() => setShowAllCatalog(true)}
-              className="inline-flex items-center gap-2 px-8 py-4 rounded-2xl bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all font-medium"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-full bg-white/[0.04] backdrop-blur-xl border border-white/10 text-white hover:bg-white/10 transition-all font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               Show all {filteredVideos.length} videos
             </button>

--- a/app/workshops/ikigai-content-studio/page.tsx
+++ b/app/workshops/ikigai-content-studio/page.tsx
@@ -80,14 +80,14 @@ export default function IkigaiContentStudioPage() {
             <div className="flex flex-wrap items-center gap-3">
               <a
                 href="#intake"
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-full text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-fuchsia-500 hover:from-violet-400 hover:to-fuchsia-400 transition-all focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-full text-sm font-semibold text-white bg-gradient-to-r from-violet-500 to-fuchsia-500 hover:from-violet-400 hover:to-fuchsia-400 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
               >
                 <Send className="w-4 h-4" />
                 Request a conversation
               </a>
               <Link
                 href="/workshops/ikigai-branding"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-violet-300 hover:text-violet-200 transition-colors"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-violet-300 hover:text-violet-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] rounded-full px-2 py-1"
               >
                 Try the self-serve wizard
                 <ArrowRight className="w-4 h-4" />

--- a/components/guides/PDFThumbnail.tsx
+++ b/components/guides/PDFThumbnail.tsx
@@ -50,6 +50,7 @@ export default function PDFThumbnail({
             src={thumbnailUrl}
             alt={title}
             fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             className="object-cover"
           />
         ) : (

--- a/components/music/SongCard.tsx
+++ b/components/music/SongCard.tsx
@@ -33,6 +33,7 @@ export default function SongCard({ song }: SongCardProps) {
           src={song.coverImage}
           alt={song.title}
           fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
           className="object-cover transition duration-500 group-hover:scale-105"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/20 to-transparent" />

--- a/components/newsletter/NewsletterHero.tsx
+++ b/components/newsletter/NewsletterHero.tsx
@@ -66,6 +66,7 @@ export default function NewsletterHero({
           src="/images/design-lab/nature-10-constellation-garden.png"
           alt=""
           fill
+          sizes="100vw"
           className="object-cover opacity-[0.03]"
           priority={false}
         />

--- a/components/sections/AgentGrid.tsx
+++ b/components/sections/AgentGrid.tsx
@@ -83,6 +83,7 @@ export default function AgentGrid({ showTitle = true, className }: AgentGridProp
                 src={agent.imagePath}
                 alt={agent.name}
                 fill
+                sizes="(max-width: 768px) 64px, 80px"
                 className="object-cover"
               />
             </div>

--- a/components/sections/AgentShowcase.tsx
+++ b/components/sections/AgentShowcase.tsx
@@ -104,6 +104,7 @@ export default function AgentShowcase() {
                       src={agent.imagePath}
                       alt={agent.name}
                       fill
+                      sizes="56px"
                       className="object-cover"
                     />
                   </div>
@@ -132,6 +133,7 @@ export default function AgentShowcase() {
                         src={activeAgent.imagePath}
                         alt={activeAgent.name}
                         fill
+                        sizes="(max-width: 768px) 128px, 160px"
                         className="object-cover"
                         priority
                       />

--- a/components/soulbook/PillarVisualizer.tsx
+++ b/components/soulbook/PillarVisualizer.tsx
@@ -272,6 +272,7 @@ export default function PillarVisualizer() {
           src="/images/soulbook/seven-pillars.png"
           alt="Seven Pillars of Soulbook visualization"
           fill
+          sizes="100vw"
           className="object-cover opacity-10"
           quality={80}
         />

--- a/components/soulbook/SoulbookHero.tsx
+++ b/components/soulbook/SoulbookHero.tsx
@@ -31,6 +31,7 @@ export default function SoulbookHero() {
           src="/images/soulbook/hero-soulbook.png"
           alt="Soulbook hero background"
           fill
+          sizes="100vw"
           className="object-cover opacity-40"
           priority
           quality={90}

--- a/public/images/workshops/for-educators/for-educators-og.spec.md
+++ b/public/images/workshops/for-educators/for-educators-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /workshops/for-educators
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/workshops/for-educators/for-educators-og.spec.md`
+**Used by:** `app/workshops/for-educators/page.tsx` metadata
+
+## Palette
+- Enterprise emerald: #10b981 (the "go" / structured curriculum signal)
+- Tech cyan: #22d3ee (architecture, learning systems)
+- Void background: #0a0a0b
+- Chalk warm-white: soft off-white accent for paper / curriculum cards
+
+## Composition
+
+Overhead flat-lay, museum-quality, centered with calm symmetry. On a deep slate surface: a 3×3 grid of small architectural building blocks arranged with precision — each block a clean rectangular slab of brushed graphite, the front face of each etched with a single curriculum glyph (a module marker, a checkpoint, a question, a reflection prompt). The center block is taller than the rest and edged in glowing emerald, signaling the keystone module. Hairline cyan lines connect every block to its neighbors, forming a quiet learning lattice. To the left of the grid: a single open notebook with a hand-drawn syllabus tree visible — three branches, each tagged with a small emerald checkmark. To the right: a brushed-steel pen laid diagonally, and a small cyan-bound index card. Soft directional light from the upper-left, casting clean architectural shadows. Premium editorial photography, slight film grain. The scene reads "a curriculum, as architecture, ready to deploy in any classroom." No people, no hands, no chalkboards, no apples, no school-cliché props.
+
+## Type
+- Headline: "For Educators" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Workshop templates that travel" (Poppins, ~32px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Emerald micro-line above the headline (4px × 80px).
+
+## Symbols / Iconography
+- 3×3 grid of curriculum blocks — the modular template, the building-block metaphor
+- Emerald-edged keystone block — the load-bearing module that holds the curriculum together
+- Hairline cyan lattice — the learning architecture, the connection between modules
+- Hand-drawn syllabus tree — the educator's adaptation of the template, not a fixed product
+- Brushed-steel pen + index card — the working instruments of an educator-in-design-mode
+
+## Variants
+- v1: Overhead flat-lay described above — restrained, architectural, museum-quality.
+- v2: Three-quarter desk view — the 3×3 grid arranged on a slate desk surface, with the open syllabus notebook at the foreground, and a stack of three workshop binders in graphite-bound covers at the side. Late-afternoon directional light. More "educator at work" energy.
+- v3: Architectural / symbolic — a single emerald keystone block outlined in fine cyan filament, floating in deep space, surrounded by eight smaller cyan-edged blocks orbiting in a clean 3×3 constellation. Minimal, premium, no text in the image. Reads "the curriculum, as a sovereign structure."
+
+## Rationale
+
+For Educators sells workshop templates to teachers and trainers who want frameworks they can adapt — not lesson plans they have to follow verbatim. The OG must read "a curriculum-as-architecture: structured enough to deploy, modular enough to adapt." Building-block imagery signals "you assemble this" without resorting to LEGO-cliché aesthetics; the syllabus tree signals "the educator stays the designer." Emerald carries the structured / go signal; cyan carries the architecture / connectivity signal. The deliberate absence of chalkboard / apple / classroom props keeps the register premium and avoids reducing the audience to a stock-photo cliché.

--- a/public/images/workshops/ikigai-content-studio/ikigai-content-studio-og.spec.md
+++ b/public/images/workshops/ikigai-content-studio/ikigai-content-studio-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /workshops/ikigai-content-studio
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/workshops/ikigai-content-studio/ikigai-content-studio-og.spec.md`
+**Used by:** `app/workshops/ikigai-content-studio/page.tsx` metadata
+
+## Palette
+- Soul amber: #f59e0b (warmth, creator energy, studio light)
+- Enterprise emerald: #10b981 (the "go" / publish signal)
+- Void background: #0a0a0b
+- Walnut accent: deep warm wood tone for desk surface
+
+## Composition
+
+Three-quarter creator-studio view, magazine quality, anchored to the right. A warm walnut desk surface catching late-afternoon amber light from an off-frame window. Centered on the desk: a single open leather-bound notebook with a hand-drawn ikigai diagram visible — four overlapping circles in soft pencil, the center marked with a small emerald asterisk. Beside the notebook: a closed matte-silver laptop, a brass mechanical pencil laid diagonally, and a small ceramic mug of espresso. To the right edge: a vintage condenser microphone on a low stand, its grille catching the amber light. To the left: a single stem of dried wheat in a small clay vase, casting a soft architectural shadow across the page. Behind the desk: a softly out-of-focus bookshelf wall, warm and lived-in. Cinematic directional light from the upper-right window, golden-hour quality. Premium editorial photography, slight film grain. The scene reads "the studio where the creator finds their reason for being." No people, no hands, no screens-on, no logos.
+
+## Type
+- Headline: "Ikigai Content Studio" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Find your reason. Ship the work." (Poppins, ~32px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Amber micro-line above the headline (4px × 80px).
+
+## Symbols / Iconography
+- Hand-drawn ikigai diagram in the notebook — the workshop's IP, made visible in pencil
+- Vintage condenser microphone — the creator's voice as primary instrument
+- Closed laptop — work paused for reflection, not always-on production
+- Espresso + dried wheat stem — Mediterranean creator-monk tone, warmth without kitsch
+- Emerald asterisk at the center of the diagram — the "go" signal at the ikigai intersection
+
+## Variants
+- v1: Three-quarter studio view described above — warm, restrained, magazine-cover quality.
+- v2: Overhead flat-lay — the ikigai notebook open at center on a walnut desk, with the microphone laid horizontally above it, the closed laptop to one side, the espresso cup to the other, and four colored pencils (amber / emerald / violet / cyan) arrayed around the diagram. More "ritual of finding the work" energy.
+- v3: Architectural / symbolic — four overlapping circles outlined in fine amber filament, floating in deep space against the void, with a single emerald dot glowing at the dead-center intersection. Minimal, premium, no text in the image. Reads "ikigai as architecture, not as wall-poster cliché."
+
+## Rationale
+
+Ikigai Content Studio sells a workflow to creators who have the tools but haven't found the reason — or who have the reason but ship inconsistently. The OG must read "this is where the work actually gets made, not where it gets motivated about." Studio photography matches the tone of a working creator's space; the hand-drawn diagram signals that the framework is internalized, not imported from a slide deck. Amber carries the soul / warmth / creator-light register; emerald carries the "publish, ship, go" register. The vintage microphone signals voice-first production without veering into podcast-bro aesthetics.

--- a/public/images/workshops/personal-ai-coe/personal-ai-coe-og.spec.md
+++ b/public/images/workshops/personal-ai-coe/personal-ai-coe-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /workshops/personal-ai-coe
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/workshops/personal-ai-coe/personal-ai-coe-og.spec.md`
+**Used by:** `app/workshops/personal-ai-coe/page.tsx` metadata
+
+## Palette
+- Enterprise emerald: #10b981 (the "go" / governance signal)
+- Tech cyan: #22d3ee (architecture, intelligence)
+- Void background: #0a0a0b
+- Slate boardroom: deep graphite for surface tone
+
+## Composition
+
+Boardroom three-quarter view, executive scale. Long obsidian table polished to a mirror, anchored to the left half of the frame. Floating above the table — slightly off-center to the right — a six-faceted architectural diagram: six emerald-edged hexagonal pillars arranged in a tight constellation, each labeled with a single glyph (Strategy, Governance, Talent, Technology, Data, Ethics). Hairline cyan lines connect every pillar to every other, suggesting an operational lattice. Behind the diagram: a softly lit floor-to-ceiling window with a city skyline at dawn, blurred into bokeh. On the table: a single closed leather portfolio in oxblood, a brushed-steel pen laid diagonally, and a small espresso cup, untouched. Cinematic directional light from the upper-left window, casting clean architectural shadows. Premium editorial photography, restrained color grading, slight film grain. The scene reads "a Fortune 500 boardroom redesigned for one." No people, no hands, no logos.
+
+## Type
+- Headline: "Personal AI CoE" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Run your life like an enterprise" (Poppins, ~32px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Emerald micro-line above the headline (4px × 80px).
+
+## Symbols / Iconography
+- Six hexagonal pillars — the 6-pillar architecture (Strategy / Governance / Talent / Technology / Data / Ethics)
+- Hairline cyan lattice — operational connectivity, system thinking
+- Obsidian boardroom table — executive seriousness, scale
+- Leather portfolio + brushed pen — sovereign decision-making instruments
+- Dawn skyline through window — the long horizon, the enterprise view
+
+## Variants
+- v1: Boardroom three-quarter view described above — executive, architectural, restrained.
+- v2: Overhead flat-lay — the six hexagonal pillars laid out on a slate desk surface as physical blocks, each etched with its glyph, connected by inlaid cyan filament. A single emerald ring at the center binds the constellation. Reads "the architecture, in your hands."
+- v3: Pure architectural — a single emerald hexagon outlined in fine cyan filament, floating in deep space, with five smaller hexagons orbiting it in a precise constellation. Minimal, premium, no text in the image. Reads "the framework as a sovereign symbol."
+
+## Rationale
+
+Personal AI CoE sells enterprise-grade architecture to executives running their own lives — not a productivity app. The OG must read "the same framework I deploy at Fortune 500s, scaled for one." Boardroom photography signals executive register without resorting to suit-and-handshake clichés; the six-pillar diagram is the actual IP, made visible. Emerald carries the "operational go" signal; cyan threads carry the "architecture and intelligence" signal. The dawn skyline keeps the tone aspirational without dipping into hustle aesthetics.

--- a/public/images/workshops/sovereign-leadership/sovereign-leadership-og.spec.md
+++ b/public/images/workshops/sovereign-leadership/sovereign-leadership-og.spec.md
@@ -1,0 +1,37 @@
+# OG Image Spec — /workshops/sovereign-leadership
+
+**Target:** 1200×630px, ≤200KB after compression
+**Generation:** `node scripts/nb-generate.mjs --spec public/images/workshops/sovereign-leadership/sovereign-leadership-og.spec.md`
+**Used by:** `app/workshops/sovereign-leadership/page.tsx` metadata
+
+## Palette
+- Violet bridge: #8b5cf6 (sovereignty, the leadership register)
+- Enterprise emerald: #10b981 (the "go" signal, delegated action)
+- Void background: #0a0a0b
+- Brass accent: aged warm metal for compass markings
+
+## Composition
+
+Overhead flat-lay, museum-quality, slightly off-center to the right. On a deep charcoal slate surface: a single antique brass compass, half-open, the needle pointing emerald-true. Beside it: a polished obsidian king chess piece standing upright, casting a long sovereign shadow. To the left: three smaller pieces — a knight, a bishop, a rook — arranged in a clean diagonal line as if mid-deployment, each carved from matte black walnut with violet-edged bases. Above the compass: a single hairline emerald arc tracing a delegation path from the king to the three pieces, like a command line drawn in light. Soft directional light from the upper-left, casting long architectural shadows. Premium editorial photography, slight film grain. The scene reads "the operator chooses the move; the agents execute." No people, no hands, no chessboard squares (the surface is solid slate, not a game).
+
+## Type
+- Headline: "Sovereign Leadership" (Poppins Display, ~72px, weight 700, white)
+- Subtitle: "Lead the AI you delegate to" (Poppins, ~32px, weight 500, white at 65%)
+
+Type anchored bottom-left, 80px padding. Violet micro-line above the headline (4px × 80px).
+
+## Symbols / Iconography
+- Antique brass compass with emerald needle — sovereign direction, true-north framework
+- Obsidian king chess piece — the operator, the sovereign
+- Three deployed pieces (knight / bishop / rook) — the agents, the delegated workforce
+- Hairline emerald arc — the delegation command, the line of authority
+- Slate surface (no chessboard) — the open field of operation, not a game
+
+## Variants
+- v1: Overhead flat-lay described above — restrained, premium, museum-quality.
+- v2: Three-quarter desk view — the king and three deployed pieces arranged on a slate surface, with a leather-bound notebook open to a hand-drawn delegation diagram at the left, and a brushed-steel pen laid diagonally. More "operator at work" energy, late-afternoon window light.
+- v3: Architectural / symbolic — a single violet compass-rose outlined in fine emerald filament, floating in deep space, with four smaller emerald arrows radiating from its center in cardinal directions. Inside the rose: a stylized king-crown silhouette in brass. Minimal, premium, no text in the image. Reads "sovereignty as architecture, not as posture."
+
+## Rationale
+
+Sovereign Leadership sells a leadership operating system to people who are already delegating to AI — but doing it without a framework. The OG must read "the operator stays the operator; the agents stay agents." Chess imagery without a board signals strategy without games-of-chance; the compass carries the "true-north" register without resorting to motivational poster aesthetics. Violet anchors the leadership / sovereignty signal; emerald carries the operational "go" line. The premium stationery tone matches the workshop's executive audience without veering into corporate stock-photo territory.


### PR DESCRIPTION
Wave 13 of overnight excellence. 3 commits.

## What ships

- **★ Perf — 39 image `sizes` props added** across 30 files (commit `dcec0fb7`). Without `sizes`, browsers can't pick the right responsive variant from next/image's srcSet — mobile users were downloading desktop-sized assets. This is a measurable LCP win. Sizing strategy varies by context (100vw for full-bleed, max-w-Nxl for constrained, card-grid 50vw→33vw→25vw, pixel sizes for fixed avatars).
- **Music + Watch + AI Architecture polish** (commit `eff496f9`): typography spec scale, CTAs rounded-full + focus rings, section padding py-20 lg:py-28, glassmorphism cards.
- **Workshop OG specs + ikigai alignment** (commit `dd4c1c29`): 4 NB2-ready OG specs (personal-ai-coe, sovereign-leadership, ikigai-content-studio, for-educators). Ikigai focus-visible alignment with sibling pattern.

## Pre-flight gates
- `npx tsc --noEmit` → 0 errors ✓
- All 3 commits clean

## Architectural ideas surfaced for future waves
- Client→server split on top-of-funnel pages (golden-age, frankx, music, ai-world) — bundle reduction 20-40%
- Hero PNG → AVIF + quality={75}
- @next/bundle-analyzer for per-route JS weight

🤖 Generated overnight by Claude Code Opus 4.7