### PR TITLE
docs(quality): hub registry + model-upgrade playbook + voice-audit tooling

### DIFF
--- a/docs/HUB_REGISTRY.csv
+++ b/docs/HUB_REGISTRY.csv
@@ -1,0 +1,42 @@
+hub,route,tier,register,voice,fresh,reviewed_model,reviewed_date,priority,notes
+Home,/,1,mainstream,clean,current,Opus 4.8,2026-06-02,P0,Oracle scrub + honest counts + autoplay fix (#107/#110)
+ACOS,/acos,1,product,unaudited,unaudited,legacy,,P0,Verify 90+/60+/80+ counts vs repo
+AI Architecture Hub,/ai-architecture,1,enterprise,unaudited,unaudited,legacy,,P0,Central builder hub
+Music,/music,1,product,review,unaudited,legacy,,P1,MusicShell voice flagged
+Courses,/courses,1,mainstream,unaudited,current,Opus 4.8,2026-06-02,P1,Build-blocker fixed (#140)
+About,/about,1,mainstream,unaudited,unaudited,legacy,,P1,Story & mission
+Bio,/bio,1,enterprise,clean,current,Opus 4.8,2026-06-02,P1,Softened EMEA credential
+Build / Agentic Builder Lab,/build,1,enterprise,unaudited,unaudited,legacy,,P1,Build-in-public
+Start Here,/start,1,mainstream,unaudited,unaudited,legacy,,P1,First-touch funnel
+GenCreators,/gencreator,2,mainstream,unaudited,unaudited,legacy,,P2,Framework hub
+Learn Hub,/learn,2,mainstream,unaudited,unaudited,legacy,,P2,
+Explore / Resources,/resources,2,mainstream,review,unaudited,legacy,,P2,templates page has guru-slop
+Prompt Library,/prompt-library,2,mainstream,unaudited,unaudited,legacy,,P2,Verify 200+ count
+Research Hub,/research,2,enterprise,unaudited,unaudited,legacy,,P2,
+Intelligence Atlas,/intelligence-atlas,2,enterprise,unaudited,unaudited,legacy,,P2,
+Library,/library,2,mainstream,unaudited,unaudited,legacy,,P2,Verify 23 books/411K words
+Watch,/watch,2,mainstream,clean,current,Opus 4.8,2026-06-02,P2,Oracle scrub
+Developers,/developers,2,enterprise,unaudited,unaudited,legacy,,P2,
+AI World,/ai-world,2,enterprise,unaudited,unaudited,legacy,,P2,
+Work With Me,/work-with-me,2,enterprise,unaudited,unaudited,legacy,,P1,
+Consulting,/consulting,2,enterprise,unaudited,unaudited,legacy,,P1,Oracle scrub (#107)
+Coaching,/coaching,2,mainstream,unaudited,unaudited,legacy,,P2,Oracle scrub (#107)
+Workshops,/workshops,2,enterprise,unaudited,unaudited,legacy,,P2,
+Studio,/studio,2,mainstream,clean,current,Opus 4.8,2026-06-02,P2,enterprise-to-creator bridge copy
+Enterprise,/enterprise,2,enterprise,unaudited,unaudited,legacy,,P1,
+AI CoE,/ai-coe,2,enterprise,unaudited,unaudited,legacy,,P2,Build-your-own CoE
+Partnerships,/partnerships,2,enterprise,unaudited,unaudited,legacy,,P2,Oracle scrub (#107)
+Founders Circle,/founders-circle,2,mainstream,clean,current,Opus 4.8,2026-06-02,P2,Past-tense Oracle
+Content Studio,/content-studio,2,mainstream,rewrite,unaudited,legacy,,P2,aligned with soul purpose guru-slop
+AI Assessment,/ai-assessment,2,mainstream,review,unaudited,legacy,,P2,AI transformation OK; check rest
+Books,/books,2,mainstream,review,unaudited,legacy,,P2,books-registry flagged; verify count
+Golden Age,/golden-age,2,mainstream,unaudited,unaudited,legacy,,P2,Flagship book
+Blog,/blog,2,mainstream,review,stale,legacy,,P2,Per-post audit
+Rails / Canon,/canon,3,contemplative,clean,unaudited,legacy,,P3,Serif register by design — do not flatten
+Soulbook,/soulbook,3,contemplative,clean,unaudited,legacy,,P3,Product name; reflective intentional
+German family,/familie,3,personal-de,na,unaudited,legacy,,P3,Personal register
+Command Center,/command-center,3,na,na,na,legacy,,P3,Owner-only
+Ops,/ops,3,na,na,na,legacy,,P3,Owner-only
+Admin,/admin,3,na,na,na,legacy,,P3,Owner-only
+Dashboard,/dashboard,3,na,na,na,legacy,,P3,Owner-only
+Investment,/frankx-investment-dashboard,3,na,na,na,legacy,,P3,Owner-only

--- a/docs/HUB_REGISTRY.md
+++ b/docs/HUB_REGISTRY.md
@@ -1,0 +1,64 @@
+# FrankX Hub Registry
+
+> The maintained source of truth for every **major hub** on frankx.ai.
+> Purpose: track quality, brand-voice, and freshness per hub so we can systematically
+> re-audit and upgrade the whole site each time a stronger model ships.
+>
+> **Cadence:** see `docs/MODEL_UPGRADE_PLAYBOOK.md`. Update the `Reviewed` column
+> (model + date) every time a hub is upgraded. Never let a hub silently fall behind.
+
+**Legend**
+- **Register** — the intended voice of the hub:
+  - `mainstream` — direct, technical, warm (default brand voice)
+  - `enterprise` — AI-architect / consulting register (precise, credentialed)
+  - `contemplative` — the rails/canon register (`/(rails)`, `/on-*`, `/canon`, soulbook) — *intentionally* reflective; serif font. **Do not flatten.**
+  - `product` — named products (Vibe OS, ACOS, Soulbook) — proper nouns stay
+  - `personal-de` — German family pages (`/familie`, `/opa-und-oma`, …) — personal register
+- **Voice** — `clean` · `review` (slop flagged) · `rewrite` (clear guru-slop) · `n/a`
+- **Fresh** — content currency: `current` · `stale` · `unaudited`
+- **Reviewed** — last model + date that upgraded the hub. `legacy` = pre-tracking (assume Opus 4.6 era).
+- **Pri** — upgrade priority: `P0` launch-critical · `P1` high-traffic · `P2` secondary · `P3` long-tail
+
+See `HUB_REGISTRY.csv` for the machine-maintained version. Update both together.
+
+## Tier 1 — Flagship (email/launch traffic lands here)
+
+| Hub | Route | Register | Voice | Fresh | Reviewed | Pri |
+|-----|-------|----------|-------|-------|----------|-----|
+| Home | `/` | mainstream | clean | current | Opus 4.8 · 2026-06-02 | P0 |
+| ACOS | `/acos` | product | unaudited | unaudited | legacy | P0 |
+| AI Architecture Hub | `/ai-architecture` | enterprise | unaudited | unaudited | legacy | P0 |
+| Music | `/music` | product | review | unaudited | legacy | P1 |
+| Courses | `/courses` | mainstream | unaudited | current | Opus 4.8 · 2026-06-02 | P1 |
+| About | `/about` | mainstream | unaudited | unaudited | legacy | P1 |
+| Bio / Press | `/bio` | enterprise | clean | current | Opus 4.8 · 2026-06-02 | P1 |
+| Build / Agentic Builder Lab | `/build` | enterprise | unaudited | unaudited | legacy | P1 |
+| Start Here | `/start` | mainstream | unaudited | unaudited | legacy | P1 |
+
+## Tier 2 — Section hubs, commercial, books (see CSV for full list)
+
+GenCreators, Learn, Resources, Prompt Library, Research, Intelligence Atlas, Library,
+Watch, Developers, AI World, Work-With-Me, Consulting, Coaching, Workshops, Studio,
+Enterprise, AI CoE, Partnerships, Founders Circle, Content Studio, AI Assessment,
+Books, Golden Age, Blog.
+
+## Tier 3 — Contemplative register (DO NOT flatten — intentional voice)
+
+Rails/Canon (`/(rails)`, `/canon`, `/on-*`), Soulbook, Soul Frequency, German family
+(`/familie`, `/opa-und-oma`, `/lebensbaum`, `/hoffnung`, `/erde`).
+
+## Tier 3 — Owner-only (private, login-gated)
+
+Command Center, Ops, Admin, Dashboard, Investment.
+
+---
+
+## Known duplicates / cleanup candidates (audit before launch)
+- `/ai-architecture` vs `/ai-architectures` — confirm canonical, redirect the other.
+- `/links` vs `/linktree` — pick one.
+- `/family` vs `/familie` — pick one.
+- `/assessment` vs `/ai-assessment` vs `/assess` — consolidate funnel.
+- `/products/agentic-creator-os` vs `/acos` — confirm canonical ACOS page.
+- Dead code (not routed): `components/home/HomePage.tsx`, `components/home/V3HomePage.tsx`, `components/v0-variants/*`.
+
+> ⚠ Per CLAUDE.md: never delete/rename live URLs without checking traffic + adding redirects. Hide from nav, keep the page. Flag, don't nuke.

--- a/docs/HUB_REGISTRY.md
+++ b/docs/HUB_REGISTRY.md
@@ -54,11 +54,18 @@ Command Center, Ops, Admin, Dashboard, Investment.
 ---
 
 ## Known duplicates / cleanup candidates (audit before launch)
+
+**Route-level (user-facing):**
 - `/ai-architecture` vs `/ai-architectures` — confirm canonical, redirect the other.
 - `/links` vs `/linktree` — pick one.
 - `/family` vs `/familie` — pick one.
 - `/assessment` vs `/ai-assessment` vs `/assess` — consolidate funnel.
 - `/products/agentic-creator-os` vs `/acos` — confirm canonical ACOS page.
-- Dead code (not routed): `components/home/HomePage.tsx`, `components/home/V3HomePage.tsx`, `components/v0-variants/*`.
+
+**`lib/route-enumeration.mjs` sync (sitemap + link-check integrity):**
+- Duplicate route definitions: `/inner-circle` (×3), `/community` (×2), `/founders-circle` (×2) — dedupe.
+- Missing active hubs in `STATIC_ROUTES`: `/work-with-me`, `/consulting`, `/gencreator` — add so sitemap + link validation stay in sync.
+
+**Dead code (not routed):** `components/home/HomePage.tsx`, `components/home/V3HomePage.tsx`, `components/v0-variants/*`.
 
 > ⚠ Per CLAUDE.md: never delete/rename live URLs without checking traffic + adding redirects. Hide from nav, keep the page. Flag, don't nuke.

--- a/docs/MODEL_UPGRADE_PLAYBOOK.md
+++ b/docs/MODEL_UPGRADE_PLAYBOOK.md
@@ -1,0 +1,42 @@
+# Model Upgrade Playbook
+
+> Every time a stronger model ships, we run the whole site back through this loop so
+> frankx.ai stays at top state: current information, true brand voice, no AI slop,
+> excellent visuals. Driven by `docs/HUB_REGISTRY.md` / `.csv`.
+
+## When to run
+- A new frontier model is available (the trigger).
+- Quarterly, regardless, for freshness.
+- Before any major launch / email blast.
+
+## The loop (per hub, highest priority first)
+
+1. **Pick the batch** — sort the registry by `priority` then oldest `reviewed_date`. P0/P1 first.
+2. **Read the live page** — via the authenticated Vercel fetch (`web_fetch_vercel_url` on `https://www.frankx.ai/<route>`) so you audit what visitors actually see.
+3. **Audit against four axes:**
+   - **Voice** — true brand voice (direct, technical, warm; results over claims; no guru language). Run `bash scripts/voice-audit.sh <path>`.
+   - **Freshness** — dates, model names, stats, "coming soon" that already shipped, dead links.
+   - **Accuracy** — every claim verifiable (counts, credentials). No inflation (cf. 630→90 skills).
+   - **Visual** — layout, hierarchy, spacing, responsive, a11y (`/ui-ux-pro-max`, `/web-design-expert`, `/ui-ux-design-expert`). Screenshot QA via `/gstack` against local `next dev` or the Vercel preview.
+4. **Fix on a branch** — never edit `main` directly. Surgical edits; preserve intentional registers (contemplative/rails, product names, German family pages).
+5. **Verify** — `npm run type-check` + Vercel preview build green. Local `next build` can't fetch Google Fonts in the sandbox — rely on the preview.
+6. **Ship** — squash-merge to `main`; confirm the production deploy reaches READY (not ERROR) before moving on.
+7. **Update the registry** — set `voice`, `fresh`, `reviewed_model`, `reviewed_date` for each hub touched.
+
+## Brand-voice ruleset (the bar)
+
+**Keep (legitimate, on-brand):**
+- "AI transformation", "AI Center of Excellence", "enterprise AI" — standard enterprise terms.
+- Product proper nouns: Vibe OS, ACOS, Soulbook, GenCreator, Soul Frequency, Starlight Intelligence.
+- The contemplative register on `/(rails)`, `/canon`, `/on-*`, `/soulbook`.
+
+**Rewrite (guru-slop / LLM tells):**
+- "soul-aligned", "soul purpose", "transformation rituals", "awakening", "consciousness" (as marketing), "elevate your", "unlock the power", "unleash", "supercharge", "harness the power", "synergy", "seamless", "cutting-edge", "game-changing", "revolutionary", "next level", "deep dive", "delve", "embark on a journey", "in today's fast-paced world", "whether you're…", "look no further", "tapestry", "testament to".
+- Replace with concrete, specific, demonstrated language. Show the work, then name it.
+
+**Decision (2026-06-02):** Keep named products/personas; fix only the generic guru-slop in surrounding copy. Never rename a product. Roll out autonomously to main, P0/P1 first. Verify + correct all numeric claims.
+
+**Test:** "If someone asks 'what does that mean specifically?' — can you answer with examples and evidence?" If not, rewrite.
+
+## Status key
+Definition of done per hub for a model generation: `voice=clean`, `fresh=current`, `reviewed_*` = current model + date.

--- a/docs/MODEL_UPGRADE_PLAYBOOK.md
+++ b/docs/MODEL_UPGRADE_PLAYBOOK.md
@@ -14,7 +14,7 @@
 1. **Pick the batch** — sort the registry by `priority` then oldest `reviewed_date`. P0/P1 first.
 2. **Read the live page** — via the authenticated Vercel fetch (`web_fetch_vercel_url` on `https://www.frankx.ai/<route>`) so you audit what visitors actually see.
 3. **Audit against four axes:**
-   - **Voice** — true brand voice (direct, technical, warm; results over claims; no guru language). Run `bash scripts/voice-audit.sh <path>`.
+   - **Voice** — true brand voice (direct, technical, warm; results over claims; no guru language). Run `bash scripts/voice-audit.sh <local-path>` (a filesystem path like `app/about`, NOT a URL route like `/about`).
    - **Freshness** — dates, model names, stats, "coming soon" that already shipped, dead links.
    - **Accuracy** — every claim verifiable (counts, credentials). No inflation (cf. 630→90 skills).
    - **Visual** — layout, hierarchy, spacing, responsive, a11y (`/ui-ux-pro-max`, `/web-design-expert`, `/ui-ux-design-expert`). Screenshot QA via `/gstack` against local `next dev` or the Vercel preview.

--- a/scripts/voice-audit.sh
+++ b/scripts/voice-audit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Brand-voice / AI-slop scanner for frankx.ai
+# Usage:
+#   bash scripts/voice-audit.sh                  # rank all app/ + components/ files by slop density
+#   bash scripts/voice-audit.sh <path>           # show flagged lines in one file/dir
+# See docs/MODEL_UPGRADE_PLAYBOOK.md for the ruleset. "AI transformation" is intentionally
+# NOT flagged (legitimate enterprise term). Guru-slop and LLM tells are.
+
+set -euo pipefail
+
+PAT='soul-aligned|soul purpose|transformation ritual|awakening|consciousness|unlock the power|unleash|supercharge|elevate your|harness the power|synergy|seamless|cutting-edge|game-chang|revolutioniz|revolutionary|next level|in today.?s (fast|world|digital)|fast-paced|ever-evolving|deep dive|delve|embark on|tapestry|testament to|look no further|in the realm of|realm of|skyrocket|effortless|paradigm shift|world-class|level up|dive into'
+
+TARGET="${1:-}"
+INCLUDES=(--include=*.tsx --include=*.ts --include=*.mdx --include=*.md)
+
+if [ -n "$TARGET" ]; then
+  echo "Flagged lines in: $TARGET"
+  grep -rnEi "$PAT" "$TARGET" "${INCLUDES[@]}" 2>/dev/null || echo "  (none — clean)"
+  exit 0
+fi
+
+echo "Top files by slop-term density (app/ + components/, excluding api routes & prompt templates):"
+grep -rEil "$PAT" app components "${INCLUDES[@]}" 2>/dev/null \
+  | grep -vE '^app/api/' \
+  | while read -r f; do
+      n=$(grep -rEio "$PAT" "$f" 2>/dev/null | wc -l | tr -d ' ')
+      echo "$n $f"
+    done | sort -rn | head -50

--- a/scripts/voice-audit.sh
+++ b/scripts/voice-audit.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-PAT='soul-aligned|soul purpose|transformation ritual|awakening|consciousness|unlock the power|unleash|supercharge|elevate your|harness the power|synergy|seamless|cutting-edge|game-chang|revolutioniz|revolutionary|next level|in today.?s (fast|world|digital)|fast-paced|ever-evolving|deep dive|delve|embark on|tapestry|testament to|look no further|in the realm of|realm of|skyrocket|effortless|paradigm shift|world-class|level up|dive into'
+PAT='soul-aligned|soul purpose|transformation ritual|awakening|consciousness|unlock the power|unleash|supercharge|elevate your|harness the power|synergy|seamless|cutting-edge|game-chang|revolutioniz|revolutionary|next level|in today'\''?s (fast|world|digital)|fast-paced|ever-evolving|deep dive|delve|embark on|tapestry|testament to|look no further|in the realm of|realm of|skyrocket|effortless|paradigm shift|world-class|level up|dive into'
 
 TARGET="${1:-}"
 INCLUDES=(--include=*.tsx --include=*.ts --include=*.mdx --include=*.md)
@@ -20,7 +20,10 @@ if [ -n "$TARGET" ]; then
   exit 0
 fi
 
-echo "Top files by slop-term density (app/ + components/, excluding api routes & prompt templates):"
+# Excludes app/api/ — that's where AI prompt-generation files live (their prompt
+# templates legitimately contain words like "leverage/seamless"). User-facing
+# copy under app/resources/templates etc. IS audited.
+echo "Top files by slop-term density (app/ + components/, excluding app/api/ prompt-gen routes):"
 grep -rEil "$PAT" app components "${INCLUDES[@]}" 2>/dev/null \
   | grep -vE '^app/api/' \
   | while read -r f; do

--- a/scripts/voice-audit.sh
+++ b/scripts/voice-audit.sh
@@ -2,7 +2,8 @@
 # Brand-voice / AI-slop scanner for frankx.ai
 # Usage:
 #   bash scripts/voice-audit.sh                  # rank all app/ + components/ files by slop density
-#   bash scripts/voice-audit.sh <path>           # show flagged lines in one file/dir
+#   bash scripts/voice-audit.sh <local-path>     # show flagged lines in one local file/dir (e.g. app/about)
+# Note: pass a LOCAL filesystem path (app/about, content/blog), NOT a URL route (/about).
 # See docs/MODEL_UPGRADE_PLAYBOOK.md for the ruleset. "AI transformation" is intentionally
 # NOT flagged (legitimate enterprise term). Guru-slop and LLM tells are.
 
@@ -23,6 +24,6 @@ echo "Top files by slop-term density (app/ + components/, excluding api routes &
 grep -rEil "$PAT" app components "${INCLUDES[@]}" 2>/dev/null \
   | grep -vE '^app/api/' \
   | while read -r f; do
-      n=$(grep -rEio "$PAT" "$f" 2>/dev/null | wc -l | tr -d ' ')
+      n=$(grep -Eio "$PAT" "$f" 2>/dev/null | wc -l | tr -d ' ')
       echo "$n $f"
-    done | sort -rn | head -50
+    done | sort -rn | head -50 || true


### PR DESCRIPTION
## What

Foundation for keeping frankx.ai at top state across model generations:

- **`docs/HUB_REGISTRY.md` + `.csv`** — maintained source of truth for every major hub, with per-hub **voice / freshness / reviewed-model** tracking and priority tiers.
- **`docs/MODEL_UPGRADE_PLAYBOOK.md`** — the repeatable loop to re-audit + upgrade the whole site each time a stronger model ships (the trigger Frank asked for), plus the agreed brand-voice ruleset.
- **`scripts/voice-audit.sh`** — reusable AI-slop / brand-voice scanner (excludes legitimate enterprise terms like "AI transformation"; flags guru-slop + LLM tells).

## Why

Much of the site was built on older models — uneven brand voice, AI-slop in places, and some stale/inflated stats (e.g. the "630 skills" → corrected to "90+"). This makes the upgrade process systematic and tracked instead of ad hoc.

## Decisions baked in (from Frank, 2026-06-02)
- Keep named products/personas (Soulbook, Soul Frequency, etc.); fix only generic guru-slop in surrounding copy.
- Roll out autonomously to `main`, P0/P1 hubs first.
- Verify + correct all numeric claims.

Docs/tooling only — no app/runtime changes.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new content auditing tool that scans the codebase for specific terminology patterns, supporting both file density ranking across key directories and targeted analysis of specified paths with line-by-line reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->