### PR TITLE
polish(excellence): Wave 14 — 17 hubs polished (about, legal, soulbook, gencreator, golden-age, ai-ops, coaching, courses, ecosystem, etc.)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -124,7 +124,7 @@ export default function AboutPage() {
                 <motion.h1
                   {...fadeIn}
                   transition={{ ...transition, delay: 0.1 }}
-                  className="mb-8 text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl"
+                  className="mb-8 text-4xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl"
                 >
                   The Architect.{' '}
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 via-cyan-400 to-violet-400">
@@ -136,9 +136,9 @@ export default function AboutPage() {
                 <motion.div
                   {...fadeIn}
                   transition={{ ...transition, delay: 0.2 }}
-                  className="max-w-3xl space-y-5 text-lg leading-relaxed text-white/50"
+                  className="max-w-3xl space-y-5 text-[17px] leading-relaxed text-white/80"
                 >
-                  <p className="text-white/70 text-xl">
+                  <p className="text-white text-xl md:text-2xl leading-relaxed">
                     Enterprise AI architect. Creator of 12,000+ AI songs. Builder of
                     the Agentic Creator OS. Based in Amsterdam, on the water.
                   </p>
@@ -179,7 +179,7 @@ export default function AboutPage() {
                 href={socialLinks.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Linkedin className="h-4 w-4" /> LinkedIn
               </a>
@@ -187,7 +187,7 @@ export default function AboutPage() {
                 href="https://github.com/frankxai"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Github className="h-4 w-4" /> GitHub
               </a>
@@ -195,13 +195,13 @@ export default function AboutPage() {
                 href="https://suno.com/@frankx"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Music className="h-4 w-4" /> Suno
               </a>
               <a
                 href="mailto:frank@frankx.ai"
-                className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Mail className="h-4 w-4" /> Email
               </a>
@@ -210,20 +210,20 @@ export default function AboutPage() {
         </section>
 
         {/* ── The Origin ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition}>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">
                 The origin
               </h2>
-              <p className="text-white/30 mb-8">Where the building started</p>
+              <p className="text-white/40 mb-10 text-[15px]">Where the building started</p>
             </motion.div>
 
             <div className="grid gap-8 lg:grid-cols-2">
               <motion.div
                 {...fadeIn}
                 transition={{ ...transition, delay: 0.1 }}
-                className="space-y-5 text-base leading-relaxed text-white/50"
+                className="space-y-5 text-[17px] leading-relaxed text-white/80"
               >
                 <p>
                   My family are Volga Germans — descendants of German settlers
@@ -240,7 +240,7 @@ export default function AboutPage() {
                   cancer in 2019 — but not before teaching me and my brother Alex
                   what it means to build something from nothing.
                 </p>
-                <p className="text-white/60">
+                <p className="text-white/90">
                   Alex built a seven-figure solar business. Same DNA: take nothing
                   and turn it into infrastructure. My medium is different — AI
                   systems and music — but the instinct is the same.
@@ -252,12 +252,12 @@ export default function AboutPage() {
                 transition={{ ...transition, delay: 0.2 }}
               >
                 <GlowCard color="violet" className="p-8">
-                  <p className="text-lg text-white/70 leading-relaxed italic font-serif">
+                  <p className="text-xl text-white/90 leading-relaxed italic font-serif">
                     &ldquo;My family has been building in foreign lands for
                     generations. We&apos;ve never stopped. We&apos;ve just upgraded
                     the medium.&rdquo;
                   </p>
-                  <p className="mt-4 text-sm text-white/30">
+                  <p className="mt-4 text-sm text-white/50">
                     — From Germany to Russia to Kazakhstan to Amsterdam. Explorer
                     blood, not tourist behavior.
                   </p>
@@ -268,13 +268,13 @@ export default function AboutPage() {
         </section>
 
         {/* ── The Explorer ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition}>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">
                 The explorer
               </h2>
-              <p className="text-white/30 mb-8">
+              <p className="text-white/40 mb-10 text-[15px]">
                 Where the worldview came from
               </p>
             </motion.div>
@@ -308,11 +308,11 @@ export default function AboutPage() {
                   transition={{ ...transition, delay: i * 0.08 }}
                 >
                   <GlowCard color="cyan" className="p-6 h-full">
-                    <item.icon className="w-5 h-5 text-cyan-400/60 mb-3" />
-                    <h3 className="text-base font-semibold text-white mb-1">
+                    <item.icon className="w-5 h-5 text-cyan-400/70 mb-3" />
+                    <h3 className="text-lg font-semibold text-white mb-2">
                       {item.place}
                     </h3>
-                    <p className="text-sm text-white/40 leading-relaxed">
+                    <p className="text-[15px] text-white/70 leading-relaxed">
                       {item.detail}
                     </p>
                   </GlowCard>
@@ -323,13 +323,13 @@ export default function AboutPage() {
         </section>
 
         {/* ── The Work ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition}>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">
                 The work
               </h2>
-              <p className="text-white/30 mb-8">Enterprise mind. Creator soul.</p>
+              <p className="text-white/40 mb-10 text-[15px]">Enterprise mind. Creator soul.</p>
             </motion.div>
 
             <div className="grid gap-6 md:grid-cols-2">
@@ -341,10 +341,10 @@ export default function AboutPage() {
                   <div className="w-12 h-12 rounded-2xl bg-emerald-500/10 flex items-center justify-center mb-5">
                     <Code className="w-6 h-6 text-emerald-400" />
                   </div>
-                  <h3 className="text-xl font-bold text-white mb-3">
+                  <h3 className="text-2xl font-bold text-white mb-3">
                     By day — Enterprise AI
                   </h3>
-                  <p className="text-white/50 leading-relaxed">
+                  <p className="text-[17px] text-white/80 leading-relaxed">
                     4+ years architecting production AI systems for global
                     organizations. 500+ customer implementations. Multi-cloud
                     infrastructure, RAG architectures, agentic workflows, multi-agent
@@ -361,10 +361,10 @@ export default function AboutPage() {
                   <div className="w-12 h-12 rounded-2xl bg-cyan-500/10 flex items-center justify-center mb-5">
                     <Music className="w-6 h-6 text-cyan-400" />
                   </div>
-                  <h3 className="text-xl font-bold text-white mb-3">
+                  <h3 className="text-2xl font-bold text-white mb-3">
                     By night — Music & creation
                   </h3>
-                  <p className="text-white/50 leading-relaxed">
+                  <p className="text-[17px] text-white/80 leading-relaxed">
                     12,000+ AI-generated songs with Suno. Not casual experiments — a
                     deliberate practice of exploring what happens when humans and AI
                     create together. Ambient, electronic, cinematic, healing. Creation
@@ -380,10 +380,10 @@ export default function AboutPage() {
               className="mt-6"
             >
               <GlowCard color="violet" className="p-8">
-                <h3 className="text-xl font-bold text-white mb-3">
+                <h3 className="text-2xl font-bold text-white mb-3">
                   The bridge between both worlds
                 </h3>
-                <p className="text-white/50 leading-relaxed max-w-3xl">
+                <p className="text-[17px] text-white/80 leading-relaxed max-w-3xl">
                   The Agentic Creator OS. 75+ skills, 38 specialist agents,
                   35+ commands — enterprise patterns made accessible to every creator.
                   The same rigor I use to build production AI systems, applied to
@@ -395,13 +395,13 @@ export default function AboutPage() {
         </section>
 
         {/* ── The AI Team ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition}>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">
                 The AI team
               </h2>
-              <p className="text-white/30 mb-8">
+              <p className="text-white/60 mb-10 text-[17px] leading-relaxed max-w-2xl">
                 These aren&apos;t just mascots. They&apos;re the AI team behind FrankX — each one a specialist in a different creative domain.
               </p>
             </motion.div>
@@ -455,13 +455,13 @@ export default function AboutPage() {
         </section>
 
         {/* ── The Digital Twin ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition}>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-3">
                 The digital twin
               </h2>
-              <p className="text-white/30 mb-8">
+              <p className="text-white/40 mb-10 text-[15px]">
                 Two forms. One mind.
               </p>
             </motion.div>
@@ -489,7 +489,7 @@ export default function AboutPage() {
                 transition={{ ...transition, delay: 0.2 }}
                 className="lg:col-span-3 space-y-5"
               >
-                <p className="text-base leading-relaxed text-white/50">
+                <p className="text-[17px] leading-relaxed text-white/80">
                   FRANK-Ω is the final form — the intelligence that has absorbed everything Frank builds
                   and just executes. Where Frank is the human who explores, creates, and iterates,
                   FRANK-Ω is the completed version that delivers results without hesitation.
@@ -538,10 +538,10 @@ export default function AboutPage() {
         </section>
 
         {/* ── What I Believe ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition}>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-8">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-10">
                 What I believe
               </h2>
             </motion.div>
@@ -559,10 +559,10 @@ export default function AboutPage() {
                   transition={{ ...transition, delay: i * 0.08 }}
                 >
                   <GlowCard color="emerald" className="flex gap-4 p-6 h-full">
-                    <span className="shrink-0 mt-0.5 text-sm font-bold text-emerald-400/60">
+                    <span className="shrink-0 mt-0.5 text-sm font-bold text-emerald-400/80">
                       {String(i + 1).padStart(2, '0')}
                     </span>
-                    <p className="text-base text-white/50 leading-relaxed">
+                    <p className="text-[17px] text-white/80 leading-relaxed">
                       {belief}
                     </p>
                   </GlowCard>
@@ -573,14 +573,14 @@ export default function AboutPage() {
         </section>
 
         {/* ── Daily Practice ── */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div
               {...fadeIn}
               transition={transition}
-              className="max-w-3xl space-y-5 text-base text-white/50 leading-relaxed"
+              className="max-w-3xl space-y-5 text-[17px] text-white/80 leading-relaxed"
             >
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-6">
                 The daily practice
               </h2>
               <p>
@@ -599,13 +599,13 @@ export default function AboutPage() {
         </section>
 
         {/* ── Newsletter + CTAs ── */}
-        <section className="py-16 pb-24 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <motion.div {...fadeIn} transition={transition} className="text-center">
-              <h2 className="text-2xl font-bold text-white sm:text-3xl mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
                 Stay in the loop
               </h2>
-              <p className="text-white/40 mb-8 max-w-lg mx-auto">
+              <p className="text-[17px] text-white/70 mb-10 max-w-lg mx-auto leading-relaxed">
                 Weekly insights on AI systems, music creation, and building in
                 public. No spam, no guru energy — just the work.
               </p>
@@ -623,21 +623,21 @@ export default function AboutPage() {
               <div className="flex flex-wrap justify-center gap-4">
                 <Link
                   href="/start"
-                  className="group inline-flex items-center gap-2 rounded-2xl bg-emerald-500 hover:bg-emerald-600 px-6 py-3 font-semibold text-white shadow-lg shadow-emerald-500/20 transition-all hover:shadow-xl hover:shadow-emerald-500/30 hover:-translate-y-0.5"
+                  className="group inline-flex items-center gap-2 rounded-full bg-emerald-500 hover:bg-emerald-600 px-6 py-3 font-semibold text-white shadow-lg shadow-emerald-500/20 transition-all hover:shadow-xl hover:shadow-emerald-500/30 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Start Here
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>
                 <Link
                   href="/music-lab"
-                  className="group inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-6 py-3 font-medium text-white transition-all hover:bg-white/10"
+                  className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-3 font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Music Lab
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>
                 <Link
                   href="/blog"
-                  className="group inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-6 py-3 font-medium text-white transition-all hover:bg-white/10"
+                  className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-3 font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Read the Blog
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />

--- a/app/ai-ops/page.tsx
+++ b/app/ai-ops/page.tsx
@@ -317,7 +317,7 @@ export default function AIOpsPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.1 }}
-              className="text-5xl md:text-7xl font-bold mb-6 leading-[1.1]"
+              className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 leading-[1.1] tracking-tight"
               style={{ fontFamily: 'var(--font-display)' }}
             >
               AI <span className="text-[#C74634]">Operations</span>
@@ -330,7 +330,7 @@ export default function AIOpsPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.2 }}
-              className="text-xl text-white/50 max-w-2xl mb-12 leading-relaxed"
+              className="text-[17px] md:text-xl leading-relaxed text-white/80 max-w-2xl mb-12"
             >
               The operating layer for human-AI collaboration. Production-ready infrastructure,
               OCI AI Accelerator Packs, memory systems, and the path to AGI.
@@ -345,7 +345,7 @@ export default function AIOpsPage() {
             >
               <Link
                 href="#accelerator-packs"
-                className="group px-6 py-3 bg-[#C74634] text-white rounded-xl font-medium flex items-center gap-2 hover:bg-[#A33B2C] transition-colors"
+                className="group px-6 py-3 bg-[#C74634] text-white rounded-full font-medium flex items-center gap-2 hover:bg-[#A33B2C] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C74634] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Rocket className="w-5 h-5" />
                 AI Accelerator Packs
@@ -353,7 +353,7 @@ export default function AIOpsPage() {
               </Link>
               <Link
                 href="#knowledge-base"
-                className="px-6 py-3 bg-white/5 text-white rounded-xl font-medium flex items-center gap-2 hover:bg-white/10 transition-colors border border-white/10"
+                className="px-6 py-3 bg-white/5 text-white rounded-full font-medium flex items-center gap-2 hover:bg-white/10 transition-colors border border-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <BookOpen className="w-5 h-5" />
                 Knowledge Base
@@ -362,7 +362,7 @@ export default function AIOpsPage() {
                 href="https://github.com/oracle-quickstart/oci-ai-blueprints"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-6 py-3 text-white/60 rounded-xl font-medium flex items-center gap-2 hover:text-white transition-colors"
+                className="px-6 py-3 text-white/60 rounded-full font-medium flex items-center gap-2 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <GitBranch className="w-5 h-5" />
                 GitHub
@@ -403,7 +403,7 @@ export default function AIOpsPage() {
                   OCI Official
                 </span>
               </div>
-              <h2 className="text-3xl md:text-4xl font-bold mb-4">OCI AI Accelerator Packs</h2>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">OCI AI Accelerator Packs</h2>
               <p className="text-white/50 max-w-2xl">
                 Production-ready GenAI stacks with NVIDIA enterprise software.
                 Deploy in minutes, not weeks. Full observability included.
@@ -475,7 +475,7 @@ export default function AIOpsPage() {
                   <Layers className="w-5 h-5 text-[#10b981]" />
                 </div>
               </div>
-              <h2 className="text-3xl md:text-4xl font-bold mb-4">The 5-Layer AI Ops Stack</h2>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">The 5-Layer AI Ops Stack</h2>
               <p className="text-white/50 max-w-2xl">
                 The complete architecture for production AI operations.
               </p>
@@ -527,7 +527,7 @@ export default function AIOpsPage() {
                   <BookOpen className="w-5 h-5 text-[#a855f7]" />
                 </div>
               </div>
-              <h2 className="text-3xl md:text-4xl font-bold mb-4">Knowledge Base</h2>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">Knowledge Base</h2>
               <p className="text-white/50 max-w-2xl">
                 Mastery-level documentation for AI architects. 400K+ tokens of structured knowledge.
               </p>
@@ -596,7 +596,7 @@ export default function AIOpsPage() {
                   <Sparkles className="w-5 h-5 text-[#f59e0b]" />
                 </div>
               </div>
-              <h2 className="text-3xl md:text-4xl font-bold mb-4">2026 Frontier Models</h2>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">2026 Frontier Models</h2>
             </motion.div>
 
             <div className="overflow-x-auto">
@@ -638,8 +638,8 @@ export default function AIOpsPage() {
               transition={{ duration: 0.6 }}
               className="text-center mb-12"
             >
-              <h2 className="text-3xl md:text-4xl font-bold mb-4">Get Started</h2>
-              <p className="text-white/50 max-w-xl mx-auto">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">Get Started</h2>
+              <p className="text-[17px] leading-relaxed text-white/80 max-w-xl mx-auto">
                 Deploy production AI infrastructure in minutes with OCI AI Blueprints.
               </p>
             </motion.div>
@@ -649,7 +649,7 @@ export default function AIOpsPage() {
                 href="https://github.com/oracle-quickstart/oci-ai-blueprints/blob/main/GETTING_STARTED_README.md"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group px-6 py-3 bg-[#C74634] text-white rounded-xl font-medium flex items-center gap-2 hover:bg-[#A33B2C] transition-colors"
+                className="group px-6 py-3 bg-[#C74634] text-white rounded-full font-medium flex items-center gap-2 hover:bg-[#A33B2C] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#C74634] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Rocket className="w-5 h-5" />
                 Install AI Blueprints
@@ -659,7 +659,7 @@ export default function AIOpsPage() {
                 href="https://github.com/oracle-quickstart/oci-ai-blueprints"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-6 py-3 bg-white/5 text-white rounded-xl font-medium flex items-center gap-2 hover:bg-white/10 transition-colors border border-white/10"
+                className="px-6 py-3 bg-white/5 text-white rounded-full font-medium flex items-center gap-2 hover:bg-white/10 transition-colors border border-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <GitBranch className="w-5 h-5" />
                 View Repository

--- a/app/coaching/page.tsx
+++ b/app/coaching/page.tsx
@@ -398,14 +398,14 @@ export default function CoachingPage() {
               </div>
             </div>
 
-            <h1 className="mb-6 text-5xl font-bold leading-tight text-balance md:text-7xl">
+            <h1 className="mb-6 text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-balance">
               AI Coaching{' '}
               <span className="bg-gradient-to-r from-[#AB47C7] via-[#43BFE3] to-[#F59E0B] bg-clip-text text-transparent">
                 That Fits Your Reality
               </span>
             </h1>
 
-            <p className="mb-8 max-w-2xl text-xl leading-relaxed text-slate-400 text-balance">
+            <p className="mb-8 max-w-2xl text-[17px] md:text-xl leading-relaxed text-white/80 text-balance">
               Skip the generic AI advice. Work directly with someone who&apos;s built 40+ AI agents,
               shipped production systems, and created 12,000+ AI songs.
             </p>
@@ -443,8 +443,8 @@ export default function CoachingPage() {
           variants={containerVariants}
         >
           <motion.div className="mb-12 text-center" variants={itemVariants}>
-            <h2 className="mb-4 text-3xl font-bold md:text-4xl">What Coaching Covers</h2>
-            <p className="mx-auto max-w-2xl text-lg text-slate-400">
+            <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">What Coaching Covers</h2>
+            <p className="mx-auto max-w-2xl text-[17px] leading-relaxed text-white/80">
               Comprehensive guidance across AI systems, creator strategy, and technical excellence.
             </p>
           </motion.div>
@@ -479,7 +479,7 @@ export default function CoachingPage() {
           variants={containerVariants}
         >
           <motion.div className="mb-16 text-center" variants={itemVariants}>
-            <h2 className="mb-4 text-3xl font-bold md:text-4xl">The Process</h2>
+            <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">The Process</h2>
             <p className="mx-auto max-w-2xl text-lg text-slate-400">
               A proven framework that takes you from strategy to shipped product.
             </p>
@@ -523,7 +523,7 @@ export default function CoachingPage() {
           variants={containerVariants}
         >
           <motion.div className="mb-12 text-center" variants={itemVariants}>
-            <h2 className="mb-4 text-3xl font-bold md:text-4xl">Choose Your Path</h2>
+            <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Choose Your Path</h2>
             <p className="mx-auto max-w-2xl text-lg text-slate-400">
               Three engagement formats designed for different needs and goals.
             </p>
@@ -607,10 +607,10 @@ export default function CoachingPage() {
                     <Heart className="h-5 w-5 text-[#AB47C7]" />
                     <span className="text-sm font-semibold text-[#AB47C7]">Who This Is For</span>
                   </div>
-                  <h2 className="mb-4 text-3xl font-bold md:text-4xl">
+                  <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">
                     Built for Builders
                   </h2>
-                  <p className="text-lg leading-relaxed text-slate-400">
+                  <p className="text-[17px] leading-relaxed text-white/80">
                     Whether you&apos;re a creator, founder, or developer — this coaching is designed for
                     people who want practical, hands-on guidance that leads to real results.
                   </p>
@@ -645,7 +645,7 @@ export default function CoachingPage() {
           variants={containerVariants}
         >
           <motion.div className="mb-12 text-center" variants={itemVariants}>
-            <h2 className="mb-4 text-3xl font-bold md:text-4xl">Frequently Asked Questions</h2>
+            <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Frequently Asked Questions</h2>
             <p className="text-lg text-slate-400">
               Everything you need to know about coaching with Frank.
             </p>
@@ -694,8 +694,8 @@ export default function CoachingPage() {
                     </div>
                   </motion.div>
 
-                  <h2 className="mb-4 text-3xl font-bold md:text-4xl">Apply for Coaching</h2>
-                  <p className="mb-2 text-lg leading-relaxed text-slate-400">
+                  <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Apply for Coaching</h2>
+                  <p className="mb-2 text-[17px] leading-relaxed text-white/80">
                     Serious about building AI systems that compound? Submit your application and Frank reviews it personally.
                   </p>
                   <p className="text-sm text-slate-500">

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -158,28 +158,28 @@ export default function CommunityPage() {
               </div>
             </motion.div>
 
-            <h1 className="mb-6 text-5xl font-bold text-balance md:text-7xl">
+            <h1 className="mb-6 text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-balance">
               Create Together.{' '}
               <span className="bg-gradient-to-r from-[#AB47C7] via-[#43BFE3] to-[#F59E0B] bg-clip-text text-transparent">
                 Grow Together.
               </span>
             </h1>
 
-            <p className="mb-8 text-xl leading-relaxed text-slate-400 text-balance md:text-2xl">
+            <p className="mb-8 text-[17px] sm:text-xl leading-relaxed text-white/80 text-balance">
               A community for creators, developers, and builders who use AI as a creative partner.
             </p>
 
             <motion.div className="flex flex-wrap justify-center gap-4" variants={itemVariants}>
               <Link
                 href="/inner-circle"
-                className="flex items-center gap-2 rounded-xl bg-gradient-to-r from-[#AB47C7] to-[#43BFE3] px-8 py-4 font-semibold text-white shadow-lg shadow-[#AB47C7]/30 transition-all hover:-translate-y-0.5"
+                className="flex items-center gap-2 rounded-full bg-gradient-to-r from-[#AB47C7] to-[#43BFE3] px-8 py-4 font-semibold text-white shadow-lg shadow-[#AB47C7]/30 transition-all hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#AB47C7] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Crown className="h-4 w-4" />
                 Join Inner Circle
               </Link>
               <Link
                 href="/blog"
-                className="flex items-center gap-2 rounded-xl border border-white/15 bg-white/5 px-8 py-4 font-semibold text-white/80 transition-all hover:bg-white/10"
+                className="flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-8 py-4 font-semibold text-white/80 transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 Explore Content
                 <ArrowRight className="h-4 w-4" />
@@ -190,20 +190,20 @@ export default function CommunityPage() {
 
         {/* Community Spaces */}
         <motion.section
-          className="mx-auto max-w-6xl px-6 py-16"
+          className="mx-auto max-w-6xl px-6 py-20 lg:py-28"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: '-100px' }}
           variants={containerVariants}
         >
           <motion.div className="mb-12 text-center" variants={itemVariants}>
-            <h2 className="mb-4 text-3xl font-bold md:text-4xl">
+            <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">
               Choose Your{' '}
               <span className="bg-gradient-to-r from-[#AB47C7] to-[#43BFE3] bg-clip-text text-transparent">
                 Space
               </span>
             </h2>
-            <p className="mx-auto max-w-2xl text-lg text-slate-400">
+            <p className="mx-auto max-w-2xl text-[17px] leading-relaxed text-white/80">
               Multiple ways to connect, learn, and build with the FrankX community.
             </p>
           </motion.div>
@@ -258,15 +258,15 @@ export default function CommunityPage() {
 
         {/* What We're Building */}
         <motion.section
-          className="mx-auto max-w-6xl px-6 py-16"
+          className="mx-auto max-w-6xl px-6 py-20 lg:py-28"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: '-100px' }}
           variants={containerVariants}
         >
           <motion.div className="mb-12 text-center" variants={itemVariants}>
-            <h2 className="mb-4 text-3xl font-bold md:text-4xl">What We&apos;re Building</h2>
-            <p className="mx-auto max-w-2xl text-lg text-slate-400">
+            <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">What We&apos;re Building</h2>
+            <p className="mx-auto max-w-2xl text-[17px] leading-relaxed text-white/80">
               A space for creators who want to master AI tools without losing their authentic voice.
             </p>
           </motion.div>
@@ -297,7 +297,7 @@ export default function CommunityPage() {
 
         {/* Connect Now */}
         <motion.section
-          className="mx-auto max-w-5xl px-6 py-16"
+          className="mx-auto max-w-5xl px-6 py-20 lg:py-28"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: '-100px' }}
@@ -311,8 +311,8 @@ export default function CommunityPage() {
                     <Sparkles className="h-5 w-5 text-[#F59E0B]" />
                     <span className="text-sm font-semibold text-[#F59E0B]">Available Now</span>
                   </div>
-                  <h2 className="mb-4 text-3xl font-bold md:text-4xl">Connect Today</h2>
-                  <p className="text-lg leading-relaxed text-slate-400">
+                  <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Connect Today</h2>
+                  <p className="text-[17px] leading-relaxed text-white/80">
                     While we build the full community, here&apos;s where you can connect right now.
                   </p>
                 </div>
@@ -375,8 +375,8 @@ export default function CommunityPage() {
 
               <div className="relative z-10">
                 <Users className="mx-auto mb-6 h-12 w-12 text-[#AB47C7]" />
-                <h2 className="mb-4 text-3xl font-bold md:text-4xl">Be First to Know</h2>
-                <p className="mb-8 text-lg leading-relaxed text-slate-400">
+                <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">Be First to Know</h2>
+                <p className="mb-8 text-[17px] leading-relaxed text-white/80">
                   Join the newsletter to get notified when the community launches. Plus weekly AI
                   insights and creator resources.
                 </p>

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -228,12 +228,12 @@ export default function CoursesPage() {
                 </span>
               </div>
 
-              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 tracking-tight leading-[1.1]">
+              <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-6 tracking-tight leading-[1.1]">
                 Course roadmap, truth-first.
                 <span className="block mt-2 text-white/60">Only planned tracks and live waitlists.</span>
               </h1>
 
-              <p className="text-lg md:text-xl text-white/50 max-w-2xl mb-10 leading-relaxed">
+              <p className="text-[17px] md:text-xl leading-relaxed text-white/80 max-w-2xl mb-10">
                 These are planned courses. No paid enrollment or video lesson library is live yet.
                 Each page shows what is currently true and collects waitlist interest.
               </p>
@@ -281,7 +281,7 @@ export default function CoursesPage() {
           </div>
         </section>
 
-        <section className="py-16">
+        <section className="py-20 lg:py-28">
           <div className="max-w-6xl mx-auto px-6">
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {filteredCourses.map((course, i) => (
@@ -291,7 +291,7 @@ export default function CoursesPage() {
           </div>
         </section>
 
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-6xl mx-auto px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -302,10 +302,10 @@ export default function CoursesPage() {
               <p className="text-xs font-medium uppercase tracking-[0.25em] text-emerald-400/70 mb-2">
                 Curated Learning
               </p>
-              <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
                 Free courses I recommend
               </h2>
-              <p className="text-white/50 max-w-2xl">
+              <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl">
                 External resources from Oracle, Google, and MIT while the FrankX courses are still in development.
               </p>
             </motion.div>
@@ -363,30 +363,30 @@ export default function CoursesPage() {
           </div>
         </section>
 
-        <section className="py-20 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-4xl mx-auto px-6 text-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
             >
-              <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-6">
                 Want launch updates first?
               </h2>
-              <p className="text-lg text-white/50 mb-10 max-w-2xl mx-auto">
+              <p className="text-[17px] leading-relaxed text-white/80 mb-10 max-w-2xl mx-auto">
                 Join the course waitlist from any roadmap page and get beta invites and release notifications.
               </p>
               <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
                 <Link
                   href="/courses/conscious-ai-foundations#waitlist"
-                  className="group inline-flex items-center gap-3 rounded-full bg-emerald-500 hover:bg-emerald-600 text-white px-8 py-4 font-semibold shadow-lg shadow-emerald-500/20 transition-all hover:shadow-xl hover:shadow-emerald-500/30 hover:-translate-y-0.5"
+                  className="group inline-flex items-center gap-3 rounded-full bg-emerald-500 hover:bg-emerald-600 text-white px-8 py-4 font-semibold shadow-lg shadow-emerald-500/20 transition-all hover:shadow-xl hover:shadow-emerald-500/30 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Get Early Access
                   <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
                 </Link>
                 <Link
                   href="/students"
-                  className="inline-flex items-center gap-3 px-8 py-4 rounded-full font-medium text-white/60 hover:text-white border border-white/10 hover:border-white/20 transition-all"
+                  className="inline-flex items-center gap-3 px-8 py-4 rounded-full font-medium text-white/60 hover:text-white border border-white/10 hover:border-white/20 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   Free Resources
                 </Link>

--- a/app/creators/page.tsx
+++ b/app/creators/page.tsx
@@ -172,7 +172,7 @@ export default function CreatorsPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.1 }}
-              className="mb-6 max-w-4xl text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl"
+              className="mb-6 max-w-4xl text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white"
             >
               Create with AI.
               <span className="mt-2 block bg-gradient-to-r from-pink-400 via-violet-400 to-cyan-400 bg-clip-text text-transparent">
@@ -184,7 +184,7 @@ export default function CreatorsPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.2 }}
-              className="mb-8 max-w-2xl text-lg leading-relaxed text-slate-400 sm:text-xl"
+              className="mb-8 max-w-2xl text-[17px] sm:text-xl leading-relaxed text-white/80"
             >
               Master AI tools that amplify your creative voice—never replace it.
               From 12,000+ AI songs to visual storytelling, discover the creator's path to AI mastery.
@@ -272,10 +272,10 @@ export default function CreatorsPage() {
               <span className="mb-4 inline-block rounded-full border border-pink-500/20 bg-pink-500/10 px-4 py-1.5 text-sm font-medium text-pink-400">
                 Creative Paths
               </span>
-              <h2 className="mb-4 text-3xl font-bold text-white sm:text-4xl">
+              <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
                 Choose Your Creative Domain
               </h2>
-              <p className="mx-auto max-w-2xl text-lg text-slate-400">
+              <p className="mx-auto max-w-2xl text-[17px] leading-relaxed text-white/80">
                 Structured paths to master AI-assisted creation. Start with prompts, develop your unique style.
               </p>
             </motion.div>
@@ -339,10 +339,10 @@ export default function CreatorsPage() {
                 <span className="mb-4 inline-block rounded-full border border-amber-500/20 bg-amber-500/10 px-4 py-1.5 text-sm font-medium text-amber-400">
                   Premium Product
                 </span>
-                <h2 className="mb-6 text-3xl font-bold text-white sm:text-4xl">
+                <h2 className="mb-6 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
                   GenCreator OS
                 </h2>
-                <p className="mb-8 text-lg text-slate-400">
+                <p className="mb-8 text-[17px] leading-relaxed text-white/80">
                   The complete creative operating system for AI-powered creators.
                   Templates, workflows, and frameworks that preserve your authentic voice.
                 </p>
@@ -442,7 +442,7 @@ export default function CreatorsPage() {
               <p className="text-xs font-medium uppercase tracking-[0.25em] text-pink-400/70 mb-2">
                 Field Guides
               </p>
-              <h2 className="text-2xl md:text-3xl font-bold text-white">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
                 Essential reading for AI creators
               </h2>
             </motion.div>
@@ -513,10 +513,10 @@ export default function CreatorsPage() {
               viewport={{ once: true }}
               className="text-center mb-12"
             >
-              <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
                 Your creative transformation
               </h2>
-              <p className="text-white/50">From tech-overwhelmed to AI-empowered creator</p>
+              <p className="text-[17px] leading-relaxed text-white/80">From tech-overwhelmed to AI-empowered creator</p>
             </motion.div>
 
             <div className="grid md:grid-cols-3 gap-6">
@@ -569,31 +569,31 @@ export default function CreatorsPage() {
               className="rounded-2xl border border-white/10 bg-gradient-to-b from-slate-900/80 to-slate-900/40 p-10 text-center backdrop-blur-xl"
             >
               <BookOpen className="mx-auto mb-6 h-12 w-12 text-pink-400" />
-              <h2 className="mb-4 text-2xl font-bold text-white sm:text-3xl">
+              <h2 className="mb-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
                 Start Creating Today
               </h2>
-              <p className="mx-auto mb-8 max-w-lg text-slate-400">
+              <p className="mx-auto mb-8 max-w-lg text-[17px] leading-relaxed text-white/80">
                 Explore free prompts and see what's possible with AI-powered creation.
                 No signup required—just start making.
               </p>
               <div className="flex flex-wrap justify-center gap-4">
                 <Link
                   href="/prompt-library"
-                  className="group flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/10"
+                  className="group flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   <Music className="h-5 w-5" />
                   Music Prompts
                 </Link>
                 <Link
                   href="/prompt-library"
-                  className="group flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/10"
+                  className="group flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   <PenLine className="h-5 w-5" />
                   Writing Prompts
                 </Link>
                 <Link
                   href="/prompt-library"
-                  className="group flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/10"
+                  className="group flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 font-medium text-white transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   <ImageIcon className="h-5 w-5" />
                   Image Prompts

--- a/app/ecosystem/page.tsx
+++ b/app/ecosystem/page.tsx
@@ -111,12 +111,12 @@ function TierSection({ tierId, label, description }: { tierId: EcosystemTier; la
   if (entries.length === 0) return null
 
   return (
-    <section className="py-10">
+    <section className="py-14">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-end justify-between gap-4 mb-6">
           <div>
-            <h2 className="text-xl sm:text-2xl font-bold text-zinc-50 mb-1">{label}</h2>
-            <p className="text-sm text-zinc-500 max-w-2xl">{description}</p>
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-zinc-50 mb-2">{label}</h2>
+            <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl">{description}</p>
           </div>
           <span className="text-xs font-mono text-zinc-500 whitespace-nowrap">{entries.length} systems</span>
         </div>
@@ -147,16 +147,16 @@ export default function EcosystemPage() {
             <span>FrankX Ecosystem Map</span>
           </div>
 
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-zinc-50 leading-tight tracking-tight mb-6">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-zinc-50 leading-[1.1] tracking-tight mb-6">
             Every system, in one map
           </h1>
 
-          <p className="text-lg sm:text-xl text-zinc-400 max-w-3xl leading-relaxed mb-6">
+          <p className="text-[17px] sm:text-xl leading-relaxed text-white/80 max-w-3xl mb-6">
             {ecosystemEntries.length} systems across 4 tiers — public surfaces on frankx.ai, open-source substrate
             you can fork, internal operational layers, and the daily ops tooling that keeps it all running.
           </p>
 
-          <p className="text-base text-zinc-500 max-w-3xl leading-relaxed">
+          <p className="text-[17px] text-zinc-500 max-w-3xl leading-relaxed">
             For the operational subset Frank uses to run the business day-to-day, see{' '}
             <Link href="/os" className="text-cyan-300 hover:text-cyan-200 underline decoration-cyan-300/30 hover:decoration-cyan-300/60 underline-offset-2">
               FrankX OS

--- a/app/for/architects/page.tsx
+++ b/app/for/architects/page.tsx
@@ -164,14 +164,14 @@ export default function ArchitectsLandingPage() {
               For Architects & Engineers
             </motion.div>
 
-            <motion.h1 variants={itemVariants} className="text-4xl font-bold leading-tight sm:text-5xl lg:text-6xl">
+            <motion.h1 variants={itemVariants} className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1]">
               <span className="text-white">Enterprise AI architecture </span>
               <span className="bg-gradient-to-r from-cyan-400 via-blue-400 to-violet-400 bg-clip-text text-transparent">
                 that ships
               </span>
             </motion.h1>
 
-            <motion.p variants={itemVariants} className="mt-6 max-w-2xl text-lg text-white/60 leading-relaxed">
+            <motion.p variants={itemVariants} className="mt-6 max-w-2xl text-[17px] leading-relaxed text-white/80">
               Production patterns for multi-agent systems, RAG architectures, and agentic workflows.
               Built from enterprise experience, documented for everyone.
             </motion.p>
@@ -179,7 +179,7 @@ export default function ArchitectsLandingPage() {
             <motion.div variants={itemVariants} className="mt-8 flex flex-wrap gap-4">
               <Link
                 href="/ai-architecture"
-                className="group inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-full font-semibold transition-all hover:shadow-[0_0_40px_rgba(255,255,255,0.15)] hover:-translate-y-0.5"
+                className="group inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-full font-semibold transition-all hover:shadow-[0_0_40px_rgba(255,255,255,0.15)] hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <Layers className="h-4 w-4" />
                 Architecture Hub
@@ -187,7 +187,7 @@ export default function ArchitectsLandingPage() {
               </Link>
               <Link
                 href="/research"
-                className="group inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-white/70 hover:text-white border border-white/10 hover:border-white/20 transition-all"
+                className="group inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-white/70 hover:text-white border border-white/10 hover:border-white/20 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <BookOpen className="h-4 w-4" />
                 Research Hub
@@ -231,8 +231,8 @@ export default function ArchitectsLandingPage() {
             viewport={{ once: true }}
             className="mb-12"
           >
-            <h2 className="text-3xl sm:text-4xl font-bold text-white">Architecture patterns</h2>
-            <p className="mt-3 text-lg text-white/50">Production-tested, enterprise-grade, documented.</p>
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Architecture patterns</h2>
+            <p className="mt-3 text-[17px] leading-relaxed text-white/80">Production-tested, enterprise-grade, documented.</p>
           </motion.div>
 
           <div className="grid sm:grid-cols-2 gap-6">
@@ -279,8 +279,8 @@ export default function ArchitectsLandingPage() {
             className="flex items-end justify-between mb-8"
           >
             <div>
-              <h2 className="text-2xl sm:text-3xl font-bold text-white">Technical deep dives</h2>
-              <p className="mt-2 text-white/50">Architecture patterns and production guides.</p>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Technical deep dives</h2>
+              <p className="mt-2 text-[17px] leading-relaxed text-white/80">Architecture patterns and production guides.</p>
             </div>
             <Link href="/blog" className="hidden sm:inline-flex items-center gap-2 text-sm text-white/60 hover:text-white transition-colors">
               All articles <ArrowRight className="h-4 w-4" />
@@ -326,10 +326,10 @@ export default function ArchitectsLandingPage() {
             className="rounded-2xl border border-white/10 bg-white/[0.03] p-8 sm:p-10 text-center backdrop-blur-sm"
           >
             <GitBranch className="mx-auto h-8 w-8 text-cyan-400 mb-4" />
-            <h2 className="text-xl sm:text-2xl font-bold text-white mb-3">
+            <h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-white mb-3">
               Architecture insights weekly
             </h2>
-            <p className="text-sm text-white/50 mb-6 max-w-md mx-auto">
+            <p className="text-[17px] leading-relaxed text-white/80 mb-6 max-w-md mx-auto">
               Production AI patterns, agent architectures, and enterprise deployment strategies.
             </p>
             <div className="max-w-sm mx-auto">
@@ -351,7 +351,7 @@ export default function ArchitectsLandingPage() {
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
-            className="text-2xl sm:text-3xl font-bold text-white text-center mb-10"
+            className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white text-center mb-10"
           >
             Questions architects ask
           </motion.h2>
@@ -380,31 +380,31 @@ export default function ArchitectsLandingPage() {
       </section>
 
       {/* Final CTA */}
-      <section className="relative py-20 pb-24">
+      <section className="relative py-20 lg:py-28 pb-24">
         <div className="mx-auto max-w-3xl px-6 text-center">
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
             Build something that matters.
           </h2>
-          <p className="text-lg text-white/50 mb-8">
+          <p className="text-[17px] leading-relaxed text-white/80 mb-8">
             Architecture patterns, agent templates, and production guides. All open.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/ai-architecture"
-              className="group inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-full font-semibold transition-all hover:shadow-[0_0_40px_rgba(255,255,255,0.15)]"
+              className="group inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-full font-semibold transition-all hover:shadow-[0_0_40px_rgba(255,255,255,0.15)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               Architecture Hub
               <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" />
             </Link>
             <Link
               href="/acos"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-white/70 border border-white/10 hover:border-white/20 hover:text-white transition-all"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-white/70 border border-white/10 hover:border-white/20 hover:text-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               ACOS
             </Link>
             <Link
               href="/research"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-white/70 border border-white/10 hover:border-white/20 hover:text-white transition-all"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-full font-medium text-white/70 border border-white/10 hover:border-white/20 hover:text-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               Research Hub
             </Link>

--- a/app/founders-circle/page.tsx
+++ b/app/founders-circle/page.tsx
@@ -24,14 +24,14 @@ export default function FoundersCirclePage() {
           <p className="text-xs font-medium text-rose-400 uppercase tracking-[0.18em] mb-6">
             Founder's Circle
           </p>
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white tracking-tight mb-8 leading-[1.05]">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white tracking-tight mb-8 leading-[1.05]">
             For founders whose problem is judgment, not artifacts.
           </h1>
-          <p className="text-lg text-zinc-300 leading-relaxed mb-5 max-w-2xl">
+          <p className="text-[17px] leading-relaxed text-white/80 mb-5 max-w-2xl">
             Most builders need templates. The Toolkit and Architect tiers are for them — and
             they are excellent. Some operators have a different problem.
           </p>
-          <p className="text-lg text-zinc-300 leading-relaxed mb-10 max-w-2xl">
+          <p className="text-[17px] leading-relaxed text-white/80 mb-10 max-w-2xl">
             Their decisions cost or earn millions. Their time is the constraint, not their
             budget. They have read the books and built the prototypes. What they need is a
             second brain who has shipped enterprise AI systems and can give them the
@@ -41,7 +41,7 @@ export default function FoundersCirclePage() {
           <div className="flex flex-wrap items-center gap-4">
             <Link
               href="/founders-circle/apply"
-              className="inline-flex items-center gap-2 px-6 py-3.5 rounded-xl text-base font-semibold bg-rose-500/15 hover:bg-rose-500/25 border border-rose-500/30 text-rose-300 transition-colors"
+              className="inline-flex items-center gap-2 px-6 py-3.5 rounded-full text-base font-semibold bg-rose-500/15 hover:bg-rose-500/25 border border-rose-500/30 text-rose-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               Apply for the Circle
               <ArrowRight className="w-4 h-4" />
@@ -63,9 +63,9 @@ export default function FoundersCirclePage() {
       </section>
 
       {/* What you get — deliberately spartan */}
-      <section className="pb-20">
+      <section className="py-20 lg:py-28">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-semibold text-white mb-8 tracking-tight">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-8 tracking-tight">
             What's in a quarter
           </h2>
           <div className="grid sm:grid-cols-2 gap-4">
@@ -125,9 +125,9 @@ export default function FoundersCirclePage() {
       </section>
 
       {/* The honest bar — who this is for */}
-      <section className="pb-20">
+      <section className="py-20 lg:py-28">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-semibold text-white mb-6 tracking-tight">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-6 tracking-tight">
             Who the Circle is genuinely for
           </h2>
           <div className="space-y-4">
@@ -207,22 +207,22 @@ export default function FoundersCirclePage() {
       </section>
 
       {/* Apply CTA — bottom restate */}
-      <section className="pb-24">
+      <section className="py-20 lg:py-28">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="rounded-2xl border border-rose-500/20 bg-rose-500/[0.04] p-8 text-center">
             <p className="text-xs font-medium text-rose-400 uppercase tracking-[0.18em] mb-3">
               Q2 2026 · 10 seats
             </p>
-            <h3 className="text-2xl font-semibold text-white mb-4 tracking-tight">
+            <h3 className="text-2xl md:text-3xl font-semibold text-white mb-4 tracking-tight">
               Apply for the next quarter
             </h3>
-            <p className="text-sm text-zinc-300 max-w-lg mx-auto leading-relaxed mb-6">
+            <p className="text-[17px] text-zinc-300 max-w-lg mx-auto leading-relaxed mb-6">
               The application takes 8 minutes. We reply within 5 business days. If a current
               quarter is full, you'll be offered the next one.
             </p>
             <Link
               href="/founders-circle/apply"
-              className="inline-flex items-center gap-2 px-6 py-3.5 rounded-xl text-base font-semibold bg-rose-500/15 hover:bg-rose-500/25 border border-rose-500/30 text-rose-300 transition-colors"
+              className="inline-flex items-center gap-2 px-6 py-3.5 rounded-full text-base font-semibold bg-rose-500/15 hover:bg-rose-500/25 border border-rose-500/30 text-rose-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               Start the application
               <ArrowRight className="w-4 h-4" />

--- a/app/gencreator/page.tsx
+++ b/app/gencreator/page.tsx
@@ -95,7 +95,7 @@ export default function GenCreatorHubPage() {
       <GenCreatorNav />
 
       {/* ─── Hero ─── */}
-      <section className="relative overflow-hidden pt-24 pb-20">
+      <section className="relative overflow-hidden pt-24 pb-20 lg:pb-28">
         <div className="absolute inset-0 bg-gradient-to-br from-emerald-950/40 via-[#02030b] to-teal-950/30" />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(16,185,129,0.12),transparent_55%)]" />
 
@@ -120,12 +120,12 @@ export default function GenCreatorHubPage() {
             </div>
           </div>
 
-          <h1 className="text-4xl font-bold leading-tight sm:text-5xl md:text-6xl lg:text-7xl">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1]">
             <span className="bg-gradient-to-r from-white via-emerald-100 to-teal-100 bg-clip-text text-transparent">
               The GenCreator Framework
             </span>
           </h1>
-          <p className="mt-6 text-lg text-white/60 sm:text-xl md:text-2xl">
+          <p className="mt-6 text-[17px] leading-relaxed text-white/80 sm:text-xl md:text-2xl">
             The complete operating system for generative creators.
             <br className="hidden sm:block" />
             Principles. Handbook. Blueprints. Soul. Manifesto.
@@ -190,12 +190,12 @@ export default function GenCreatorHubPage() {
       </section>
 
       {/* ─── Sections ─── */}
-      <section className="py-20">
+      <section className="py-20 lg:py-28">
         <div className="mx-auto max-w-5xl px-6">
-          <h2 className="text-center text-3xl font-bold text-white sm:text-4xl">
+          <h2 className="text-center text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
             Explore the Framework
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-center text-white/50">
+          <p className="mx-auto mt-4 max-w-2xl text-center text-[17px] leading-relaxed text-white/80">
             Five interconnected systems that together form a complete creator operating framework.
           </p>
           <div className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -219,12 +219,12 @@ export default function GenCreatorHubPage() {
       </section>
 
       {/* ─── Philosophy Teaser ─── */}
-      <section className="border-y border-white/[0.08] bg-white/[0.03] py-20">
+      <section className="border-y border-white/[0.08] bg-white/[0.03] py-20 lg:py-28">
         <div className="mx-auto max-w-4xl px-6 text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
             What is a GenCreator?
           </h2>
-          <div className="mx-auto mt-8 max-w-3xl space-y-6 text-lg leading-relaxed text-white/60">
+          <div className="mx-auto mt-8 max-w-3xl space-y-6 text-[17px] leading-relaxed text-white/80">
             <p>
               A GenCreator is the new breed of creator — someone who wields AI as a creative force multiplier,
               not a replacement. They build systems that compound, ship daily, own their infrastructure,
@@ -246,12 +246,12 @@ export default function GenCreatorHubPage() {
       </section>
 
       {/* ─── CTA ─── */}
-      <section className="py-20">
+      <section className="py-20 lg:py-28">
         <div className="mx-auto max-w-3xl px-6 text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
             Start Your GenCreator Journey
           </h2>
-          <p className="mt-4 text-lg text-white/50">
+          <p className="mt-4 text-[17px] leading-relaxed text-white/80">
             Begin with the principles. Read the handbook. Execute the blueprints. Build your soul.md.
           </p>
           <div className="mt-10 flex flex-wrap justify-center gap-4">

--- a/app/golden-age/page.tsx
+++ b/app/golden-age/page.tsx
@@ -53,7 +53,7 @@ export default function GoldenAgePage() {
             </motion.div>
 
             {/* Title */}
-            <h1 className="font-serif text-5xl sm:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-white via-amber-200 to-white bg-clip-text text-transparent leading-tight drop-shadow-2xl">
+            <h1 className="font-serif text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] bg-gradient-to-r from-white via-amber-200 to-white bg-clip-text text-transparent drop-shadow-2xl">
               {bookMetadata.title}
             </h1>
 
@@ -68,7 +68,7 @@ export default function GoldenAgePage() {
               animate={{ opacity: 1 }}
               transition={{ delay: 0.4 }}
             >
-              <p className="text-lg text-gray-300 max-w-2xl mx-auto leading-relaxed">
+              <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl mx-auto">
                 <span className="text-2xl font-serif text-amber-400">2 AM.</span> Studio lights glow. An idea hits — that electric moment when you <em className="font-semibold not-italic text-white">know</em> something wants to be created through you.
                 <br /><br />
                 <span className="bg-gradient-to-r from-amber-400 to-orange-400 bg-clip-text text-transparent font-semibold">This book is for creators ready to answer that call</span> — with AI as your amplifier, not your replacement.
@@ -107,7 +107,7 @@ export default function GoldenAgePage() {
             >
               <Link
                 href="/golden-age/chapter-01-when-creation-calls"
-                className="group inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-amber-500 to-orange-500 text-white rounded-2xl font-semibold hover:from-amber-600 hover:to-orange-600 transition-all shadow-lg shadow-amber-500/25 hover:shadow-xl hover:shadow-amber-500/30 focus:outline-none focus:ring-4 focus:ring-amber-500/50 cursor-pointer"
+                className="group inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-amber-500 to-orange-500 text-white rounded-full font-semibold hover:from-amber-600 hover:to-orange-600 transition-all shadow-lg shadow-amber-500/25 hover:shadow-xl hover:shadow-amber-500/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 cursor-pointer"
               >
                 <Zap className="w-5 h-5" />
                 <span>Start Chapter 1</span>
@@ -116,7 +116,7 @@ export default function GoldenAgePage() {
 
               <Link
                 href="#chapters"
-                className="group inline-flex items-center gap-2 px-8 py-4 border-2 border-white/30 text-white rounded-2xl font-medium hover:border-white/60 hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-white/30 transition-all backdrop-blur-sm cursor-pointer"
+                className="group inline-flex items-center gap-2 px-8 py-4 border-2 border-white/30 text-white rounded-full font-medium hover:border-white/60 hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 transition-all backdrop-blur-sm cursor-pointer"
               >
                 <Book className="w-5 h-5" />
                 <span>Browse All Chapters</span>
@@ -130,13 +130,13 @@ export default function GoldenAgePage() {
       </section>
 
       {/* Book Chapters Section - Now with chapter art */}
-      <section id="chapters" className="py-20 scroll-mt-20">
+      <section id="chapters" className="py-20 lg:py-28 scroll-mt-20">
         <div className="max-w-5xl mx-auto px-6">
           <div className="space-y-4 mb-12">
-            <h2 className="font-serif text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white">
+            <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-gray-900 dark:text-white">
               The Journey
             </h2>
-            <p className="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+            <p className="text-[17px] leading-relaxed text-gray-700 dark:text-white/80">
               Each chapter is a session. Read in order, or drop in where you need it most. The path unfolds as you walk it.
             </p>
           </div>
@@ -259,13 +259,13 @@ export default function GoldenAgePage() {
       </div>
 
       {/* Related Essays Section */}
-      <section id="essays" className="py-20 bg-gray-50 dark:bg-slate-900/50 scroll-mt-20">
+      <section id="essays" className="py-20 lg:py-28 bg-gray-50 dark:bg-slate-900/50 scroll-mt-20">
         <div className="max-w-5xl mx-auto px-6">
           <div className="space-y-4 mb-12">
-            <h2 className="font-serif text-4xl sm:text-5xl font-bold text-gray-900 dark:text-white">
+            <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-gray-900 dark:text-white">
               Studio Notes
             </h2>
-            <p className="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+            <p className="text-[17px] leading-relaxed text-gray-700 dark:text-white/80">
               Companion essays from the creative trenches. Strategy, implementation, and real-world intelligence.
             </p>
           </div>
@@ -318,17 +318,17 @@ export default function GoldenAgePage() {
       </section>
 
       {/* Chapter Notifications Signup */}
-      <section className="py-20 bg-gradient-to-br from-amber-50 via-white to-orange-50 dark:from-amber-950/20 dark:via-slate-950 dark:to-orange-950/20 border-t border-amber-200 dark:border-amber-900/30">
+      <section className="py-20 lg:py-28 bg-gradient-to-br from-amber-50 via-white to-orange-50 dark:from-amber-950/20 dark:via-slate-950 dark:to-orange-950/20 border-t border-amber-200 dark:border-amber-900/30">
         <div className="max-w-2xl mx-auto px-6">
           <div className="text-center space-y-6 mb-8">
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-900 dark:text-amber-200 text-sm font-medium border border-amber-200 dark:border-amber-800">
               <Stars className="w-4 h-4" />
               <span>New Chapters Weekly</span>
             </div>
-            <h2 className="font-serif text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white">
+            <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-gray-900 dark:text-white">
               Get Notified When New Chapters Drop
             </h2>
-            <p className="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+            <p className="text-[17px] leading-relaxed text-gray-700 dark:text-white/80">
               Join 5,000+ creators receiving weekly chapters, music drops, and studio intelligence. No spam, just creation fuel.
             </p>
           </div>
@@ -344,7 +344,7 @@ export default function GoldenAgePage() {
       </section>
 
       {/* Call to Action - with hero image background */}
-      <section className="relative py-24 overflow-hidden">
+      <section className="relative py-20 lg:py-28 overflow-hidden">
         <div className="absolute inset-0">
           <Image
             src="/images/golden-age/hero-golden-age.png"
@@ -356,15 +356,15 @@ export default function GoldenAgePage() {
           <div className="absolute inset-0 bg-gradient-to-t from-white via-white/90 to-white/80 dark:from-slate-950 dark:via-slate-950/90 dark:to-slate-950/80" />
         </div>
         <div className="relative z-10 max-w-2xl mx-auto px-6 text-center space-y-6">
-          <h2 className="font-serif text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white">
+          <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-gray-900 dark:text-white">
             Your Next Session Awaits
           </h2>
-          <p className="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+          <p className="text-[17px] leading-relaxed text-gray-700 dark:text-white/80">
             That voice inside you? The one that knows you&apos;re meant to create something? It&apos;s time to listen. Chapter 1 starts here.
           </p>
           <Link
             href="/golden-age/chapter-01-when-creation-calls"
-            className="inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-amber-500 to-orange-500 text-white rounded-2xl font-semibold text-lg hover:from-amber-600 hover:to-orange-600 focus:outline-none focus:ring-4 focus:ring-amber-500/50 transition-all shadow-lg shadow-amber-500/25 hover:shadow-xl cursor-pointer"
+            className="inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-amber-500 to-orange-500 text-white rounded-full font-semibold text-lg hover:from-amber-600 hover:to-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950 transition-all shadow-lg shadow-amber-500/25 hover:shadow-xl cursor-pointer"
           >
             <Zap className="w-5 h-5" />
             <span>Begin Chapter 1</span>

--- a/app/legal/imprint/page.tsx
+++ b/app/legal/imprint/page.tsx
@@ -5,73 +5,102 @@ export const metadata: Metadata = {
   description: 'Legal information and company details for Arcanea Labs BV, trading as FrankX.',
 }
 
+const IMPRINT_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'Imprint',
+  description: 'Legal information and company details for Arcanea Labs BV, trading as FrankX.',
+  url: 'https://frankx.ai/legal/imprint',
+  inLanguage: 'en',
+  isPartOf: {
+    '@type': 'WebSite',
+    name: 'FrankX',
+    url: 'https://frankx.ai',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Arcanea Labs BV',
+    url: 'https://frankx.ai',
+    address: { '@type': 'PostalAddress', addressLocality: 'Amsterdam', addressCountry: 'NL' },
+  },
+  dateModified: '2026-06-02',
+}
+
 export default function ImprintPage() {
   return (
-    <article className="prose prose-invert prose-zinc max-w-none">
-      <h1 className="text-3xl font-bold text-white mb-2">Imprint</h1>
-      <p className="text-zinc-500 text-sm mb-8">Legal disclosure pursuant to Dutch law</p>
+    <article className="max-w-none">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(IMPRINT_JSONLD) }}
+      />
+      <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.1] text-white mb-3">Imprint</h1>
+      <p className="text-zinc-500 text-sm mb-12">Legal disclosure pursuant to Dutch law</p>
 
-      <section className="space-y-6">
+      <section className="space-y-14">
         <div>
-          <h2 className="text-xl font-semibold text-zinc-200">Company Information</h2>
-          <table className="w-full text-sm mt-3">
-            <tbody className="divide-y divide-zinc-800">
-              <Row label="Legal name" value="Arcanea Labs BV" />
-              <Row label="Trading as" value="FrankX / frankx.ai" />
-              <Row label="Registered office" value="Amsterdam, Netherlands" />
-              <Row label="KvK number" value="[PENDING — update after registration]" pending />
-              <Row label="BTW-id" value="[PENDING — update after registration]" pending />
-              <Row label="Director (DGA)" value="Frank Riemer" />
-            </tbody>
-          </table>
+          <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">Company Information</h2>
+          <div className="overflow-x-auto mt-4 rounded-lg border border-white/10 bg-white/[0.02]">
+            <table className="w-full text-[15px] md:text-[16px]">
+              <tbody className="divide-y divide-white/10">
+                <Row label="Legal name" value="Arcanea Labs BV" />
+                <Row label="Trading as" value="FrankX / frankx.ai" />
+                <Row label="Registered office" value="Amsterdam, Netherlands" />
+                <Row label="KvK number" value="[PENDING — update after registration]" pending />
+                <Row label="BTW-id" value="[PENDING — update after registration]" pending />
+                <Row label="Director (DGA)" value="Frank Riemer" />
+              </tbody>
+            </table>
+          </div>
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold text-zinc-200">Contact</h2>
-          <table className="w-full text-sm mt-3">
-            <tbody className="divide-y divide-zinc-800">
-              <Row label="Email" value="frank@frankx.ai" />
-              <Row label="Website" value="https://frankx.ai" />
-            </tbody>
-          </table>
+          <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">Contact</h2>
+          <div className="overflow-x-auto mt-4 rounded-lg border border-white/10 bg-white/[0.02]">
+            <table className="w-full text-[15px] md:text-[16px]">
+              <tbody className="divide-y divide-white/10">
+                <Row label="Email" value="frank@frankx.ai" />
+                <Row label="Website" value="https://frankx.ai" />
+              </tbody>
+            </table>
+          </div>
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold text-zinc-200">Dispute Resolution</h2>
-          <p className="text-zinc-400 text-sm leading-relaxed">
+          <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">Dispute Resolution</h2>
+          <p className="text-[16px] md:text-[17px] leading-[1.7] text-white/75">
             The European Commission provides a platform for online dispute resolution (ODR):{' '}
             <a
               href="https://ec.europa.eu/consumers/odr"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-violet-400 hover:text-violet-300"
+              className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors"
             >
               ec.europa.eu/consumers/odr
             </a>
           </p>
-          <p className="text-zinc-400 text-sm leading-relaxed mt-2">
+          <p className="text-[16px] md:text-[17px] leading-[1.7] text-white/75 mt-4">
             We are not obligated to participate in dispute resolution proceedings before a consumer arbitration board, but we are willing to engage in good faith to resolve any disputes.
           </p>
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold text-zinc-200">Liability for Content</h2>
-          <p className="text-zinc-400 text-sm leading-relaxed">
+          <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">Liability for Content</h2>
+          <p className="text-[16px] md:text-[17px] leading-[1.7] text-white/75">
             The content of this website has been created with the utmost care. However, we cannot guarantee the accuracy, completeness, or timeliness of the content. As a service provider, we are responsible for our own content on these pages under Dutch law. We are not obligated to monitor transmitted or stored third-party information.
           </p>
         </div>
       </section>
 
-      <p className="text-zinc-600 text-xs mt-12">Last updated: March 2026</p>
+      <p className="text-white/50 text-sm mt-16 pt-8 border-t border-white/10">Last updated: June 2026</p>
     </article>
   )
 }
 
 function Row({ label, value, pending }: { label: string; value: string; pending?: boolean }) {
   return (
-    <tr>
-      <td className="py-2 pr-4 text-zinc-500 w-40">{label}</td>
-      <td className={`py-2 ${pending ? 'text-amber-500/70 italic' : 'text-zinc-300'}`}>{value}</td>
+    <tr className="hover:bg-white/[0.02] transition-colors">
+      <td className="py-3 px-4 text-white/60 font-medium w-48 whitespace-nowrap">{label}</td>
+      <td className={`py-3 px-4 ${pending ? 'text-amber-400/80 italic' : 'text-white/85'}`}>{value}</td>
     </tr>
   )
 }

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -9,15 +9,15 @@ export const metadata: Metadata = {
 export default function LegalPage() {
   return (
     <div className="min-h-screen bg-[#0a0a0b] text-white">
-      <div className="max-w-3xl mx-auto px-6 py-24">
+      <div className="max-w-3xl mx-auto px-6 py-20 lg:py-28">
         <Link
           href="/"
-          className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors mb-8 text-sm"
+          className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors mb-10 text-sm"
         >
           &larr; Back to Home
         </Link>
 
-        <h1 className="text-4xl font-bold mb-8">Legal Information</h1>
+        <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] mb-12">Legal Information</h1>
 
         <div className="space-y-8">
           {/* Quick Links */}

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -5,11 +5,35 @@ export const metadata: Metadata = {
   description: 'How Arcanea Labs BV handles your personal data. GDPR-compliant privacy policy.',
 }
 
+const PRIVACY_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'Privacy Policy',
+  description: 'How Arcanea Labs BV handles your personal data. GDPR-compliant privacy policy.',
+  url: 'https://frankx.ai/legal/privacy',
+  inLanguage: 'en',
+  isPartOf: {
+    '@type': 'WebSite',
+    name: 'FrankX',
+    url: 'https://frankx.ai',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Arcanea Labs BV',
+    url: 'https://frankx.ai',
+  },
+  dateModified: '2026-06-02',
+}
+
 export default function PrivacyPage() {
   return (
-    <article className="prose prose-invert prose-zinc max-w-none">
-      <h1 className="text-3xl font-bold text-white mb-2">Privacy Policy</h1>
-      <p className="text-zinc-500 text-sm mb-8">Effective: [DATE] &bull; Last updated: March 2026</p>
+    <article className="max-w-none">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(PRIVACY_JSONLD) }}
+      />
+      <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.1] text-white mb-3">Privacy Policy</h1>
+      <p className="text-zinc-500 text-sm mb-12">Effective: [DATE] &bull; Last updated: June 2026</p>
 
       <Section title="1. Who We Are">
         <p>Arcanea Labs BV (&ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;), trading as FrankX, is the data controller responsible for your personal data.</p>
@@ -23,15 +47,15 @@ export default function PrivacyPage() {
       </Section>
 
       <Section title="2. What Data We Collect">
-        <h3 className="text-base font-medium text-zinc-300 mt-4">Data you provide directly</h3>
-        <ul className="text-zinc-400 text-sm space-y-1">
+        <h3 className="text-lg font-medium text-white mt-5 mb-2">Data you provide directly</h3>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Email address and name (newsletter signup, purchases)</li>
           <li>Payment information (processed by Stripe/Paddle — we do not store card details)</li>
           <li>Messages you send us via contact forms</li>
         </ul>
 
-        <h3 className="text-base font-medium text-zinc-300 mt-4">Data collected automatically</h3>
-        <ul className="text-zinc-400 text-sm space-y-1">
+        <h3 className="text-lg font-medium text-white mt-6 mb-2">Data collected automatically</h3>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Pages visited and interactions (via Vercel Analytics — privacy-focused, no cookies)</li>
           <li>Device type, browser, and approximate location (country level)</li>
           <li>IP address (anonymized, not stored long-term)</li>
@@ -59,7 +83,7 @@ export default function PrivacyPage() {
           ['Hosting', 'Vercel', 'US (EU SCCs)', 'Website hosting and analytics'],
           ['Code hosting', 'GitHub', 'US (EU SCCs)', 'Development infrastructure'],
         ]} />
-        <p className="text-sm text-zinc-500 mt-2">All US-based processors operate under EU Standard Contractual Clauses (SCCs) for international data transfers.</p>
+        <p className="text-[15px] text-white/55 mt-3">All US-based processors operate under EU Standard Contractual Clauses (SCCs) for international data transfers.</p>
       </Section>
 
       <Section title="5. How Long We Keep Data">
@@ -75,16 +99,16 @@ export default function PrivacyPage() {
 
       <Section title="6. Your Rights (GDPR)">
         <p>Under the General Data Protection Regulation, you have the right to:</p>
-        <ul className="text-zinc-400 text-sm space-y-2">
-          <li><strong className="text-zinc-300">Access</strong> — Request a copy of the personal data we hold about you</li>
-          <li><strong className="text-zinc-300">Rectification</strong> — Ask us to correct inaccurate or incomplete data</li>
-          <li><strong className="text-zinc-300">Erasure</strong> — Request deletion of your personal data (&ldquo;right to be forgotten&rdquo;)</li>
-          <li><strong className="text-zinc-300">Restriction</strong> — Ask us to restrict processing of your data</li>
-          <li><strong className="text-zinc-300">Portability</strong> — Receive your data in a structured, machine-readable format</li>
-          <li><strong className="text-zinc-300">Object</strong> — Object to processing based on legitimate interests</li>
-          <li><strong className="text-zinc-300">Withdraw consent</strong> — Withdraw consent at any time (e.g., unsubscribe from newsletter)</li>
+        <ul className="list-disc pl-5 space-y-2.5">
+          <li><strong className="text-white font-semibold">Access</strong> — Request a copy of the personal data we hold about you</li>
+          <li><strong className="text-white font-semibold">Rectification</strong> — Ask us to correct inaccurate or incomplete data</li>
+          <li><strong className="text-white font-semibold">Erasure</strong> — Request deletion of your personal data (&ldquo;right to be forgotten&rdquo;)</li>
+          <li><strong className="text-white font-semibold">Restriction</strong> — Ask us to restrict processing of your data</li>
+          <li><strong className="text-white font-semibold">Portability</strong> — Receive your data in a structured, machine-readable format</li>
+          <li><strong className="text-white font-semibold">Object</strong> — Object to processing based on legitimate interests</li>
+          <li><strong className="text-white font-semibold">Withdraw consent</strong> — Withdraw consent at any time (e.g., unsubscribe from newsletter)</li>
         </ul>
-        <p className="mt-3">To exercise any of these rights, email <a href="mailto:privacy@frankx.ai" className="text-violet-400">privacy@frankx.ai</a>. We will respond within 30 days.</p>
+        <p className="mt-4">To exercise any of these rights, email <a href="mailto:privacy@frankx.ai" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">privacy@frankx.ai</a>. We will respond within 30 days.</p>
       </Section>
 
       <Section title="7. Cookies">
@@ -94,7 +118,7 @@ export default function PrivacyPage() {
           ['Essential', 'Strictly necessary', 'Session management, security', 'Session'],
           ['Analytics', 'Performance', 'Vercel Analytics (privacy-focused)', 'Session'],
         ]} />
-        <p className="text-sm text-zinc-500 mt-2">We do not use marketing cookies or third-party tracking cookies. Vercel Analytics is privacy-focused and does not use cookies for tracking individual users.</p>
+        <p className="text-[15px] text-white/55 mt-3">We do not use marketing cookies or third-party tracking cookies. Vercel Analytics is privacy-focused and does not use cookies for tracking individual users.</p>
       </Section>
 
       <Section title="8. International Transfers">
@@ -118,16 +142,16 @@ export default function PrivacyPage() {
         <p>We may update this privacy policy from time to time. We will notify you of significant changes via email or a notice on our website. The &ldquo;last updated&rdquo; date at the top indicates the most recent revision.</p>
       </Section>
 
-      <p className="text-zinc-600 text-xs mt-12">Last updated: March 2026</p>
+      <p className="text-white/50 text-sm mt-16 pt-8 border-t border-white/10">Last updated: June 2026</p>
     </article>
   )
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="mt-10">
-      <h2 className="text-xl font-semibold text-zinc-200 mb-3">{title}</h2>
-      <div className="text-zinc-400 text-sm leading-relaxed space-y-3">{children}</div>
+    <section className="mt-14">
+      <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">{title}</h2>
+      <div className="text-[16px] md:text-[17px] leading-[1.7] text-white/75 space-y-4">{children}</div>
     </section>
   )
 }
@@ -136,13 +160,20 @@ function InfoTable({ rows }: { rows: string[][] }) {
   if (rows.length === 0) return null
   const isHeader = rows[0].length > 2
   return (
-    <div className="overflow-x-auto mt-3">
-      <table className="w-full text-sm">
-        <tbody className="divide-y divide-zinc-800">
+    <div className="overflow-x-auto mt-4 rounded-lg border border-white/10 bg-white/[0.02]">
+      <table className="w-full text-[15px] md:text-[16px]">
+        <tbody className="divide-y divide-white/10">
           {rows.map((row, i) => (
-            <tr key={i} className={i === 0 && isHeader ? 'text-zinc-500' : ''}>
+            <tr key={i} className={i === 0 && isHeader ? 'bg-white/[0.03] text-white/60' : 'hover:bg-white/[0.02] transition-colors'}>
               {row.map((cell, j) => (
-                <td key={j} className={`py-1.5 pr-4 ${j === 0 ? 'text-zinc-500 font-medium' : 'text-zinc-400'}`}>
+                <td
+                  key={j}
+                  className={`py-3 px-4 ${
+                    j === 0
+                      ? 'text-white/60 font-medium'
+                      : 'text-white/80'
+                  }`}
+                >
                   {cell}
                 </td>
               ))}

--- a/app/legal/refund/page.tsx
+++ b/app/legal/refund/page.tsx
@@ -5,15 +5,39 @@ export const metadata: Metadata = {
   description: 'Refund and cancellation policy for FrankX digital products and services.',
 }
 
+const REFUND_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'Refund Policy',
+  description: 'Refund and cancellation policy for FrankX digital products and services.',
+  url: 'https://frankx.ai/legal/refund',
+  inLanguage: 'en',
+  isPartOf: {
+    '@type': 'WebSite',
+    name: 'FrankX',
+    url: 'https://frankx.ai',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Arcanea Labs BV',
+    url: 'https://frankx.ai',
+  },
+  dateModified: '2026-06-02',
+}
+
 export default function RefundPage() {
   return (
-    <article className="prose prose-invert prose-zinc max-w-none">
-      <h1 className="text-3xl font-bold text-white mb-2">Refund Policy</h1>
-      <p className="text-zinc-500 text-sm mb-8">Effective: [DATE] &bull; Last updated: March 2026</p>
+    <article className="max-w-none">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(REFUND_JSONLD) }}
+      />
+      <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.1] text-white mb-3">Refund Policy</h1>
+      <p className="text-zinc-500 text-sm mb-12">Effective: [DATE] &bull; Last updated: June 2026</p>
 
       <Section title="Digital Products (Downloads)">
         <p>Under the EU Consumer Rights Directive, you have a 14-day right of withdrawal for online purchases. However, for digital products with immediate delivery, this right is waived when you:</p>
-        <ol>
+        <ol className="list-decimal pl-5 space-y-1.5">
           <li>Give explicit consent to begin the download/access immediately</li>
           <li>Acknowledge that you lose your right of withdrawal</li>
         </ol>
@@ -35,10 +59,10 @@ export default function RefundPage() {
       </Section>
 
       <Section title="How to Request a Refund">
-        <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-5 mt-3">
-          <p className="text-zinc-300 font-medium mb-2">Contact us at:</p>
-          <p><a href="mailto:frank@frankx.ai" className="text-violet-400">frank@frankx.ai</a></p>
-          <p className="mt-3 text-zinc-500 text-xs">Please include your order number, the product purchased, and the reason for your refund request. We aim to respond within 2 business days.</p>
+        <div className="bg-white/[0.03] border border-white/10 rounded-xl p-6 mt-4">
+          <p className="text-white font-semibold mb-2">Contact us at:</p>
+          <p><a href="mailto:frank@frankx.ai" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">frank@frankx.ai</a></p>
+          <p className="mt-4 text-white/55 text-[14px] leading-relaxed">Please include your order number, the product purchased, and the reason for your refund request. We aim to respond within 2 business days.</p>
         </div>
       </Section>
 
@@ -52,26 +76,26 @@ export default function RefundPage() {
 
       <Section title="Your Consumer Rights">
         <p>This refund policy does not affect your statutory consumer rights under Dutch and EU law. If you believe your consumer rights have been violated, you may contact the{' '}
-          <a href="https://www.consuwijzer.nl" target="_blank" rel="noopener noreferrer" className="text-violet-400">
+          <a href="https://www.consuwijzer.nl" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">
             ConsuWijzer
           </a>{' '}
           (Dutch consumer information portal) or use the{' '}
-          <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer" className="text-violet-400">
+          <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">
             EU Online Dispute Resolution platform
           </a>.
         </p>
       </Section>
 
-      <p className="text-zinc-600 text-xs mt-12">Last updated: March 2026</p>
+      <p className="text-white/50 text-sm mt-16 pt-8 border-t border-white/10">Last updated: June 2026</p>
     </article>
   )
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="mt-10">
-      <h2 className="text-xl font-semibold text-zinc-200 mb-3">{title}</h2>
-      <div className="text-zinc-400 text-sm leading-relaxed space-y-3">{children}</div>
+    <section className="mt-14">
+      <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">{title}</h2>
+      <div className="text-[16px] md:text-[17px] leading-[1.7] text-white/75 space-y-4">{children}</div>
     </section>
   )
 }

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -5,11 +5,35 @@ export const metadata: Metadata = {
   description: 'Terms and conditions for using FrankX products and services.',
 }
 
+const TERMS_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'Terms of Service',
+  description: 'Terms and conditions for using FrankX products and services.',
+  url: 'https://frankx.ai/legal/terms',
+  inLanguage: 'en',
+  isPartOf: {
+    '@type': 'WebSite',
+    name: 'FrankX',
+    url: 'https://frankx.ai',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Arcanea Labs BV',
+    url: 'https://frankx.ai',
+  },
+  dateModified: '2026-06-02',
+}
+
 export default function TermsPage() {
   return (
-    <article className="prose prose-invert prose-zinc max-w-none">
-      <h1 className="text-3xl font-bold text-white mb-2">Terms of Service</h1>
-      <p className="text-zinc-500 text-sm mb-8">Effective: [DATE] &bull; Last updated: March 2026</p>
+    <article className="max-w-none">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(TERMS_JSONLD) }}
+      />
+      <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.1] text-white mb-3">Terms of Service</h1>
+      <p className="text-zinc-500 text-sm mb-12">Effective: [DATE] &bull; Last updated: June 2026</p>
 
       <Section title="1. Introduction">
         <p>These Terms of Service (&ldquo;Terms&rdquo;) govern your use of the website frankx.ai and all products and services offered by Arcanea Labs BV (&ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;), registered in Amsterdam, Netherlands.</p>
@@ -18,7 +42,7 @@ export default function TermsPage() {
 
       <Section title="2. Products and Services">
         <p>We offer digital products and services including but not limited to:</p>
-        <ul>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Digital downloads (PDFs, templates, prompt packs)</li>
           <li>Online courses and educational content</li>
           <li>Software tools and SaaS subscriptions</li>
@@ -38,20 +62,20 @@ export default function TermsPage() {
 
       <Section title="5. Right of Withdrawal (EU Consumers)">
         <p>Under the EU Consumer Rights Directive (2011/83/EU), you have a 14-day right of withdrawal for online purchases.</p>
-        <p><strong className="text-zinc-300">Exception for digital content:</strong> By purchasing digital products with immediate delivery, you explicitly consent to the immediate provision of digital content and acknowledge that you thereby waive your 14-day right of withdrawal. This consent is requested during the checkout process.</p>
-        <p>For products where the withdrawal right applies, you may exercise it by contacting us at <a href="mailto:frank@frankx.ai" className="text-violet-400">frank@frankx.ai</a> within 14 days of purchase.</p>
+        <p><strong className="text-white font-semibold">Exception for digital content:</strong> By purchasing digital products with immediate delivery, you explicitly consent to the immediate provision of digital content and acknowledge that you thereby waive your 14-day right of withdrawal. This consent is requested during the checkout process.</p>
+        <p>For products where the withdrawal right applies, you may exercise it by contacting us at <a href="mailto:frank@frankx.ai" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">frank@frankx.ai</a> within 14 days of purchase.</p>
       </Section>
 
       <Section title="6. License Grant">
         <p>Upon purchase, we grant you a personal, non-exclusive, non-transferable license to use the digital product for your own purposes.</p>
-        <p><strong className="text-zinc-300">You may:</strong></p>
-        <ul>
+        <p><strong className="text-white font-semibold">You may:</strong></p>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Use the product for personal and professional projects</li>
           <li>Store copies on your personal devices</li>
           <li>Use templates and prompts in your own work</li>
         </ul>
-        <p><strong className="text-zinc-300">You may not:</strong></p>
-        <ul>
+        <p><strong className="text-white font-semibold">You may not:</strong></p>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Redistribute, resell, or share the product with others</li>
           <li>Claim authorship of the product</li>
           <li>Use the product to create a competing product</li>
@@ -67,7 +91,7 @@ export default function TermsPage() {
 
       <Section title="8. User Conduct">
         <p>You agree not to:</p>
-        <ul>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Use our services for any unlawful purpose</li>
           <li>Attempt to gain unauthorized access to our systems</li>
           <li>Interfere with the proper functioning of our website</li>
@@ -77,7 +101,7 @@ export default function TermsPage() {
 
       <Section title="9. Limitation of Liability">
         <p>To the maximum extent permitted by Dutch law:</p>
-        <ul>
+        <ul className="list-disc pl-5 space-y-1.5">
           <li>Our digital products are provided &ldquo;as is&rdquo; without warranty of any kind</li>
           <li>We are not liable for any indirect, incidental, or consequential damages</li>
           <li>Our total liability is limited to the amount you paid for the specific product</li>
@@ -88,7 +112,7 @@ export default function TermsPage() {
       <Section title="10. Governing Law">
         <p>These Terms are governed by the laws of the Netherlands. Any disputes arising from these Terms shall be submitted to the competent court in Amsterdam, Netherlands.</p>
         <p>For EU consumers: You may also use the Online Dispute Resolution platform at{' '}
-          <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer" className="text-violet-400">
+          <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">
             ec.europa.eu/consumers/odr
           </a>
         </p>
@@ -100,20 +124,20 @@ export default function TermsPage() {
 
       <Section title="12. Contact">
         <p>For questions about these Terms, contact us at{' '}
-          <a href="mailto:frank@frankx.ai" className="text-violet-400">frank@frankx.ai</a>
+          <a href="mailto:frank@frankx.ai" className="text-emerald-400 hover:text-emerald-300 underline decoration-emerald-400/30 underline-offset-4 transition-colors">frank@frankx.ai</a>
         </p>
       </Section>
 
-      <p className="text-zinc-600 text-xs mt-12">Last updated: March 2026</p>
+      <p className="text-white/50 text-sm mt-16 pt-8 border-t border-white/10">Last updated: June 2026</p>
     </article>
   )
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="mt-10">
-      <h2 className="text-xl font-semibold text-zinc-200 mb-3">{title}</h2>
-      <div className="text-zinc-400 text-sm leading-relaxed space-y-3">{children}</div>
+    <section className="mt-14">
+      <h2 className="text-2xl md:text-3xl font-semibold text-white tracking-tight mb-4">{title}</h2>
+      <div className="text-[16px] md:text-[17px] leading-[1.7] text-white/75 space-y-4">{children}</div>
     </section>
   )
 }

--- a/app/soulbook/7-pillars/page.tsx
+++ b/app/soulbook/7-pillars/page.tsx
@@ -336,13 +336,13 @@ export default function SevenPillarsPage() {
             <span className="inline-block px-4 py-2 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-400 text-sm font-medium mb-6">
               The Soulbook Framework
             </span>
-            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white mb-6">
               The 7 Pillars of{' '}
               <span className="bg-gradient-to-r from-amber-400 via-gold-400 to-amber-400 bg-clip-text text-transparent">
                 Conscious Living
               </span>
             </h1>
-            <p className="text-xl text-slate-400 max-w-3xl mx-auto mb-8">
+            <p className="text-[17px] leading-relaxed text-white/80 max-w-3xl mx-auto mb-8">
               A comprehensive framework for building an extraordinary life through
               intentional development across seven interconnected dimensions of human
               excellence.
@@ -360,7 +360,7 @@ export default function SevenPillarsPage() {
       </section>
 
       {/* Pillar Cards Grid */}
-      <section className="py-16 px-4">
+      <section className="py-20 lg:py-28 px-4">
         <div className="max-w-7xl mx-auto">
           <motion.div
             variants={containerVariants}
@@ -381,7 +381,7 @@ export default function SevenPillarsPage() {
       </section>
 
       {/* Bottom CTA */}
-      <section className="py-20 px-4">
+      <section className="py-20 lg:py-28 px-4">
         <div className="max-w-4xl mx-auto">
           <GlassmorphicCard variant="luxury" gradient="aurora" border="glow" className="p-12 text-center">
             <motion.div
@@ -390,10 +390,10 @@ export default function SevenPillarsPage() {
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
             >
-              <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
                 Where to begin
               </h2>
-              <p className="text-slate-400 mb-8 max-w-2xl mx-auto">
+              <p className="text-[17px] leading-relaxed text-white/80 mb-8 max-w-2xl mx-auto">
                 Take the assessment when you're ready — it shows which pillars need
                 attention first.
               </p>

--- a/app/soulbook/golden-path/page.tsx
+++ b/app/soulbook/golden-path/page.tsx
@@ -33,13 +33,13 @@ export default function GoldenPathPage() {
               <span>Accelerated Breakthrough</span>
             </div>
 
-            <h1 className="text-5xl md:text-7xl font-bold font-serif">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] font-serif">
               <span className="bg-gradient-to-r from-purple-300 via-violet-400 to-indigo-400 bg-clip-text text-transparent">
                 Golden Path
               </span>
             </h1>
 
-            <p className="text-xl text-white/70 max-w-2xl leading-relaxed">
+            <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl">
               Your accelerated 4-week breakthrough through the 3 most transformative pillars:
               Consciousness, Emotional Mastery, and Purpose.
             </p>
@@ -63,19 +63,19 @@ export default function GoldenPathPage() {
       </section>
 
       {/* Coming Soon Content */}
-      <section className="py-20 px-6">
+      <section className="py-20 lg:py-28 px-6">
         <div className="max-w-4xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.3 }}
-            className="text-center space-y-8 p-12 rounded-2xl bg-gradient-to-br from-white/5 to-white/0 border border-white/10"
+            className="text-center space-y-8 p-12 rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl"
           >
             <div className="text-6xl">🛤️</div>
-            <h2 className="text-3xl font-bold font-serif text-white">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight font-serif text-white">
               Coming Soon
             </h2>
-            <p className="text-xl text-white/60 max-w-xl mx-auto">
+            <p className="text-[17px] leading-relaxed text-white/80 max-w-xl mx-auto">
               The Golden Path is designed for rapid transformation. Focused, intensive,
               and results-driven. Join the waitlist to secure your spot.
             </p>

--- a/app/soulbook/page.tsx
+++ b/app/soulbook/page.tsx
@@ -30,17 +30,17 @@ const productSchema = {
 
 function PhilosophySection() {
   return (
-    <section className="py-24 px-6 relative">
+    <section className="py-20 lg:py-28 px-6 relative">
       <div className="absolute inset-0 bg-gradient-to-b from-black via-midnight-950 to-black" />
 
       <div className="relative z-10 max-w-6xl mx-auto">
         <div className="text-center mb-16">
-          <h2 className="font-serif text-4xl md:text-5xl font-bold mb-4">
+          <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">
             <span className="bg-gradient-to-r from-amber-200 via-yellow-400 to-amber-500 bg-clip-text text-transparent">
               Our Philosophy
             </span>
           </h2>
-          <p className="text-xl text-white/70 max-w-2xl mx-auto">
+          <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl mx-auto">
             The principles that guide the Soulbook framework and your transformation journey.
           </p>
         </div>
@@ -74,18 +74,18 @@ function PhilosophySection() {
 
 function PricingSection() {
   return (
-    <section className="py-24 px-6 relative">
+    <section className="py-20 lg:py-28 px-6 relative">
       <div className="absolute inset-0 bg-gradient-to-b from-black via-midnight-950 to-black" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_var(--tw-gradient-stops))] from-amber-900/10 via-transparent to-transparent" />
 
       <div className="relative z-10 max-w-7xl mx-auto">
         <div className="text-center mb-16">
-          <h2 className="font-serif text-4xl md:text-5xl font-bold mb-4">
+          <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-4">
             <span className="bg-gradient-to-r from-amber-200 via-yellow-400 to-amber-500 bg-clip-text text-transparent">
               Investment Options
             </span>
           </h2>
-          <p className="text-xl text-white/70 max-w-2xl mx-auto">
+          <p className="text-[17px] leading-relaxed text-white/80 max-w-2xl mx-auto">
             Choose the level of transformation that resonates with your journey.
           </p>
         </div>
@@ -163,7 +163,7 @@ function PricingSection() {
 
 function AssessmentCTA() {
   return (
-    <section className="py-24 px-6 relative overflow-hidden">
+    <section className="py-20 lg:py-28 px-6 relative overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-r from-amber-900/20 via-midnight-950 to-purple-900/20" />
 
       <div className="relative z-10 max-w-4xl mx-auto text-center">
@@ -172,12 +172,12 @@ function AssessmentCTA() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
         >
-          <h2 className="font-serif text-4xl md:text-5xl font-bold mb-6">
+          <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight mb-6">
             <span className="bg-gradient-to-r from-amber-200 via-yellow-400 to-amber-500 bg-clip-text text-transparent">
               Not Sure Where to Start?
             </span>
           </h2>
-          <p className="text-xl text-white/70 mb-8 max-w-2xl mx-auto">
+          <p className="text-[17px] leading-relaxed text-white/80 mb-8 max-w-2xl mx-auto">
             Take our free assessment to discover which Life Book aligns with your current needs and transformation goals.
           </p>
 

--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -139,7 +139,7 @@ export default function StartPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.1 }}
-              className="mb-6 max-w-4xl font-display text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl"
+              className="mb-6 max-w-4xl font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.1] tracking-tight text-white"
             >
               Welcome to the hub.
               <span className="mt-2 block text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 via-cyan-400 to-violet-400">
@@ -151,7 +151,7 @@ export default function StartPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.2 }}
-              className="max-w-2xl text-lg leading-relaxed text-white/40 sm:text-xl"
+              className="max-w-2xl text-[17px] sm:text-xl leading-relaxed text-white/80"
             >
               AI architect by day. Music creator by night.
               Everything I learn and build—shared openly.
@@ -254,7 +254,7 @@ export default function StartPage() {
         <ProductLadder />
 
         {/* Quick Links Section */}
-        <section className="py-16">
+        <section className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -263,8 +263,8 @@ export default function StartPage() {
               transition={{ duration: 0.5 }}
               className="mb-8"
             >
-              <h2 className="text-2xl font-bold text-white">Quick links</h2>
-              <p className="mt-2 text-white/40">More ways to explore</p>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Quick links</h2>
+              <p className="mt-2 text-[17px] leading-relaxed text-white/80">More ways to explore</p>
             </motion.div>
 
             <motion.div
@@ -307,7 +307,7 @@ export default function StartPage() {
         </section>
 
         {/* About CTA */}
-        <section className="py-16 pb-24">
+        <section className="py-20 lg:py-28 pb-24">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -321,17 +321,17 @@ export default function StartPage() {
 
               <div className="relative flex flex-col items-start gap-6 md:flex-row md:items-center md:justify-between">
                 <div className="max-w-xl">
-                  <h2 className="text-2xl font-bold text-white sm:text-3xl">
+                  <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">
                     Want the full story?
                   </h2>
-                  <p className="mt-3 text-white/40">
+                  <p className="mt-3 text-[17px] leading-relaxed text-white/80">
                     Learn about my journey from enterprise architecture to AI music creation,
                     and why I built this hub to share everything openly.
                   </p>
                 </div>
                 <Link
                   href="/about"
-                  className="group inline-flex items-center gap-2 rounded-2xl bg-emerald-500 hover:bg-emerald-600 px-6 py-3 font-semibold text-white transition-all hover:-translate-y-0.5 shadow-lg shadow-emerald-500/20 hover:shadow-xl hover:shadow-emerald-500/30"
+                  className="group inline-flex items-center gap-2 rounded-full bg-emerald-500 hover:bg-emerald-600 px-6 py-3 font-semibold text-white transition-all hover:-translate-y-0.5 shadow-lg shadow-emerald-500/20 hover:shadow-xl hover:shadow-emerald-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   About me
                   <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />


### PR DESCRIPTION
Wave 14 of overnight excellence campaign. 3 commits, 17 hubs polished.

## What ships

### About + Legal premium long-form (commit `d8b9eda9`)
- /about: H1 hit `lg:text-7xl`, 9 H2s upgraded, body `text-[17px]/80`, premium quote card
- /legal/{privacy,terms,refund,imprint}: `max-w-3xl` reading column, body `leading-[1.7]`, redesigned tables with hover states, violet→emerald link palette, 'Last updated' → 2026-06-02, WebPage JSON-LD added
- **Lawyer-locked legal content preserved unchanged**, [DATE] placeholders intact

### Soulbook + Gencreator + Golden-age (commit `da6e9a99`)
- /soulbook + /soulbook/7-pillars + /soulbook/golden-path: spec typography, premium glass Coming Soon card, section padding
- /gencreator: hero polish, 3 section H2s
- /golden-age: 4 H2s + body + section padding, **3 anchor CTAs migrated rounded-2xl → rounded-full with focus-visible rings**

### 9 more Tier-1/2 hubs (commit `bb6e90f3a`)
ai-ops, coaching, community, courses, creators, ecosystem, for/architects, founders-circle, start — all received the spec polish (H1/H2 scale, body lift, CTAs rounded-full + focus-rings, section padding py-20 lg:py-28).

## Pre-flight gates
- `npx tsc --noEmit` → 0 errors ✓
- All 3 commits clean

## Deferred to future deep-work sessions (flagged in commit body)
- /dashboard, /intelligence-system, /starlight-intelligence-system, /intelligence-map — Tier-1 explainer hubs with bespoke layouts
- /agentic-builder-lab, /ai-architect-academy, /agentic-ai-center — long marketing pages
- /tools, /prompt-library — listing surfaces with filter UX

🤖 Generated overnight by Claude Code Opus 4.7