### PR TITLE
fix(courses): unblock production build — server-safe schema on /courses

### DIFF
--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,20 +1,21 @@
 import JsonLd from '@/components/seo/JsonLd'
-import CoursesShell, { courseCardsForSchema } from '@/components/courses/CoursesShell'
+import CoursesShell from '@/components/courses/CoursesShell'
+import { plannedCourses } from '@/lib/courses/roadmap'
 
 export default function CoursesPage() {
   const courseListSchema = {
     name: 'FrankX Course Roadmap',
     description:
       'Planned course roadmap for AI foundations, agent architecture systems, and creator business systems.',
-    numberOfItems: courseCardsForSchema.length,
-    itemListElement: courseCardsForSchema.map((course, index) => ({
+    numberOfItems: plannedCourses.length,
+    itemListElement: plannedCourses.map((course, index) => ({
       '@type': 'ListItem',
       position: index + 1,
       item: {
         '@type': 'Course',
         name: course.title,
-        description: course.description,
-        url: `https://frankx.ai${course.href}`,
+        description: course.shortDescription,
+        url: `https://frankx.ai/courses/${course.slug}`,
         provider: { '@type': 'Organization', name: 'FrankX.AI' },
       },
     })),


### PR DESCRIPTION
## Why

**Production deploys have been failing since the `/courses` server-shell refactor.** `frankx.ai` is frozen on the last good deploy (PR #131); every `main` deploy after it is in `ERROR`, so none of the recent work (Oracle scrub, footer, content, perf refactors) has reached production.

Root cause — `/courses` crashed at prerender:
```
Error occurred prerendering page "/courses"
TypeError: courseCardsForSchema.map is not a function
Export encountered an error on /courses/page → exiting the build
```

`app/courses/page.tsx` (a Server Component) imported the `courseCardsForSchema` **array** from `components/courses/CoursesShell.tsx`, which is a `'use client'` module. Importing a non-component value across the client boundary yields a client-reference proxy at prerender time, not the array — so `.map` throws and the whole build aborts.

## Fix

Build the `ItemList` schema directly from `plannedCourses` (`@/lib/courses/roadmap`), a plain server-safe module that is the original source of the data. No cross-boundary value import. Same schema shape (`name`/`description`/`url` per course).

## Validation

- `tsc --noEmit` — clean (exit 0) across the repo.
- Local `next build` reproduced the exact pre-fix `/courses` crash; with the fix it compiles past prerender (local build only stops later on Google-Fonts fetch, which is a sandbox network limit, not a code issue — Vercel has font access).
- Audited the other ~38 server-shell refactors for the same anti-pattern: `/courses` was the only broken one (`/ai-architectures` already uses a separate `architectures-data` module).

## Impact

Unblocks the entire production deploy queue ahead of launch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal course data structure handling for better schema generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->