### PR TITLE
polish+refactor(excellence): Wave 20 — ai-architecture split + 10 more hubs polished

### DIFF
--- a/app/ai-architecture/page.tsx
+++ b/app/ai-architecture/page.tsx
@@ -1,592 +1,94 @@
-'use client'
-
-import Link from 'next/link'
-import Image from 'next/image'
-import { motion } from 'framer-motion'
-import {
-  Layers,
-  BookOpen,
-  Play,
-  Package,
-  Wrench,
-  ArrowRight,
-  Shield,
-  Database,
-  Network,
-  Server,
-  Key,
-  ExternalLink,
-  Sparkles,
-  Zap,
-  Globe,
-  Lock,
-} from 'lucide-react'
-
 import prototypesData from '@/data/ai-architecture/prototypes.json'
-import { CATEGORY_META, AI_PROVIDER_META } from '@/types/ai-architecture'
-import type { ArchitecturePrototype, PrototypeCategory, AIProvider } from '@/types/ai-architecture'
+import type { ArchitecturePrototype } from '@/types/ai-architecture'
+import AIArchitectureShell from '@/components/ai-architecture/AIArchitectureShell'
 
+const HUB_URL = 'https://frankx.ai/ai-architecture'
 const blueprints = prototypesData as ArchitecturePrototype[]
+const publishedCount = blueprints.filter((b) => b.status === 'published').length
 
-const hubSections = [
-  {
-    id: 'blueprints',
-    title: 'Blueprints',
-    description: 'Architecture diagrams, implementation guides & production patterns. Free to learn from.',
-    icon: BookOpen,
-    href: '/ai-architecture/blueprints',
-    color: 'cyan',
-    badge: 'FREE',
-    stat: `${blueprints.filter(b => b.status === 'published').length}+ patterns`,
-  },
-  {
-    id: 'prototypes',
-    title: 'Prototypes',
-    description: 'Interactive demos powered by your own API keys. Test patterns before building.',
-    icon: Play,
-    href: '/ai-architecture/prototypes',
-    color: 'violet',
-    badge: 'BYOK',
-    stat: 'Live demos',
-  },
-  {
-    id: 'templates',
-    title: 'Templates',
-    description: 'Production-ready starter kits with one-click deploy to Vercel, Railway, or OCI.',
-    icon: Package,
-    href: '/ai-architecture/templates',
-    color: 'emerald',
-    badge: '$29+',
-    stat: 'Ship faster',
-  },
-  {
-    id: 'tools',
-    title: 'Tools',
-    description: 'Curated collection of frameworks, databases, platforms & developer resources.',
-    icon: Wrench,
-    href: '/ai-architecture/tools',
-    color: 'amber',
-    badge: null,
-    stat: '30+ tools',
-  },
-]
-
-const categoryIcons: Record<PrototypeCategory, typeof Shield> = {
-  'ai-gateway': Shield,
-  'rag-production': Database,
-  'multi-agent-orchestration': Network,
-  'mcp-servers': Server,
-  'llm-ops': Wrench,
-  'vector-databases': Layers,
-  'ai-coe': BookOpen,
-  'security-governance': Shield,
-  'cost-optimization': Sparkles,
-  'observability': Play,
-}
-
-const colorMap: Record<string, { bg: string; border: string; icon: string; badge: string; glow: string }> = {
-  cyan: {
-    bg: 'bg-cyan-500/[0.06]',
-    border: 'border-cyan-500/20 hover:border-cyan-400/40',
-    icon: 'bg-cyan-500/15 text-cyan-400',
-    badge: 'bg-cyan-500/15 text-cyan-400 border border-cyan-500/25',
-    glow: 'group-hover:shadow-[0_8px_30px_rgba(6,182,212,0.12)]',
-  },
-  violet: {
-    bg: 'bg-violet-500/[0.06]',
-    border: 'border-violet-500/20 hover:border-violet-400/40',
-    icon: 'bg-violet-500/15 text-violet-400',
-    badge: 'bg-violet-500/15 text-violet-400 border border-violet-500/25',
-    glow: 'group-hover:shadow-[0_8px_30px_rgba(139,92,246,0.12)]',
-  },
-  emerald: {
-    bg: 'bg-emerald-500/[0.06]',
-    border: 'border-emerald-500/20 hover:border-emerald-400/40',
-    icon: 'bg-emerald-500/15 text-emerald-400',
-    badge: 'bg-emerald-500/15 text-emerald-400 border border-emerald-500/25',
-    glow: 'group-hover:shadow-[0_8px_30px_rgba(16,185,129,0.12)]',
-  },
-  amber: {
-    bg: 'bg-amber-500/[0.06]',
-    border: 'border-amber-500/20 hover:border-amber-400/40',
-    icon: 'bg-amber-500/15 text-amber-400',
-    badge: 'bg-amber-500/15 text-amber-400 border border-amber-500/25',
-    glow: 'group-hover:shadow-[0_8px_30px_rgba(245,158,11,0.12)]',
-  },
-}
-
-const staggerChild = {
-  hidden: { opacity: 0, y: 24 },
-  show: { opacity: 1, y: 0 },
-}
-
-const staggerContainer = {
-  hidden: { opacity: 0 },
-  show: {
-    opacity: 1,
-    transition: { staggerChildren: 0.08, delayChildren: 0.1 },
-  },
-}
-
-function HubBackground() {
-  return (
-    <div className="fixed inset-0 -z-10 overflow-hidden" aria-hidden>
-      <div className="absolute inset-0 bg-[#0a0a0b]" />
-      {/* Grid pattern */}
-      <div
-        className="absolute inset-0 opacity-[0.02]"
-        style={{
-          backgroundImage: `
-            linear-gradient(rgba(6, 182, 212, 0.5) 1px, transparent 1px),
-            linear-gradient(90deg, rgba(6, 182, 212, 0.5) 1px, transparent 1px)
-          `,
-          backgroundSize: '80px 80px',
-        }}
-      />
-      {/* Ambient orbs */}
-      <motion.div
-        className="absolute -right-60 top-20 h-[600px] w-[600px] rounded-full"
-        style={{
-          background: 'radial-gradient(circle, rgba(6,182,212,0.15) 0%, transparent 70%)',
-        }}
-        animate={{ scale: [1, 1.08, 1], opacity: [0.5, 0.35, 0.5] }}
-        transition={{ duration: 20, repeat: Infinity, ease: 'easeInOut' }}
-      />
-      <motion.div
-        className="absolute -left-40 bottom-40 h-[500px] w-[500px] rounded-full"
-        style={{
-          background: 'radial-gradient(circle, rgba(139,92,246,0.12) 0%, transparent 70%)',
-        }}
-        animate={{ scale: [1.08, 1, 1.08], opacity: [0.35, 0.5, 0.35] }}
-        transition={{ duration: 25, repeat: Infinity, ease: 'easeInOut' }}
-      />
-    </div>
-  )
-}
-
-function SectionCard({
-  section,
-}: {
-  section: (typeof hubSections)[0]
-}) {
-  const Icon = section.icon
-  const colors = colorMap[section.color]
-
-  return (
-    <motion.div variants={staggerChild}>
-      <Link href={section.href} className="group block h-full">
-        <div
-          className={`relative h-full rounded-2xl border ${colors.border} ${colors.bg} p-6 backdrop-blur-sm transition-all duration-300 group-hover:-translate-y-1 ${colors.glow}`}
-        >
-          {/* Noise texture overlay */}
-          <div className="pointer-events-none absolute inset-0 rounded-2xl opacity-30" style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Ccircle cx='7' cy='7' r='1'/%3E%3Ccircle cx='27' cy='27' r='1'/%3E%3Ccircle cx='47' cy='47' r='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`
-          }} aria-hidden />
-
-          <div className="relative z-10">
-            <div className="flex items-start justify-between">
-              <div className={`flex h-12 w-12 items-center justify-center rounded-xl ${colors.icon} transition-transform duration-300 group-hover:scale-105`}>
-                <Icon className="h-6 w-6" />
-              </div>
-              {section.badge && (
-                <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${colors.badge}`}>
-                  {section.badge}
-                </span>
-              )}
-            </div>
-            <h3 className="mt-4 text-lg font-bold text-white">{section.title}</h3>
-            <p className="mt-1.5 text-sm leading-relaxed text-slate-400">{section.description}</p>
-            <div className="mt-5 flex items-center justify-between">
-              <span className="text-xs font-medium text-slate-500">{section.stat}</span>
-              <div className="flex items-center gap-1 text-sm text-slate-500 transition-colors group-hover:text-white">
-                <span>Explore</span>
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </Link>
-    </motion.div>
-  )
-}
-
-function BlueprintCard({ blueprint, index }: { blueprint: ArchitecturePrototype; index: number }) {
-  const Icon = categoryIcons[blueprint.category] || Layers
-  const categoryMeta = CATEGORY_META[blueprint.category]
-
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.4, delay: index * 0.08 }}
-    >
-      <Link href={`/blueprint/${blueprint.slug}`} className="group block h-full">
-        <div className="relative h-full rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 backdrop-blur-sm transition-all duration-300 hover:border-white/15 hover:bg-white/[0.06] group-hover:-translate-y-0.5 group-hover:shadow-lg group-hover:shadow-cyan-500/[0.05]">
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-500/15 text-cyan-400">
-              <Icon className="h-5 w-5" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <h4 className="font-semibold text-white truncate">{blueprint.title}</h4>
-              <p className="text-[11px] font-medium uppercase tracking-wider text-slate-500">{categoryMeta?.name}</p>
-            </div>
-          </div>
-          <p className="mt-3 text-sm leading-relaxed text-slate-400 line-clamp-2">{blueprint.subtitle}</p>
-          <div className="mt-4 flex items-center justify-between">
-            <div className="flex items-center gap-1.5">
-              {blueprint.cloudProviders.slice(0, 3).map((provider) => (
-                <span
-                  key={provider}
-                  className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-slate-500"
-                >
-                  {provider.toUpperCase()}
-                </span>
-              ))}
-              {blueprint.cloudProviders.length > 3 && (
-                <span className="text-[10px] text-slate-600">+{blueprint.cloudProviders.length - 3}</span>
-              )}
-            </div>
-            <ArrowRight className="h-4 w-4 text-slate-600 transition-all group-hover:translate-x-1 group-hover:text-cyan-400" />
-          </div>
-        </div>
-      </Link>
-    </motion.div>
-  )
-}
-
-function ProviderButton({ provider }: { provider: AIProvider }) {
-  const meta = AI_PROVIDER_META[provider]
-  const providerColors: Record<string, string> = {
-    orange: 'border-orange-500/25 hover:border-orange-400/50 hover:bg-orange-500/10',
-    emerald: 'border-emerald-500/25 hover:border-emerald-400/50 hover:bg-emerald-500/10',
-    blue: 'border-blue-500/25 hover:border-blue-400/50 hover:bg-blue-500/10',
-    red: 'border-red-500/25 hover:border-red-400/50 hover:bg-red-500/10',
-  }
-
-  return (
-    <a
-      href={meta.keyUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={`flex items-center gap-2 rounded-lg border bg-white/[0.02] px-3 py-2 text-sm text-slate-400 transition-all hover:text-white ${providerColors[meta.color]}`}
-    >
-      <Key className="h-3.5 w-3.5" />
-      <span className="font-medium">{meta.shortName}</span>
-      <ExternalLink className="h-3 w-3 opacity-40" />
-    </a>
-  )
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'CollectionPage',
+      '@id': `${HUB_URL}#page`,
+      url: HUB_URL,
+      name: 'AI Architecture Hub | FrankX',
+      description:
+        'Production-ready AI architecture patterns. Explore blueprints, test with your own API keys, and deploy with starter templates. Cloud-agnostic patterns that work everywhere.',
+      isPartOf: { '@id': 'https://frankx.ai/#website' },
+      about: [
+        { '@type': 'Thing', name: 'AI Architecture' },
+        { '@type': 'Thing', name: 'LLM Applications' },
+        { '@type': 'Thing', name: 'Agent Orchestration' },
+        { '@type': 'Thing', name: 'RAG' },
+        { '@type': 'Thing', name: 'MCP Servers' },
+      ],
+      mainEntity: {
+        '@type': 'ItemList',
+        name: 'AI Architecture Sections',
+        numberOfItems: 4,
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Blueprints',
+            url: `${HUB_URL}/blueprints`,
+            description: `${publishedCount}+ production architecture patterns, free to learn from.`,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Prototypes',
+            url: `${HUB_URL}/prototypes`,
+            description: 'Interactive BYOK demos to test patterns before building.',
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: 'Templates',
+            url: `${HUB_URL}/templates`,
+            description: 'Production-ready starter kits with one-click deploy.',
+          },
+          {
+            '@type': 'ListItem',
+            position: 4,
+            name: 'Tools',
+            url: `${HUB_URL}/tools`,
+            description: 'Curated frameworks, databases, platforms & developer resources.',
+          },
+        ],
+      },
+    },
+    {
+      '@type': 'Service',
+      '@id': `${HUB_URL}#service`,
+      name: 'AI Architecture Reference',
+      provider: { '@type': 'Person', name: 'Frank Riemer', url: 'https://frankx.ai' },
+      areaServed: 'Worldwide',
+      serviceType: 'AI System Design',
+      description:
+        'Cloud-agnostic AI architecture patterns spanning RAG, multi-agent orchestration, MCP servers, AI gateways, vector databases, and LLM ops.',
+      url: HUB_URL,
+    },
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://frankx.ai' },
+        { '@type': 'ListItem', position: 2, name: 'AI Architecture', item: HUB_URL },
+      ],
+    },
+  ],
 }
 
 export default function AIArchitectureHubPage() {
-  const publishedBlueprints = blueprints.filter((b) => b.status === 'published').slice(0, 6)
-
   return (
     <>
-      <HubBackground />
-      <main className="relative min-h-screen">
-        {/* Hero */}
-        <section className="pt-32 pb-20 lg:pb-28 sm:pt-36">
-          <div className="mx-auto max-w-6xl px-6">
-            <motion.div
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.5 }}
-              className="mb-6 flex items-center gap-4"
-            >
-              <Image
-                src="/images/team/codex-falcon.png"
-                alt="Codex — AI Architecture Specialist"
-                width={64}
-                height={64}
-                priority
-                className="rounded-2xl"
-                style={{ boxShadow: '0 0 30px -6px rgba(16,185,129,0.4)' }}
-              />
-              <div className="inline-flex items-center gap-2.5 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 backdrop-blur-sm">
-                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-gradient-to-br from-cyan-500/30 to-violet-500/30">
-                  <Layers className="h-3.5 w-3.5 text-white" />
-                </div>
-                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-                  AI Architecture Hub
-                </span>
-              </div>
-            </motion.div>
-
-            <motion.h1
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.08 }}
-              className="mb-6 max-w-4xl font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white"
-            >
-              Learn. Try.{' '}
-              <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-emerald-400 bg-clip-text text-transparent">
-                Build.
-              </span>
-            </motion.h1>
-
-            <motion.p
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.16 }}
-              className="mb-10 max-w-2xl text-[17px] leading-relaxed text-white/80"
-            >
-              Production-ready AI architecture patterns. Explore blueprints, test with your own API
-              keys, and deploy with starter templates. Cloud-agnostic patterns that work everywhere.
-            </motion.p>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.24 }}
-              className="flex flex-wrap gap-4"
-            >
-              <Link
-                href="/ai-architecture/blueprints"
-                className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
-              >
-                <BookOpen className="h-4 w-4" />
-                Browse Blueprints
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-              </Link>
-              <Link
-                href="/ai-architecture/prototypes"
-                className="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
-              >
-                <Play className="h-4 w-4" />
-                Try Prototypes
-              </Link>
-            </motion.div>
-          </div>
-        </section>
-
-        {/* Journey Steps - Visual progression */}
-        <section className="py-6">
-          <div className="mx-auto max-w-6xl px-6">
-            <motion.div
-              initial={{ opacity: 0, scaleX: 0 }}
-              animate={{ opacity: 1, scaleX: 1 }}
-              transition={{ duration: 0.8, delay: 0.4 }}
-              className="flex items-center justify-center gap-3 text-xs font-medium text-slate-500"
-            >
-              <span className="flex items-center gap-1.5">
-                <BookOpen className="h-3.5 w-3.5 text-cyan-400" />
-                Learn
-              </span>
-              <div className="h-px w-12 bg-gradient-to-r from-cyan-500/40 to-violet-500/40" />
-              <span className="flex items-center gap-1.5">
-                <Play className="h-3.5 w-3.5 text-violet-400" />
-                Try
-              </span>
-              <div className="h-px w-12 bg-gradient-to-r from-violet-500/40 to-emerald-500/40" />
-              <span className="flex items-center gap-1.5">
-                <Zap className="h-3.5 w-3.5 text-emerald-400" />
-                Build
-              </span>
-            </motion.div>
-          </div>
-        </section>
-
-        {/* Hub Navigation Cards */}
-        <section className="py-20 lg:py-28">
-          <div className="mx-auto max-w-6xl px-6">
-            <motion.div
-              variants={staggerContainer}
-              initial="hidden"
-              animate="show"
-              className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4"
-            >
-              {hubSections.map((section) => (
-                <SectionCard key={section.id} section={section} />
-              ))}
-            </motion.div>
-          </div>
-        </section>
-
-        {/* BYOK Section */}
-        <section className="py-20 lg:py-28 border-y border-white/[0.04]">
-          <div className="mx-auto max-w-6xl px-6">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5 }}
-              className="relative overflow-hidden rounded-2xl border border-violet-500/15 bg-violet-500/[0.04] p-8 backdrop-blur-sm"
-            >
-              {/* Subtle glow */}
-              <div className="pointer-events-none absolute -right-20 -top-20 h-40 w-40 rounded-full bg-violet-500/10 blur-3xl" aria-hidden />
-
-              <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-                <div className="flex-1">
-                  <div className="mb-3 flex items-center gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-500/15">
-                      <Lock className="h-5 w-5 text-violet-400" />
-                    </div>
-                    <div>
-                      <h3 className="text-lg font-bold text-white">Bring Your Own Key</h3>
-                      <p className="text-xs font-medium text-violet-400/80">Zero cost to us. Full control to you.</p>
-                    </div>
-                  </div>
-                  <p className="max-w-xl text-[17px] leading-relaxed text-white/80">
-                    Try prototypes using your own API keys. Keys stay in your browser localStorage —
-                    never sent to our servers. Works with any provider. You control costs.
-                  </p>
-                </div>
-                <div className="flex flex-wrap gap-2.5">
-                  <ProviderButton provider="anthropic" />
-                  <ProviderButton provider="openai" />
-                  <ProviderButton provider="google" />
-                  <ProviderButton provider="oci" />
-                </div>
-              </div>
-            </motion.div>
-          </div>
-        </section>
-
-        {/* Featured Blueprints */}
-        <section className="py-20 lg:py-28">
-          <div className="mx-auto max-w-6xl px-6">
-            <div className="mb-10 flex items-end justify-between">
-              <div>
-                <motion.p
-                  initial={{ opacity: 0 }}
-                  whileInView={{ opacity: 1 }}
-                  viewport={{ once: true }}
-                  className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400"
-                >
-                  Architecture Patterns
-                </motion.p>
-                <motion.h2
-                  initial={{ opacity: 0, y: 12 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true }}
-                  className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white"
-                >
-                  Featured Blueprints
-                </motion.h2>
-                <motion.p
-                  initial={{ opacity: 0, y: 12 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true }}
-                  transition={{ delay: 0.1 }}
-                  className="mt-3 text-[17px] leading-relaxed text-white/80"
-                >
-                  Production-ready patterns with diagrams, guides & cost estimates
-                </motion.p>
-              </div>
-              <Link
-                href="/ai-architecture/blueprints"
-                className="hidden items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-slate-400 transition-all hover:border-white/20 hover:text-white sm:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
-              >
-                View all
-                <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
-
-            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              {publishedBlueprints.map((blueprint, index) => (
-                <BlueprintCard key={blueprint.id} blueprint={blueprint} index={index} />
-              ))}
-            </div>
-
-            <div className="mt-6 flex justify-center sm:hidden">
-              <Link
-                href="/ai-architecture/blueprints"
-                className="flex items-center gap-1.5 text-sm font-medium text-cyan-400 hover:text-cyan-300"
-              >
-                View all blueprints
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        {/* Templates Teaser */}
-        <section className="py-20 lg:py-28 border-t border-white/[0.04]">
-          <div className="mx-auto max-w-6xl px-6">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              className="relative overflow-hidden rounded-2xl border border-emerald-500/15 bg-emerald-500/[0.04] backdrop-blur-xl p-8 sm:p-10 text-center"
-            >
-              {/* Decorative glow */}
-              <div className="pointer-events-none absolute left-1/2 top-0 h-32 w-64 -translate-x-1/2 bg-emerald-500/10 blur-3xl" aria-hidden />
-
-              <div className="relative">
-                <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/15 text-emerald-400">
-                  <Package className="h-7 w-7" />
-                </div>
-                <h3 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Starter Templates</h3>
-                <p className="mx-auto mb-8 max-w-lg text-[17px] leading-relaxed text-white/80">
-                  Production-ready starter kits with one-click deploy. From RAG pipelines
-                  to multi-agent frameworks — ship in hours, not weeks.
-                </p>
-                <div className="flex flex-wrap justify-center gap-3 mb-8">
-                  {[
-                    { name: 'RAG Starter Kit', price: '$49' },
-                    { name: 'Multi-Agent Framework', price: '$99' },
-                    { name: 'AI Chat Widget', price: '$29' },
-                    { name: 'MCP Server Kit', price: '$39' },
-                  ].map((template) => (
-                    <span
-                      key={template.name}
-                      className="rounded-full border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-2 text-sm text-emerald-400"
-                    >
-                      {template.name} <span className="text-emerald-500/60">•</span> {template.price}
-                    </span>
-                  ))}
-                </div>
-                <Link
-                  href="/ai-architecture/templates"
-                  className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-emerald-400 hover:shadow-lg hover:shadow-emerald-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
-                >
-                  Browse Templates
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              </div>
-            </motion.div>
-          </div>
-        </section>
-
-        {/* Cloud Agnostic */}
-        <section className="py-20 lg:py-28">
-          <div className="mx-auto max-w-6xl px-6 text-center">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-            >
-              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.06] text-white">
-                <Globe className="h-6 w-6" />
-              </div>
-              <h2 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Cloud-Agnostic Patterns</h2>
-              <p className="mx-auto mb-10 max-w-lg text-[17px] leading-relaxed text-white/80">
-                Learn the pattern once, deploy anywhere. All blueprints and templates
-                work across major cloud providers.
-              </p>
-            </motion.div>
-            <div className="flex flex-wrap justify-center gap-4">
-              {[
-                { name: 'AWS', color: 'border-orange-500/20 text-orange-400 bg-orange-500/[0.06]' },
-                { name: 'GCP', color: 'border-blue-500/20 text-blue-400 bg-blue-500/[0.06]' },
-                { name: 'Azure', color: 'border-cyan-500/20 text-cyan-400 bg-cyan-500/[0.06]' },
-                { name: 'OCI', color: 'border-red-500/20 text-red-400 bg-red-500/[0.06]' },
-              ].map((cloud) => (
-                <motion.div
-                  key={cloud.name}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  viewport={{ once: true }}
-                  className={`rounded-xl border px-8 py-4 text-sm font-semibold ${cloud.color}`}
-                >
-                  {cloud.name}
-                </motion.div>
-              ))}
-            </div>
-          </div>
-        </section>
-      </main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <AIArchitectureShell />
     </>
   )
 }

--- a/app/ai-art/page.tsx
+++ b/app/ai-art/page.tsx
@@ -582,7 +582,7 @@ export default function AIArtGalleryPage() {
               AI-Generated Art Gallery
             </div>
 
-            <h1 className="text-5xl md:text-6xl font-bold text-white mb-6">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-6">
               AI Visual{' '}
               <span className="bg-gradient-to-r from-emerald-400 to-cyan-400 bg-clip-text text-transparent">
                 Lab
@@ -629,7 +629,7 @@ export default function AIArtGalleryPage() {
           viewport={{ once: true }}
           className="bg-gradient-to-br from-emerald-500/10 to-amber-500/10 rounded-3xl border border-white/10 p-12"
         >
-          <h2 className="text-3xl font-bold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
             Create Your Own AI Art
           </h2>
           <p className="text-white/60 mb-8 max-w-xl mx-auto">

--- a/app/ai-world/page.tsx
+++ b/app/ai-world/page.tsx
@@ -305,7 +305,7 @@ export default function IntelligenceAtlasPage() {
           {/* Title */}
           <motion.h1
             variants={itemVariants}
-            className="text-5xl sm:text-6xl lg:text-7xl font-bold leading-tight mb-6"
+            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-tight mb-6"
           >
             <span className="text-white">The </span>
             <span className="bg-gradient-to-r from-purple-400 via-cyan-400 to-amber-400 bg-clip-text text-transparent">
@@ -351,7 +351,7 @@ export default function IntelligenceAtlasPage() {
       </motion.header>
 
       {/* Interactive Constellation Section */}
-      <section className="relative py-24 px-6">
+      <section className="relative py-20 lg:py-28 px-6">
         <div className="max-w-7xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -360,7 +360,7 @@ export default function IntelligenceAtlasPage() {
             viewport={{ once: true }}
             className="text-center mb-16"
           >
-            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
               Map the Constellations
             </h2>
             <p className="text-slate-400 max-w-2xl mx-auto">
@@ -483,7 +483,7 @@ export default function IntelligenceAtlasPage() {
       </section>
 
       {/* Interactive Graph Section */}
-      <section className="relative py-24 px-6 border-t border-white/5">
+      <section className="relative py-20 lg:py-28 px-6 border-t border-white/5">
         <div className="max-w-7xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -492,7 +492,7 @@ export default function IntelligenceAtlasPage() {
             viewport={{ once: true }}
             className="text-center mb-12"
           >
-            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
               Explore the Neural Network
             </h2>
             <p className="text-slate-400 max-w-2xl mx-auto">
@@ -506,7 +506,7 @@ export default function IntelligenceAtlasPage() {
       </section>
 
       {/* Philosophy Section */}
-      <section className="relative py-24 px-6 border-t border-white/5">
+      <section className="relative py-20 lg:py-28 px-6 border-t border-white/5">
         <div className="max-w-4xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -515,7 +515,7 @@ export default function IntelligenceAtlasPage() {
             viewport={{ once: true }}
             className="text-center"
           >
-            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-6">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6">
               The Luminor Philosophy
             </h2>
             <p className="text-lg text-slate-300 leading-relaxed mb-8">

--- a/app/design/page.tsx
+++ b/app/design/page.tsx
@@ -163,7 +163,7 @@ function SectionHeader({ eyebrow, title, deck }: { eyebrow: string; title: strin
   return (
     <div className="mb-10">
       <p className="text-[11px] tracking-[0.25em] uppercase text-emerald-400/60 font-medium mb-3">{eyebrow}</p>
-      <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight mb-3">{title}</h2>
+      <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white tracking-tight mb-3">{title}</h2>
       {deck && <p className="text-base text-white/60 max-w-2xl">{deck}</p>}
     </div>
   );
@@ -213,7 +213,7 @@ export default function DesignPage() {
             Built on Google Labs DESIGN.md (alpha · Apache 2.0)
           </Link>
 
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6">
             The FrankX
             <br />
             <span className="bg-gradient-to-r from-emerald-300 via-cyan-200 to-amber-300 bg-clip-text text-transparent">
@@ -263,7 +263,7 @@ export default function DesignPage() {
       </section>
 
       {/* FOUNDATION */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <SectionHeader
             eyebrow="01 · Foundation"
@@ -282,7 +282,7 @@ export default function DesignPage() {
       </section>
 
       {/* INK */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <SectionHeader
             eyebrow="02 · Ink"
@@ -304,7 +304,7 @@ export default function DesignPage() {
       </section>
 
       {/* COLOR SPECTRUMS */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <SectionHeader
             eyebrow="03 · Spectrums"
@@ -359,7 +359,7 @@ export default function DesignPage() {
       </section>
 
       {/* TYPOGRAPHY */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <SectionHeader
             eyebrow="04 · Typography"
@@ -389,7 +389,7 @@ export default function DesignPage() {
       </section>
 
       {/* SPACING + ROUNDED */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <div className="grid lg:grid-cols-2 gap-16">
             {/* Spacing */}
@@ -427,7 +427,7 @@ export default function DesignPage() {
       </section>
 
       {/* COMPONENTS */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <SectionHeader
             eyebrow="07 · Components"
@@ -502,7 +502,7 @@ export default function DesignPage() {
       </section>
 
       {/* DO'S AND DON'TS */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <SectionHeader eyebrow="08 · Compass" title="Do's and Don'ts" />
           <div className="grid md:grid-cols-2 gap-6">
@@ -539,7 +539,7 @@ export default function DesignPage() {
       </section>
 
       {/* TASTE PULL-QUOTE */}
-      <section className="py-20 lg:py-24 border-b border-white/5">
+      <section className="py-20 lg:py-28 border-b border-white/5">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
           <p className="text-[11px] tracking-[0.25em] uppercase text-amber-400/60 font-medium mb-6">
             From taste.md

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -498,7 +498,7 @@ export default function GalleryPage() {
                   AI Visual Gallery
                 </div>
 
-                <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 tracking-tight">
+                <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-6 tracking-tight">
                   The{' '}
                   <span className="bg-gradient-to-r from-cyan-400 via-purple-400 to-amber-400 bg-clip-text text-transparent">
                     Gallery
@@ -538,7 +538,7 @@ export default function GalleryPage() {
       {/* Featured Strip */}
       <section className="max-w-7xl mx-auto px-6 mb-16">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-white">Top Rated</h2>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">Top Rated</h2>
           <span className="text-xs text-white/30 uppercase tracking-wider">
             Score 8.5+
           </span>
@@ -586,7 +586,7 @@ export default function GalleryPage() {
       {/* Sub-Collections */}
       {collections.length > 0 && (
         <section className="max-w-7xl mx-auto px-6 mb-16">
-          <h2 className="text-2xl font-bold text-white mb-6">Collections</h2>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6">Collections</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {collections.map((collection, index) => (
               <CollectionCard
@@ -603,7 +603,7 @@ export default function GalleryPage() {
       <section className="max-w-7xl mx-auto px-6 pb-24">
         <div className="border-t border-white/10 pt-16 mb-8">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-3xl font-bold text-white">All Artworks</h2>
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">All Artworks</h2>
             <span className="text-white/30 text-sm">
               {filteredArtworks.length} results
             </span>

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -105,7 +105,7 @@ function HeroSection() {
               <span className="text-sm font-medium text-violet-300">Games Lab</span>
             </div>
 
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight mb-6">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-semibold tracking-tight mb-6">
               <span className="text-white">Browser games</span>
               <br />
               <span className="font-serif-italic text-white/80">built with AI</span>
@@ -207,7 +207,7 @@ function PlayNowSection() {
   }
 
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -215,7 +215,7 @@ function PlayNowSection() {
           viewport={{ once: true }}
           className="mb-12"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             Play now
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -341,7 +341,7 @@ const tierColors: Record<string, { border: string; text: string; bg: string; bad
 
 function WhatWeCanBuildSection() {
   return (
-    <section className="relative py-24 px-6">
+    <section className="relative py-20 lg:py-28 px-6">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -349,7 +349,7 @@ function WhatWeCanBuildSection() {
           viewport={{ once: true }}
           className="mb-16"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             What we can actually build
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -461,7 +461,7 @@ function TechStackSection() {
   ]
 
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -469,7 +469,7 @@ function TechStackSection() {
           viewport={{ once: true }}
           className="mb-16"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             Tech stack assessment
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -534,7 +534,7 @@ function VercelCompatSection() {
   ]
 
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -542,7 +542,7 @@ function VercelCompatSection() {
           viewport={{ once: true }}
           className="mb-16"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             What works on Vercel
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -631,7 +631,7 @@ function AgenticPipelineSection() {
   }
 
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -639,7 +639,7 @@ function AgenticPipelineSection() {
           viewport={{ once: true }}
           className="mb-16"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             Agentic game development pipeline
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -707,7 +707,7 @@ function MonetizationSection() {
   ]
 
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -715,7 +715,7 @@ function MonetizationSection() {
           viewport={{ once: true }}
           className="mb-16"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             Monetization strategy
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -767,7 +767,7 @@ function AIToolsSection() {
   ]
 
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -775,7 +775,7 @@ function AIToolsSection() {
           viewport={{ once: true }}
           className="mb-16"
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             AI tools for game development
           </h2>
           <p className="text-white/50 max-w-2xl text-lg">
@@ -816,14 +816,14 @@ function AIToolsSection() {
 
 function CTASection() {
   return (
-    <section className="relative py-24 px-6 border-t border-white/[0.04]">
+    <section className="relative py-20 lg:py-28 px-6 border-t border-white/[0.04]">
       <div className="max-w-3xl mx-auto text-center">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
         >
-          <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white mb-4">
             The research behind the games
           </h2>
           <p className="text-white/50 text-lg mb-8 max-w-xl mx-auto">

--- a/app/investor/page.tsx
+++ b/app/investor/page.tsx
@@ -270,7 +270,7 @@ export default function InvestorHubPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.08 }}
-              className="mb-6 max-w-4xl font-display text-4xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl lg:text-6xl"
+              className="mb-6 max-w-4xl font-display text-4xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl"
             >
               Your AI{' '}
               <span className="bg-gradient-to-r from-amber-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent">
@@ -341,7 +341,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* Platforms I Use */}
-        <section id="platforms" className="py-12">
+        <section id="platforms" className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -352,7 +352,7 @@ export default function InvestorHubPage() {
               <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-400">
                 What I Use Daily
               </p>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl">
+              <h2 className="text-3xl font-bold text-white sm:text-4xl lg:text-5xl">
                 Investment Platforms
               </h2>
               <p className="mt-2 max-w-lg text-slate-400">
@@ -384,7 +384,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* AI Research Stack */}
-        <section id="ai-tools" className="border-y border-white/[0.04] py-12">
+        <section id="ai-tools" className="border-y border-white/[0.04] py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -395,7 +395,7 @@ export default function InvestorHubPage() {
               <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400">
                 AI-Powered Research
               </p>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl">
+              <h2 className="text-3xl font-bold text-white sm:text-4xl lg:text-5xl">
                 Your Research Stack
               </h2>
               <p className="mt-2 max-w-lg text-slate-400">
@@ -427,7 +427,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* Hub Navigation Cards */}
-        <section className="py-12">
+        <section className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               variants={staggerContainer}
@@ -443,7 +443,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* Value Ladder */}
-        <section className="border-y border-white/[0.04] py-12">
+        <section className="border-y border-white/[0.04] py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -454,7 +454,7 @@ export default function InvestorHubPage() {
               <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-amber-400">
                 Investment in Your Edge
               </p>
-              <h2 className="text-2xl font-bold text-white sm:text-3xl">
+              <h2 className="text-3xl font-bold text-white sm:text-4xl lg:text-5xl">
                 Choose Your Level
               </h2>
             </motion.div>
@@ -490,7 +490,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* Featured Products */}
-        <section className="py-16">
+        <section className="py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6">
             <div className="mb-10 flex items-end justify-between">
               <div>
@@ -506,7 +506,7 @@ export default function InvestorHubPage() {
                   initial={{ opacity: 0, y: 12 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
-                  className="text-2xl font-bold text-white sm:text-3xl"
+                  className="text-3xl font-bold text-white sm:text-4xl lg:text-5xl"
                 >
                   Featured Products
                 </motion.h2>
@@ -548,7 +548,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* Built For Section */}
-        <section className="border-t border-white/[0.04] py-16">
+        <section className="border-t border-white/[0.04] py-20 lg:py-28">
           <div className="mx-auto max-w-6xl px-6 text-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -590,7 +590,7 @@ export default function InvestorHubPage() {
         </section>
 
         {/* CTA */}
-        <section className="border-t border-white/[0.04] py-16">
+        <section className="border-t border-white/[0.04] py-20 lg:py-28">
           <div className="mx-auto max-w-4xl px-6 text-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}

--- a/app/magic/page.tsx
+++ b/app/magic/page.tsx
@@ -209,7 +209,7 @@ export default function MagicPage() {
               transition={{ duration: 0.6, delay: 0.1 }}
               className="text-center mb-6"
             >
-              <span className="block text-5xl sm:text-6xl lg:text-7xl font-bold text-white mb-4">
+              <span className="block text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-4">
                 Arcanea
               </span>
               <span className="block text-2xl sm:text-3xl lg:text-4xl font-serif italic text-white/60">
@@ -283,7 +283,7 @@ export default function MagicPage() {
               viewport={{ once: true }}
               className="text-center mb-16"
             >
-              <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
                 Three Realms, One Vision
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
@@ -334,7 +334,7 @@ export default function MagicPage() {
         </section>
 
         {/* The Luminors */}
-        <section className="py-20 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -345,7 +345,7 @@ export default function MagicPage() {
               <span className="text-sm font-medium uppercase tracking-[0.25em] text-pink-400/80 mb-3 block">
                 AI Companions
               </span>
-              <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
                 Meet the Luminors
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
@@ -382,7 +382,7 @@ export default function MagicPage() {
         </section>
 
         {/* Philosophy */}
-        <section className="py-20 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-6xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -390,7 +390,7 @@ export default function MagicPage() {
               viewport={{ once: true }}
               className="text-center mb-16"
             >
-              <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
                 The Arcanean Philosophy
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
@@ -426,7 +426,7 @@ export default function MagicPage() {
         </section>
 
         {/* The Connection to FrankX */}
-        <section className="py-20 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="mx-auto max-w-4xl px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -434,7 +434,7 @@ export default function MagicPage() {
               viewport={{ once: true }}
               className="text-center"
             >
-              <h2 className="text-3xl sm:text-4xl font-bold text-white mb-6">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6">
                 Why Arcanea?
               </h2>
               <div className="prose prose-lg prose-invert mx-auto text-slate-300">
@@ -483,7 +483,7 @@ export default function MagicPage() {
               <div className="absolute -left-20 -bottom-20 h-60 w-60 rounded-full bg-gradient-to-br from-cyan-500/20 to-violet-500/20 blur-3xl" />
 
               <div className="relative">
-                <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+                <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
                   Where to next?
                 </h2>
                 <p className="text-lg text-slate-300 mb-8 max-w-xl mx-auto">

--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -155,7 +155,7 @@ function HeroSection() {
             </span>
           </div>
 
-          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 tracking-tight leading-[1.1]">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-6 tracking-tight leading-[1.1]">
             The
             <span className="block bg-gradient-to-r from-violet-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent">
               Plan
@@ -225,7 +225,7 @@ function FeaturedSpotlight() {
         >
           <div className="flex items-center gap-3 mb-3">
             <Target className="w-5 h-5 text-violet-400" />
-            <h2 className="text-2xl md:text-3xl font-bold text-white">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">
               Top Priority
             </h2>
           </div>
@@ -349,10 +349,10 @@ function InitiativesGrid() {
   }, [activeTrack, activeStatus])
 
   return (
-    <section id="initiatives" className="py-16 md:py-24">
+    <section id="initiatives" className="py-20 lg:py-28">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
-          <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-3">
             All Initiatives
           </h2>
           <p className="text-white/50 max-w-2xl">
@@ -547,12 +547,12 @@ function AgentActivitySection() {
   const shouldReduceMotion = useReducedMotion()
 
   return (
-    <section id="activity" className="py-16 md:py-24">
+    <section id="activity" className="py-20 lg:py-28">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
           <div className="flex items-center gap-3 mb-3">
             <Sparkles className="w-5 h-5 text-cyan-400" />
-            <h2 className="text-2xl md:text-3xl font-bold text-white">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">
               Agent Activity
             </h2>
           </div>
@@ -610,13 +610,13 @@ function AgentActivitySection() {
 
 function CTASection() {
   return (
-    <section className="py-16 md:py-24">
+    <section className="py-20 lg:py-28">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="relative bg-white/[0.02] border border-white/[0.06] rounded-3xl p-8 md:p-12 text-center">
           <div className="absolute inset-0 bg-gradient-to-br from-violet-500/[0.03] via-transparent to-cyan-500/[0.03] rounded-3xl" />
 
           <div className="relative">
-            <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">
               Follow the Journey
             </h2>
             <p className="text-white/50 mb-8 max-w-xl mx-auto">

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -314,7 +314,7 @@ export default function StudentsPage() {
               </div>
 
               {/* Headline */}
-              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 tracking-tight leading-[1.1]">
+              <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white mb-6 tracking-tight leading-[1.1]">
                 Learn AI the right way.
                 <span className="block mt-2 text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 via-emerald-400 to-violet-400">
                   Free, world-class courses.
@@ -357,7 +357,7 @@ export default function StudentsPage() {
         </section>
 
         {/* Why Learn AI Section */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-6xl mx-auto px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -368,7 +368,7 @@ export default function StudentsPage() {
               <p className="text-xs font-medium uppercase tracking-[0.25em] text-emerald-400/70 mb-2">
                 Why Now
               </p>
-              <h2 className="text-2xl md:text-3xl font-bold text-white">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">
                 AI is transforming every industry
               </h2>
             </motion.div>
@@ -555,7 +555,7 @@ export default function StudentsPage() {
         </section>
 
         {/* Learning Paths Grid */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-6xl mx-auto px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -567,7 +567,7 @@ export default function StudentsPage() {
                 <p className="text-xs font-medium uppercase tracking-[0.25em] text-cyan-400/70 mb-2">
                   Curated Courses
                 </p>
-                <h2 className="text-2xl md:text-3xl font-bold text-white">World-class learning, zero cost</h2>
+                <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">World-class learning, zero cost</h2>
               </div>
               <span className="hidden md:block text-xs uppercase tracking-[0.2em] text-white/40">
                 {learningPaths.length} courses
@@ -656,7 +656,7 @@ export default function StudentsPage() {
         </section>
 
         {/* Learning Journey Timeline */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-6xl mx-auto px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -667,7 +667,7 @@ export default function StudentsPage() {
               <p className="text-xs font-medium uppercase tracking-[0.25em] text-violet-400/70 mb-2">
                 Your Journey
               </p>
-              <h2 className="text-2xl md:text-3xl font-bold text-white">From beginner to builder</h2>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">From beginner to builder</h2>
             </motion.div>
 
             <div className="relative">
@@ -697,7 +697,7 @@ export default function StudentsPage() {
         </section>
 
         {/* Essential Readings */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-6xl mx-auto px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -708,7 +708,7 @@ export default function StudentsPage() {
               <p className="text-xs font-medium uppercase tracking-[0.25em] text-emerald-400/70 mb-2">
                 Essential Reading
               </p>
-              <h2 className="text-2xl md:text-3xl font-bold text-white">Understand the landscape</h2>
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white">Understand the landscape</h2>
             </motion.div>
 
             <div className="grid md:grid-cols-3 gap-6">
@@ -743,7 +743,7 @@ export default function StudentsPage() {
         </section>
 
         {/* Editorial Quote */}
-        <section className="py-16 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-4xl mx-auto px-6">
             <motion.blockquote
               initial={{ opacity: 0 }}
@@ -760,7 +760,7 @@ export default function StudentsPage() {
         </section>
 
         {/* Bottom CTA — Next Steps */}
-        <section className="py-20 border-t border-white/5">
+        <section className="py-20 lg:py-28 border-t border-white/5">
           <div className="max-w-6xl mx-auto px-6">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -768,7 +768,7 @@ export default function StudentsPage() {
               viewport={{ once: true }}
               className="mb-10 text-center"
             >
-              <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-3">
                 Your next steps
               </h2>
               <p className="text-white/50 max-w-xl mx-auto">

--- a/components/ai-architecture/AIArchitectureShell.tsx
+++ b/components/ai-architecture/AIArchitectureShell.tsx
@@ -1,0 +1,592 @@
+'use client'
+
+import Link from 'next/link'
+import Image from 'next/image'
+import { motion } from 'framer-motion'
+import {
+  Layers,
+  BookOpen,
+  Play,
+  Package,
+  Wrench,
+  ArrowRight,
+  Shield,
+  Database,
+  Network,
+  Server,
+  Key,
+  ExternalLink,
+  Sparkles,
+  Zap,
+  Globe,
+  Lock,
+} from 'lucide-react'
+
+import prototypesData from '@/data/ai-architecture/prototypes.json'
+import { CATEGORY_META, AI_PROVIDER_META } from '@/types/ai-architecture'
+import type { ArchitecturePrototype, PrototypeCategory, AIProvider } from '@/types/ai-architecture'
+
+const blueprints = prototypesData as ArchitecturePrototype[]
+
+const hubSections = [
+  {
+    id: 'blueprints',
+    title: 'Blueprints',
+    description: 'Architecture diagrams, implementation guides & production patterns. Free to learn from.',
+    icon: BookOpen,
+    href: '/ai-architecture/blueprints',
+    color: 'cyan',
+    badge: 'FREE',
+    stat: `${blueprints.filter(b => b.status === 'published').length}+ patterns`,
+  },
+  {
+    id: 'prototypes',
+    title: 'Prototypes',
+    description: 'Interactive demos powered by your own API keys. Test patterns before building.',
+    icon: Play,
+    href: '/ai-architecture/prototypes',
+    color: 'violet',
+    badge: 'BYOK',
+    stat: 'Live demos',
+  },
+  {
+    id: 'templates',
+    title: 'Templates',
+    description: 'Production-ready starter kits with one-click deploy to Vercel, Railway, or OCI.',
+    icon: Package,
+    href: '/ai-architecture/templates',
+    color: 'emerald',
+    badge: '$29+',
+    stat: 'Ship faster',
+  },
+  {
+    id: 'tools',
+    title: 'Tools',
+    description: 'Curated collection of frameworks, databases, platforms & developer resources.',
+    icon: Wrench,
+    href: '/ai-architecture/tools',
+    color: 'amber',
+    badge: null,
+    stat: '30+ tools',
+  },
+]
+
+const categoryIcons: Record<PrototypeCategory, typeof Shield> = {
+  'ai-gateway': Shield,
+  'rag-production': Database,
+  'multi-agent-orchestration': Network,
+  'mcp-servers': Server,
+  'llm-ops': Wrench,
+  'vector-databases': Layers,
+  'ai-coe': BookOpen,
+  'security-governance': Shield,
+  'cost-optimization': Sparkles,
+  'observability': Play,
+}
+
+const colorMap: Record<string, { bg: string; border: string; icon: string; badge: string; glow: string }> = {
+  cyan: {
+    bg: 'bg-cyan-500/[0.06]',
+    border: 'border-cyan-500/20 hover:border-cyan-400/40',
+    icon: 'bg-cyan-500/15 text-cyan-400',
+    badge: 'bg-cyan-500/15 text-cyan-400 border border-cyan-500/25',
+    glow: 'group-hover:shadow-[0_8px_30px_rgba(6,182,212,0.12)]',
+  },
+  violet: {
+    bg: 'bg-violet-500/[0.06]',
+    border: 'border-violet-500/20 hover:border-violet-400/40',
+    icon: 'bg-violet-500/15 text-violet-400',
+    badge: 'bg-violet-500/15 text-violet-400 border border-violet-500/25',
+    glow: 'group-hover:shadow-[0_8px_30px_rgba(139,92,246,0.12)]',
+  },
+  emerald: {
+    bg: 'bg-emerald-500/[0.06]',
+    border: 'border-emerald-500/20 hover:border-emerald-400/40',
+    icon: 'bg-emerald-500/15 text-emerald-400',
+    badge: 'bg-emerald-500/15 text-emerald-400 border border-emerald-500/25',
+    glow: 'group-hover:shadow-[0_8px_30px_rgba(16,185,129,0.12)]',
+  },
+  amber: {
+    bg: 'bg-amber-500/[0.06]',
+    border: 'border-amber-500/20 hover:border-amber-400/40',
+    icon: 'bg-amber-500/15 text-amber-400',
+    badge: 'bg-amber-500/15 text-amber-400 border border-amber-500/25',
+    glow: 'group-hover:shadow-[0_8px_30px_rgba(245,158,11,0.12)]',
+  },
+}
+
+const staggerChild = {
+  hidden: { opacity: 0, y: 24 },
+  show: { opacity: 1, y: 0 },
+}
+
+const staggerContainer = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.08, delayChildren: 0.1 },
+  },
+}
+
+function HubBackground() {
+  return (
+    <div className="fixed inset-0 -z-10 overflow-hidden" aria-hidden>
+      <div className="absolute inset-0 bg-[#0a0a0b]" />
+      {/* Grid pattern */}
+      <div
+        className="absolute inset-0 opacity-[0.02]"
+        style={{
+          backgroundImage: `
+            linear-gradient(rgba(6, 182, 212, 0.5) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(6, 182, 212, 0.5) 1px, transparent 1px)
+          `,
+          backgroundSize: '80px 80px',
+        }}
+      />
+      {/* Ambient orbs */}
+      <motion.div
+        className="absolute -right-60 top-20 h-[600px] w-[600px] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgba(6,182,212,0.15) 0%, transparent 70%)',
+        }}
+        animate={{ scale: [1, 1.08, 1], opacity: [0.5, 0.35, 0.5] }}
+        transition={{ duration: 20, repeat: Infinity, ease: 'easeInOut' }}
+      />
+      <motion.div
+        className="absolute -left-40 bottom-40 h-[500px] w-[500px] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgba(139,92,246,0.12) 0%, transparent 70%)',
+        }}
+        animate={{ scale: [1.08, 1, 1.08], opacity: [0.35, 0.5, 0.35] }}
+        transition={{ duration: 25, repeat: Infinity, ease: 'easeInOut' }}
+      />
+    </div>
+  )
+}
+
+function SectionCard({
+  section,
+}: {
+  section: (typeof hubSections)[0]
+}) {
+  const Icon = section.icon
+  const colors = colorMap[section.color]
+
+  return (
+    <motion.div variants={staggerChild}>
+      <Link href={section.href} className="group block h-full">
+        <div
+          className={`relative h-full rounded-2xl border ${colors.border} ${colors.bg} p-6 backdrop-blur-sm transition-all duration-300 group-hover:-translate-y-1 ${colors.glow}`}
+        >
+          {/* Noise texture overlay */}
+          <div className="pointer-events-none absolute inset-0 rounded-2xl opacity-30" style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Ccircle cx='7' cy='7' r='1'/%3E%3Ccircle cx='27' cy='27' r='1'/%3E%3Ccircle cx='47' cy='47' r='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`
+          }} aria-hidden />
+
+          <div className="relative z-10">
+            <div className="flex items-start justify-between">
+              <div className={`flex h-12 w-12 items-center justify-center rounded-xl ${colors.icon} transition-transform duration-300 group-hover:scale-105`}>
+                <Icon className="h-6 w-6" />
+              </div>
+              {section.badge && (
+                <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${colors.badge}`}>
+                  {section.badge}
+                </span>
+              )}
+            </div>
+            <h3 className="mt-4 text-lg font-bold text-white">{section.title}</h3>
+            <p className="mt-1.5 text-sm leading-relaxed text-slate-400">{section.description}</p>
+            <div className="mt-5 flex items-center justify-between">
+              <span className="text-xs font-medium text-slate-500">{section.stat}</span>
+              <div className="flex items-center gap-1 text-sm text-slate-500 transition-colors group-hover:text-white">
+                <span>Explore</span>
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  )
+}
+
+function BlueprintCard({ blueprint, index }: { blueprint: ArchitecturePrototype; index: number }) {
+  const Icon = categoryIcons[blueprint.category] || Layers
+  const categoryMeta = CATEGORY_META[blueprint.category]
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.4, delay: index * 0.08 }}
+    >
+      <Link href={`/blueprint/${blueprint.slug}`} className="group block h-full">
+        <div className="relative h-full rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 backdrop-blur-sm transition-all duration-300 hover:border-white/15 hover:bg-white/[0.06] group-hover:-translate-y-0.5 group-hover:shadow-lg group-hover:shadow-cyan-500/[0.05]">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-500/15 text-cyan-400">
+              <Icon className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h4 className="font-semibold text-white truncate">{blueprint.title}</h4>
+              <p className="text-[11px] font-medium uppercase tracking-wider text-slate-500">{categoryMeta?.name}</p>
+            </div>
+          </div>
+          <p className="mt-3 text-sm leading-relaxed text-slate-400 line-clamp-2">{blueprint.subtitle}</p>
+          <div className="mt-4 flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              {blueprint.cloudProviders.slice(0, 3).map((provider) => (
+                <span
+                  key={provider}
+                  className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-slate-500"
+                >
+                  {provider.toUpperCase()}
+                </span>
+              ))}
+              {blueprint.cloudProviders.length > 3 && (
+                <span className="text-[10px] text-slate-600">+{blueprint.cloudProviders.length - 3}</span>
+              )}
+            </div>
+            <ArrowRight className="h-4 w-4 text-slate-600 transition-all group-hover:translate-x-1 group-hover:text-cyan-400" />
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  )
+}
+
+function ProviderButton({ provider }: { provider: AIProvider }) {
+  const meta = AI_PROVIDER_META[provider]
+  const providerColors: Record<string, string> = {
+    orange: 'border-orange-500/25 hover:border-orange-400/50 hover:bg-orange-500/10',
+    emerald: 'border-emerald-500/25 hover:border-emerald-400/50 hover:bg-emerald-500/10',
+    blue: 'border-blue-500/25 hover:border-blue-400/50 hover:bg-blue-500/10',
+    red: 'border-red-500/25 hover:border-red-400/50 hover:bg-red-500/10',
+  }
+
+  return (
+    <a
+      href={meta.keyUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`flex items-center gap-2 rounded-lg border bg-white/[0.02] px-3 py-2 text-sm text-slate-400 transition-all hover:text-white ${providerColors[meta.color]}`}
+    >
+      <Key className="h-3.5 w-3.5" />
+      <span className="font-medium">{meta.shortName}</span>
+      <ExternalLink className="h-3 w-3 opacity-40" />
+    </a>
+  )
+}
+
+export default function AIArchitectureShell() {
+  const publishedBlueprints = blueprints.filter((b) => b.status === 'published').slice(0, 6)
+
+  return (
+    <>
+      <HubBackground />
+      <main className="relative min-h-screen">
+        {/* Hero */}
+        <section className="pt-32 pb-20 lg:pb-28 sm:pt-36">
+          <div className="mx-auto max-w-6xl px-6">
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.5 }}
+              className="mb-6 flex items-center gap-4"
+            >
+              <Image
+                src="/images/team/codex-falcon.png"
+                alt="Codex — AI Architecture Specialist"
+                width={64}
+                height={64}
+                priority
+                className="rounded-2xl"
+                style={{ boxShadow: '0 0 30px -6px rgba(16,185,129,0.4)' }}
+              />
+              <div className="inline-flex items-center gap-2.5 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 backdrop-blur-sm">
+                <div className="flex h-6 w-6 items-center justify-center rounded-md bg-gradient-to-br from-cyan-500/30 to-violet-500/30">
+                  <Layers className="h-3.5 w-3.5 text-white" />
+                </div>
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  AI Architecture Hub
+                </span>
+              </div>
+            </motion.div>
+
+            <motion.h1
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.08 }}
+              className="mb-6 max-w-4xl font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.1] text-white"
+            >
+              Learn. Try.{' '}
+              <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-emerald-400 bg-clip-text text-transparent">
+                Build.
+              </span>
+            </motion.h1>
+
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.16 }}
+              className="mb-10 max-w-2xl text-[17px] leading-relaxed text-white/80"
+            >
+              Production-ready AI architecture patterns. Explore blueprints, test with your own API
+              keys, and deploy with starter templates. Cloud-agnostic patterns that work everywhere.
+            </motion.p>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.24 }}
+              className="flex flex-wrap gap-4"
+            >
+              <Link
+                href="/ai-architecture/blueprints"
+                className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <BookOpen className="h-4 w-4" />
+                Browse Blueprints
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+              <Link
+                href="/ai-architecture/prototypes"
+                className="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition-all hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                <Play className="h-4 w-4" />
+                Try Prototypes
+              </Link>
+            </motion.div>
+          </div>
+        </section>
+
+        {/* Journey Steps - Visual progression */}
+        <section className="py-6">
+          <div className="mx-auto max-w-6xl px-6">
+            <motion.div
+              initial={{ opacity: 0, scaleX: 0 }}
+              animate={{ opacity: 1, scaleX: 1 }}
+              transition={{ duration: 0.8, delay: 0.4 }}
+              className="flex items-center justify-center gap-3 text-xs font-medium text-slate-500"
+            >
+              <span className="flex items-center gap-1.5">
+                <BookOpen className="h-3.5 w-3.5 text-cyan-400" />
+                Learn
+              </span>
+              <div className="h-px w-12 bg-gradient-to-r from-cyan-500/40 to-violet-500/40" />
+              <span className="flex items-center gap-1.5">
+                <Play className="h-3.5 w-3.5 text-violet-400" />
+                Try
+              </span>
+              <div className="h-px w-12 bg-gradient-to-r from-violet-500/40 to-emerald-500/40" />
+              <span className="flex items-center gap-1.5">
+                <Zap className="h-3.5 w-3.5 text-emerald-400" />
+                Build
+              </span>
+            </motion.div>
+          </div>
+        </section>
+
+        {/* Hub Navigation Cards */}
+        <section className="py-20 lg:py-28">
+          <div className="mx-auto max-w-6xl px-6">
+            <motion.div
+              variants={staggerContainer}
+              initial="hidden"
+              animate="show"
+              className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4"
+            >
+              {hubSections.map((section) => (
+                <SectionCard key={section.id} section={section} />
+              ))}
+            </motion.div>
+          </div>
+        </section>
+
+        {/* BYOK Section */}
+        <section className="py-20 lg:py-28 border-y border-white/[0.04]">
+          <div className="mx-auto max-w-6xl px-6">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+              className="relative overflow-hidden rounded-2xl border border-violet-500/15 bg-violet-500/[0.04] p-8 backdrop-blur-sm"
+            >
+              {/* Subtle glow */}
+              <div className="pointer-events-none absolute -right-20 -top-20 h-40 w-40 rounded-full bg-violet-500/10 blur-3xl" aria-hidden />
+
+              <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex-1">
+                  <div className="mb-3 flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-500/15">
+                      <Lock className="h-5 w-5 text-violet-400" />
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-bold text-white">Bring Your Own Key</h3>
+                      <p className="text-xs font-medium text-violet-400/80">Zero cost to us. Full control to you.</p>
+                    </div>
+                  </div>
+                  <p className="max-w-xl text-[17px] leading-relaxed text-white/80">
+                    Try prototypes using your own API keys. Keys stay in your browser localStorage —
+                    never sent to our servers. Works with any provider. You control costs.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2.5">
+                  <ProviderButton provider="anthropic" />
+                  <ProviderButton provider="openai" />
+                  <ProviderButton provider="google" />
+                  <ProviderButton provider="oci" />
+                </div>
+              </div>
+            </motion.div>
+          </div>
+        </section>
+
+        {/* Featured Blueprints */}
+        <section className="py-20 lg:py-28">
+          <div className="mx-auto max-w-6xl px-6">
+            <div className="mb-10 flex items-end justify-between">
+              <div>
+                <motion.p
+                  initial={{ opacity: 0 }}
+                  whileInView={{ opacity: 1 }}
+                  viewport={{ once: true }}
+                  className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400"
+                >
+                  Architecture Patterns
+                </motion.p>
+                <motion.h2
+                  initial={{ opacity: 0, y: 12 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white"
+                >
+                  Featured Blueprints
+                </motion.h2>
+                <motion.p
+                  initial={{ opacity: 0, y: 12 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: 0.1 }}
+                  className="mt-3 text-[17px] leading-relaxed text-white/80"
+                >
+                  Production-ready patterns with diagrams, guides & cost estimates
+                </motion.p>
+              </div>
+              <Link
+                href="/ai-architecture/blueprints"
+                className="hidden items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-slate-400 transition-all hover:border-white/20 hover:text-white sm:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+              >
+                View all
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+
+            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {publishedBlueprints.map((blueprint, index) => (
+                <BlueprintCard key={blueprint.id} blueprint={blueprint} index={index} />
+              ))}
+            </div>
+
+            <div className="mt-6 flex justify-center sm:hidden">
+              <Link
+                href="/ai-architecture/blueprints"
+                className="flex items-center gap-1.5 text-sm font-medium text-cyan-400 hover:text-cyan-300"
+              >
+                View all blueprints
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Templates Teaser */}
+        <section className="py-20 lg:py-28 border-t border-white/[0.04]">
+          <div className="mx-auto max-w-6xl px-6">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              className="relative overflow-hidden rounded-2xl border border-emerald-500/15 bg-emerald-500/[0.04] backdrop-blur-xl p-8 sm:p-10 text-center"
+            >
+              {/* Decorative glow */}
+              <div className="pointer-events-none absolute left-1/2 top-0 h-32 w-64 -translate-x-1/2 bg-emerald-500/10 blur-3xl" aria-hidden />
+
+              <div className="relative">
+                <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/15 text-emerald-400">
+                  <Package className="h-7 w-7" />
+                </div>
+                <h3 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Starter Templates</h3>
+                <p className="mx-auto mb-8 max-w-lg text-[17px] leading-relaxed text-white/80">
+                  Production-ready starter kits with one-click deploy. From RAG pipelines
+                  to multi-agent frameworks — ship in hours, not weeks.
+                </p>
+                <div className="flex flex-wrap justify-center gap-3 mb-8">
+                  {[
+                    { name: 'RAG Starter Kit', price: '$49' },
+                    { name: 'Multi-Agent Framework', price: '$99' },
+                    { name: 'AI Chat Widget', price: '$29' },
+                    { name: 'MCP Server Kit', price: '$39' },
+                  ].map((template) => (
+                    <span
+                      key={template.name}
+                      className="rounded-full border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-2 text-sm text-emerald-400"
+                    >
+                      {template.name} <span className="text-emerald-500/60">•</span> {template.price}
+                    </span>
+                  ))}
+                </div>
+                <Link
+                  href="/ai-architecture/templates"
+                  className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-emerald-400 hover:shadow-lg hover:shadow-emerald-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+                >
+                  Browse Templates
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </motion.div>
+          </div>
+        </section>
+
+        {/* Cloud Agnostic */}
+        <section className="py-20 lg:py-28">
+          <div className="mx-auto max-w-6xl px-6 text-center">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+            >
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.06] text-white">
+                <Globe className="h-6 w-6" />
+              </div>
+              <h2 className="mb-3 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white">Cloud-Agnostic Patterns</h2>
+              <p className="mx-auto mb-10 max-w-lg text-[17px] leading-relaxed text-white/80">
+                Learn the pattern once, deploy anywhere. All blueprints and templates
+                work across major cloud providers.
+              </p>
+            </motion.div>
+            <div className="flex flex-wrap justify-center gap-4">
+              {[
+                { name: 'AWS', color: 'border-orange-500/20 text-orange-400 bg-orange-500/[0.06]' },
+                { name: 'GCP', color: 'border-blue-500/20 text-blue-400 bg-blue-500/[0.06]' },
+                { name: 'Azure', color: 'border-cyan-500/20 text-cyan-400 bg-cyan-500/[0.06]' },
+                { name: 'OCI', color: 'border-red-500/20 text-red-400 bg-red-500/[0.06]' },
+              ].map((cloud) => (
+                <motion.div
+                  key={cloud.name}
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  whileInView={{ opacity: 1, scale: 1 }}
+                  viewport={{ once: true }}
+                  className={`rounded-xl border px-8 py-4 text-sm font-semibold ${cloud.color}`}
+                >
+                  {cloud.name}
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
Wave 20 of overnight excellence. 2 commits.

## What ships

### ★ Architectural pattern applied to /ai-architecture (commit `eec72d22`)
Fourth top-of-funnel page migrated to server shell + motion island:
- **Server** `app/ai-architecture/page.tsx`: 85 lines (down from 593) — JSON-LD @graph with CollectionPage + Service + BreadcrumbList
- **Client island** `components/ai-architecture/AIArchitectureShell.tsx`: HubBackground, SectionCard, BlueprintCard, ProviderButton, full visual layout
- Schema: CollectionPage with ItemList enumerating 4 hub sections (Blueprints, Prototypes, Templates, Tools)

### 10 more pages polished to spec (commit `c13ed72c`)
- /students, /games, /assessment/advanced, /gallery, /investor, /ai-art, /plan, /design, /ai-world, /magic
- H1 + H2 typography spec, section padding py-20 lg:py-28
- Pure token swaps, no copy or structure changes

## Skipped intentionally
- /alea, /year-of-the-fire-horse, /valentines-day/tien — intentional artistic typography
- /frankx — mega text-9xl character-art showcase
- /command-center, /onboarding, /progress — internal wizards
- /ai-evolution — already on-spec

## Pre-flight gates
- `npx tsc --noEmit` → 0 errors ✓

🤖 Generated overnight