### PR TITLE
fix(voice): de-slop /resources/templates copy (keep product names)

### DIFF
--- a/app/resources/templates/page.tsx
+++ b/app/resources/templates/page.tsx
@@ -4,14 +4,14 @@ import { Download, ExternalLink, FileText, Users, Zap } from 'lucide-react'
 import { createMetadata } from '@/lib/seo'
 
 export const metadata = createMetadata({
-  title: 'FrankX Template Library - Soul-Aligned AI Systems',
-  description: 'Download proven templates for conscious AI implementation, agent governance, and transformation rituals. Enterprise-grade systems made accessible.',
+  title: 'FrankX Template Library - Production AI Systems',
+  description: 'Download proven templates for AI implementation, agent governance, and operational workflows. Enterprise-grade systems made accessible.',
   keywords: [
     'ai templates',
     'agent governance templates',
-    'conscious ai framework',
+    'ai governance framework',
     'oracle ai architecture',
-    'transformation rituals'
+    'ai workflow templates'
   ],
   path: '/resources/templates'
 })
@@ -20,12 +20,12 @@ const templateCategories = [
   {
     id: 'ai-governance',
     title: 'AI Governance & Strategy',
-    description: 'Enterprise-grade frameworks for conscious AI implementation',
+    description: 'Enterprise-grade frameworks for production AI implementation',
     icon: FileText,
     templates: [
       {
-        title: 'Conscious AI Governance Playbook',
-        description: 'Complete framework for implementing soul-aligned AI systems in enterprise environments',
+        title: 'AI Governance Playbook',
+        description: 'Complete framework for implementing governed AI systems in enterprise environments',
         downloadUrl: '/templates/governance-overview.html',
         type: 'PDF Guide',
         pages: 24
@@ -39,7 +39,7 @@ const templateCategories = [
       },
       {
         title: 'AI Strategy Canvas',
-        description: 'Visual planning tool for aligning AI initiatives with consciousness evolution',
+        description: 'Visual planning tool for aligning AI initiatives with business strategy',
         downloadUrl: '/tools/strategy-canvas',
         type: 'PDF Canvas',
         pages: 1
@@ -48,13 +48,13 @@ const templateCategories = [
   },
   {
     id: 'transformation-rituals',
-    title: 'Transformation Rituals',
-    description: 'Daily practices for AI-human consciousness evolution',
+    title: 'Daily Operating Practices',
+    description: 'Repeatable workflows for running AI systems day to day',
     icon: Zap,
     templates: [
       {
         title: 'Daily Intelligence Operations Ritual',
-        description: 'Complete workflow for maintaining conscious AI systems',
+        description: 'Complete workflow for maintaining production AI systems',
         downloadUrl: '/templates/coe-checklist.html',
         type: 'Markdown Guide',
         pages: 8
@@ -97,7 +97,7 @@ const templateCategories = [
       },
       {
         title: 'Community AI Ritual Template',
-        description: 'Framework for group consciousness evolution practices',
+        description: 'Framework for recurring group AI practice sessions',
         downloadUrl: '/pdf-templates/5-suno-prompts.html',
         type: 'Markdown Template',
         pages: 5
@@ -118,8 +118,8 @@ export default function TemplatesPage() {
               FrankX Template Library
             </h1>
             <p className="mt-6 text-lg text-white/75 leading-relaxed">
-              Enterprise-grade systems made accessible. Download proven frameworks for conscious AI implementation,
-              transformation rituals, and soul-aligned technology adoption.
+              Enterprise-grade systems made accessible. Download proven frameworks for AI implementation,
+              agent governance, and team adoption.
             </p>
 
             <div className="mt-8 flex flex-wrap justify-center gap-4 text-sm">
@@ -127,7 +127,7 @@ export default function TemplatesPage() {
                 📋 Enterprise Ready
               </div>
               <div className="rounded-full border border-white/20 bg-white/10 px-4 py-2">
-                🌟 Consciousness Aligned
+                🎯 Production-Tested
               </div>
               <div className="rounded-full border border-white/20 bg-white/10 px-4 py-2">
                 🚀 Immediately Actionable


### PR DESCRIPTION
## What

Removes guru-slop from the public **/resources/templates** page, per the brand voice guidelines in `CLAUDE.md` (which explicitly list "soul-aligned", "consciousness", "transformation" as language to avoid).

**Before → after (copy only):**
- Meta title: "Soul-Aligned AI Systems" → "Production AI Systems"
- Meta/keywords: "conscious ai framework", "transformation rituals" → "ai governance framework", "ai workflow templates"
- Category "AI Governance" desc: "conscious AI implementation" → "production AI implementation"
- "Conscious AI Governance Playbook" → "AI Governance Playbook"; "soul-aligned AI systems" → "governed AI systems"
- "aligning AI initiatives with consciousness evolution" → "...with business strategy"
- Category "Transformation Rituals" → "Daily Operating Practices"; "AI-human consciousness evolution" → "running AI systems day to day"
- "maintaining conscious AI systems" → "maintaining production AI systems"
- "group consciousness evolution practices" → "recurring group AI practice sessions"
- Hero: "conscious AI implementation, transformation rituals, and soul-aligned technology adoption" → "AI implementation, agent governance, and team adoption"
- Badge "🌟 Consciousness Aligned" → "🎯 Production-Tested"

## Preserved (intentional)
- **"Soul Frequency"** product name, all `downloadUrl`s, the `transformation-rituals` anchor `id`, and the legitimate enterprise term **"AI transformation"** (line ~202).

## Scope
Single file, copy-only — no logic, routes, or component changes. First batch of the model-upgrade voice sweep tracked in `docs/HUB_REGISTRY.md`.

Note: two minor multi-cloud one-liners ("seamless"→"native", "cutting-edge"→"frontier") are staged and will follow in a separate batch.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_