### PR TITLE
feat(observatory): Agent Observatory showcase at /observatory

### DIFF
--- a/app/observatory/layout.tsx
+++ b/app/observatory/layout.tsx
@@ -3,17 +3,17 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Agent Observatory — The Agentic Creator OS Fleet',
   description:
-    'An interactive map of the Agentic Creator OS: 142 specialized agents, 108 skills, 66 commands, 8 workflows, and the IAM capability matrix that governs them.',
+    'An interactive map of the Agentic Creator OS: specialized agents, skills, commands, workflows, and the IAM capability matrix that governs them.',
   openGraph: {
     title: 'Agent Observatory — The Agentic Creator OS Fleet',
     description:
-      'Explore 142 specialized AI agents, their skills, commands, workflows, and IAM scoping in one interactive graph.',
+      'Explore the Agentic Creator OS fleet — agents, skills, commands, workflows, and IAM scoping in one interactive graph.',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Agent Observatory — The Agentic Creator OS Fleet',
-    description: 'An interactive map of 142 agents, 108 skills, and the system that orchestrates them.',
+    description: 'An interactive map of the agent fleet and the system that orchestrates it.',
   },
 }
 

--- a/app/observatory/layout.tsx
+++ b/app/observatory/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Agent Observatory — The Agentic Creator OS Fleet',
+  description:
+    'An interactive map of the Agentic Creator OS: 142 specialized agents, 108 skills, 66 commands, 8 workflows, and the IAM capability matrix that governs them.',
+  openGraph: {
+    title: 'Agent Observatory — The Agentic Creator OS Fleet',
+    description:
+      'Explore 142 specialized AI agents, their skills, commands, workflows, and IAM scoping in one interactive graph.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Agent Observatory — The Agentic Creator OS Fleet',
+    description: 'An interactive map of 142 agents, 108 skills, and the system that orchestrates them.',
+  },
+}
+
+export default function ObservatoryLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/observatory/page.tsx
+++ b/app/observatory/page.tsx
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Catalog } from '@/lib/observatory/types'
+import { ObservatoryShell } from '@/components/observatory/ObservatoryShell'
+
+export const dynamic = 'force-static'
+
+function loadCatalog(): Catalog {
+  const path = join(process.cwd(), 'public/observatory/catalog.json')
+  return JSON.parse(readFileSync(path, 'utf-8')) as Catalog
+}
+
+export default function ObservatoryPage() {
+  const catalog = loadCatalog()
+  return <ObservatoryShell catalog={catalog} />
+}

--- a/components/observatory/AgentGraph.tsx
+++ b/components/observatory/AgentGraph.tsx
@@ -47,22 +47,19 @@ export function AgentGraph({
   const [nodes, setNodes, onNodesChange] = useNodesState(layout.rfNodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState(layout.rfEdges)
 
-  // Re-layout when inputs change
+  // Sync nodes/edges whenever layout, live-active ids, or selection changes.
+  // Unified so a layout change (view/filter/search) never drops the active or
+  // selected highlight — both are re-derived here every time.
   useEffect(() => {
-    setNodes(layout.rfNodes)
-    setEdges(layout.rfEdges)
-  }, [layout, setNodes, setEdges])
-
-  // Apply live-active flags without recomputing layout
-  useEffect(() => {
-    if (!activeIds) return
-    setNodes((ns) =>
-      ns.map((n) => ({
+    setNodes(
+      layout.rfNodes.map((n) => ({
         ...n,
-        data: { ...n.data, active: activeIds.has(n.id) },
+        selected: n.id === selectedId,
+        data: { ...n.data, active: activeIds?.has(n.id) ?? false },
       })),
     )
-  }, [activeIds, setNodes])
+    setEdges(layout.rfEdges)
+  }, [layout, activeIds, selectedId, setNodes, setEdges])
 
   return (
     <div className="relative h-full w-full" style={{ background: palette.kraft }}>

--- a/components/observatory/AgentGraph.tsx
+++ b/components/observatory/AgentGraph.tsx
@@ -16,8 +16,9 @@ import type { Catalog, CatalogNode, NodeKind, ObservatoryView } from '@/lib/obse
 import { computeLayout } from '@/lib/observatory/layout'
 import { kindColor, tierColor, palette } from '@/lib/observatory/theme'
 import { ObservatoryNode } from './ObservatoryNode'
+import { ClusterLabel } from './ClusterLabel'
 
-const nodeTypes = { observatory: ObservatoryNode }
+const nodeTypes = { observatory: ObservatoryNode, clusterLabel: ClusterLabel }
 
 interface AgentGraphProps {
   catalog: Catalog
@@ -62,14 +63,22 @@ export function AgentGraph({
   }, [layout, activeIds, selectedId, setNodes, setEdges])
 
   return (
-    <div className="relative h-full w-full" style={{ background: palette.kraft }}>
+    <div
+      className="relative h-full w-full"
+      style={{
+        background: `radial-gradient(ellipse 80% 70% at 50% 42%, ${palette.inkSoft} 0%, ${palette.ink} 70%)`,
+      }}
+    >
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
-        onNodeClick={(_, n: RFNode) => onSelect?.((n.data as { node: CatalogNode }).node)}
+        onNodeClick={(_, n: RFNode) => {
+          const node = (n.data as { node?: CatalogNode })?.node
+          if (node) onSelect?.(node)
+        }}
         onPaneClick={() => onSelect?.(null)}
         connectionLineType={ConnectionLineType.SmoothStep}
         fitView
@@ -94,7 +103,7 @@ export function AgentGraph({
           zoomable
           nodeColor={(n) => {
             const node = (n.data as { node?: CatalogNode })?.node
-            if (!node) return palette.clay
+            if (!node) return palette.orange
             return node.kind === 'agent' && node.tier ? tierColor[node.tier] : kindColor[node.kind]
           }}
           maskColor="rgba(24,23,18,0.82)"

--- a/components/observatory/AgentGraph.tsx
+++ b/components/observatory/AgentGraph.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  ConnectionLineType,
+  type Node as RFNode,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import type { Catalog, CatalogNode, NodeKind, ObservatoryView } from '@/lib/observatory/types'
+import { computeLayout } from '@/lib/observatory/layout'
+import { kindColor, tierColor, palette } from '@/lib/observatory/theme'
+import { ObservatoryNode } from './ObservatoryNode'
+
+const nodeTypes = { observatory: ObservatoryNode }
+
+interface AgentGraphProps {
+  catalog: Catalog
+  view: ObservatoryView
+  visibleKinds: Set<NodeKind>
+  query: string
+  /** ids currently "live" (live-monitor surface) */
+  activeIds?: Set<string>
+  onSelect?: (node: CatalogNode | null) => void
+  selectedId?: string | null
+}
+
+export function AgentGraph({
+  catalog,
+  view,
+  visibleKinds,
+  query,
+  activeIds,
+  onSelect,
+  selectedId,
+}: AgentGraphProps) {
+  const layout = useMemo(
+    () => computeLayout(catalog, view, visibleKinds, query),
+    [catalog, view, visibleKinds, query],
+  )
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(layout.rfNodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState(layout.rfEdges)
+
+  // Re-layout when inputs change
+  useEffect(() => {
+    setNodes(layout.rfNodes)
+    setEdges(layout.rfEdges)
+  }, [layout, setNodes, setEdges])
+
+  // Apply live-active flags without recomputing layout
+  useEffect(() => {
+    if (!activeIds) return
+    setNodes((ns) =>
+      ns.map((n) => ({
+        ...n,
+        data: { ...n.data, active: activeIds.has(n.id) },
+      })),
+    )
+  }, [activeIds, setNodes])
+
+  return (
+    <div className="relative h-full w-full" style={{ background: palette.kraft }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={(_, n: RFNode) => onSelect?.((n.data as { node: CatalogNode }).node)}
+        onPaneClick={() => onSelect?.(null)}
+        connectionLineType={ConnectionLineType.SmoothStep}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+        minZoom={0.12}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+      >
+        <Background color={palette.lineStrong} gap={28} size={1} />
+        <Controls
+          showInteractive={false}
+          style={{
+            background: 'rgba(38,36,28,0.9)',
+            borderRadius: 10,
+            border: `1px solid ${palette.line}`,
+          }}
+        />
+        <MiniMap
+          pannable
+          zoomable
+          nodeColor={(n) => {
+            const node = (n.data as { node?: CatalogNode })?.node
+            if (!node) return palette.clay
+            return node.kind === 'agent' && node.tier ? tierColor[node.tier] : kindColor[node.kind]
+          }}
+          maskColor="rgba(24,23,18,0.82)"
+          style={{ background: 'rgba(24,23,18,0.95)', borderRadius: 10, border: `1px solid ${palette.line}` }}
+        />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/components/observatory/ClusterLabel.tsx
+++ b/components/observatory/ClusterLabel.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { memo } from 'react'
+import type { NodeProps } from '@xyflow/react'
+import { palette, withAlpha } from '@/lib/observatory/theme'
+
+export interface ClusterLabelData {
+  label: string
+  color: string
+  count: number
+  [key: string]: unknown
+}
+
+function ClusterLabelComponent({ data }: NodeProps) {
+  const { label, color, count } = data as ClusterLabelData
+  return (
+    <div
+      className="pointer-events-none flex items-center gap-2 whitespace-nowrap rounded-full px-3 py-1"
+      style={{
+        background: withAlpha(color, 0.12),
+        border: `1px solid ${withAlpha(color, 0.4)}`,
+        width: 180,
+        justifyContent: 'center',
+      }}
+    >
+      <span className="h-1.5 w-1.5 rounded-full" style={{ background: color }} />
+      <span
+        className="text-[12px] font-semibold capitalize tracking-wide"
+        style={{ color: palette.light, fontFamily: 'var(--font-poppins, inherit)' }}
+      >
+        {label}
+      </span>
+      <span className="text-[11px] tabular-nums" style={{ color: palette.faint }}>
+        {count}
+      </span>
+    </div>
+  )
+}
+
+export const ClusterLabel = memo(ClusterLabelComponent)

--- a/components/observatory/IamMatrix.tsx
+++ b/components/observatory/IamMatrix.tsx
@@ -22,12 +22,12 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
   }
 
   return (
-    <div className="h-full overflow-auto p-6" style={{ background: palette.kraft }}>
+    <div className="h-full overflow-auto p-6" style={{ background: palette.ink }}>
       <div className="mx-auto max-w-5xl">
-        <h3 className="mb-1 text-lg font-semibold" style={{ color: palette.cream }}>
+        <h3 className="mb-1 text-lg font-semibold" style={{ color: palette.light }}>
           Agent IAM — capability matrix
         </h3>
-        <p className="mb-5 text-sm" style={{ color: palette.creamDim }}>
+        <p className="mb-5 text-sm" style={{ color: palette.midGray }}>
           Six role profiles scope which tools each agent class may use and where it may write.
           Content writers can&apos;t run Bash; security auditors are read-only.
         </p>
@@ -38,7 +38,7 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
               <tr>
                 <th
                   className="sticky left-0 z-10 px-4 py-3 text-left font-medium"
-                  style={{ background: palette.kraftPanel, color: palette.creamDim }}
+                  style={{ background: palette.panel, color: palette.midGray }}
                 >
                   Tool
                 </th>
@@ -46,7 +46,7 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
                   <th
                     key={name}
                     className="px-3 py-3 text-center text-xs font-medium"
-                    style={{ background: palette.kraftPanel, color: palette.cream, minWidth: 96 }}
+                    style={{ background: palette.panel, color: palette.light, minWidth: 96 }}
                   >
                     {name.replace('-', ' ')}
                   </th>
@@ -55,16 +55,16 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
             </thead>
             <tbody>
               {tools.map((tool, i) => (
-                <tr key={tool} style={{ background: i % 2 ? palette.kraftSoft : 'transparent' }}>
+                <tr key={tool} style={{ background: i % 2 ? palette.inkSoft : 'transparent' }}>
                   <td
                     className="sticky left-0 z-10 px-4 py-2 font-mono text-xs"
-                    style={{ background: i % 2 ? palette.kraftSoft : palette.kraft, color: palette.cream }}
+                    style={{ background: i % 2 ? palette.inkSoft : palette.ink, color: palette.light }}
                   >
                     {tool}
                   </td>
                   {profiles.map(([name, p]) => {
                     const s = state(p.allowedTools, p.deniedTools, tool)
-                    const color = s === 'allow' ? ALLOW : s === 'deny' ? DENY : palette.creamFaint
+                    const color = s === 'allow' ? ALLOW : s === 'deny' ? DENY : palette.faint
                     return (
                       <td key={name} className="px-3 py-2 text-center">
                         <span
@@ -93,15 +93,15 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
             <div
               key={name}
               className="rounded-xl border p-4"
-              style={{ borderColor: palette.line, background: palette.kraftPanel }}
+              style={{ borderColor: palette.line, background: palette.panel }}
             >
-              <div className="text-sm font-semibold capitalize" style={{ color: palette.clayBright }}>
+              <div className="text-sm font-semibold capitalize" style={{ color: palette.orangeBright }}>
                 {name.replace('-', ' ')}
               </div>
-              <p className="mt-1 text-xs" style={{ color: palette.creamDim }}>
+              <p className="mt-1 text-xs" style={{ color: palette.midGray }}>
                 {p.description}
               </p>
-              <div className="mt-3 flex flex-wrap gap-2 text-[11px]" style={{ color: palette.creamFaint }}>
+              <div className="mt-3 flex flex-wrap gap-2 text-[11px]" style={{ color: palette.faint }}>
                 <span>max edits: {p.maxFileEdits ?? '—'}</span>
                 <span>· create: {p.canCreateFiles ? 'yes' : 'no'}</span>
                 <span>· delete: {p.canDeleteFiles ? 'yes' : 'no'}</span>

--- a/components/observatory/IamMatrix.tsx
+++ b/components/observatory/IamMatrix.tsx
@@ -22,7 +22,7 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
   }
 
   return (
-    <div className="h-full overflow-auto p-6" style={{ background: palette.ink }}>
+    <div className="h-full overflow-auto p-4 sm:p-6" style={{ background: palette.ink }}>
       <div className="mx-auto max-w-5xl">
         <h3 className="mb-1 text-lg font-semibold" style={{ color: palette.light }}>
           Agent IAM — capability matrix
@@ -32,8 +32,8 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
           write. Content writers can&apos;t run Bash; security auditors are read-only.
         </p>
 
-        <div className="overflow-hidden rounded-2xl border" style={{ borderColor: palette.line }}>
-          <table className="w-full border-collapse text-sm">
+        <div className="overflow-x-auto rounded-2xl border" style={{ borderColor: palette.line }}>
+          <table className="w-full min-w-[640px] border-collapse text-sm">
             <thead>
               <tr>
                 <th

--- a/components/observatory/IamMatrix.tsx
+++ b/components/observatory/IamMatrix.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import type { Catalog } from '@/lib/observatory/types'
+import { palette, withAlpha } from '@/lib/observatory/theme'
+
+const ALLOW = '#8C9A5B'
+const DENY = '#C2624F'
+
+export function IamMatrix({ catalog }: { catalog: Catalog }) {
+  const profiles = Object.entries(catalog.iam)
+  // Universe of tools across all profiles
+  const tools = [
+    ...new Set(
+      profiles.flatMap(([, p]) => [...(p.allowedTools || []), ...(p.deniedTools || [])]),
+    ),
+  ].sort()
+
+  const state = (allowed?: string[], denied?: string[], tool?: string) => {
+    if (denied?.includes(tool!)) return 'deny'
+    if (allowed?.includes(tool!)) return 'allow'
+    return 'none'
+  }
+
+  return (
+    <div className="h-full overflow-auto p-6" style={{ background: palette.kraft }}>
+      <div className="mx-auto max-w-5xl">
+        <h3 className="mb-1 text-lg font-semibold" style={{ color: palette.cream }}>
+          Agent IAM — capability matrix
+        </h3>
+        <p className="mb-5 text-sm" style={{ color: palette.creamDim }}>
+          Six role profiles scope which tools each agent class may use and where it may write.
+          Content writers can&apos;t run Bash; security auditors are read-only.
+        </p>
+
+        <div className="overflow-hidden rounded-2xl border" style={{ borderColor: palette.line }}>
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                <th
+                  className="sticky left-0 z-10 px-4 py-3 text-left font-medium"
+                  style={{ background: palette.kraftPanel, color: palette.creamDim }}
+                >
+                  Tool
+                </th>
+                {profiles.map(([name]) => (
+                  <th
+                    key={name}
+                    className="px-3 py-3 text-center text-xs font-medium"
+                    style={{ background: palette.kraftPanel, color: palette.cream, minWidth: 96 }}
+                  >
+                    {name.replace('-', ' ')}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {tools.map((tool, i) => (
+                <tr key={tool} style={{ background: i % 2 ? palette.kraftSoft : 'transparent' }}>
+                  <td
+                    className="sticky left-0 z-10 px-4 py-2 font-mono text-xs"
+                    style={{ background: i % 2 ? palette.kraftSoft : palette.kraft, color: palette.cream }}
+                  >
+                    {tool}
+                  </td>
+                  {profiles.map(([name, p]) => {
+                    const s = state(p.allowedTools, p.deniedTools, tool)
+                    const color = s === 'allow' ? ALLOW : s === 'deny' ? DENY : palette.creamFaint
+                    return (
+                      <td key={name} className="px-3 py-2 text-center">
+                        <span
+                          className="inline-flex h-5 w-5 items-center justify-center rounded-md text-[11px]"
+                          style={{
+                            background: s === 'none' ? 'transparent' : withAlpha(color, 0.18),
+                            color,
+                            border: s === 'none' ? `1px solid ${palette.line}` : `1px solid ${withAlpha(color, 0.5)}`,
+                          }}
+                          title={`${name}: ${s}`}
+                        >
+                          {s === 'allow' ? '✓' : s === 'deny' ? '✕' : '·'}
+                        </span>
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Profile cards */}
+        <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {profiles.map(([name, p]) => (
+            <div
+              key={name}
+              className="rounded-xl border p-4"
+              style={{ borderColor: palette.line, background: palette.kraftPanel }}
+            >
+              <div className="text-sm font-semibold capitalize" style={{ color: palette.clayBright }}>
+                {name.replace('-', ' ')}
+              </div>
+              <p className="mt-1 text-xs" style={{ color: palette.creamDim }}>
+                {p.description}
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2 text-[11px]" style={{ color: palette.creamFaint }}>
+                <span>max edits: {p.maxFileEdits ?? '—'}</span>
+                <span>· create: {p.canCreateFiles ? 'yes' : 'no'}</span>
+                <span>· delete: {p.canDeleteFiles ? 'yes' : 'no'}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/observatory/IamMatrix.tsx
+++ b/components/observatory/IamMatrix.tsx
@@ -28,8 +28,8 @@ export function IamMatrix({ catalog }: { catalog: Catalog }) {
           Agent IAM — capability matrix
         </h3>
         <p className="mb-5 text-sm" style={{ color: palette.midGray }}>
-          Six role profiles scope which tools each agent class may use and where it may write.
-          Content writers can&apos;t run Bash; security auditors are read-only.
+          {profiles.length} role profiles scope which tools each agent class may use and where it may
+          write. Content writers can&apos;t run Bash; security auditors are read-only.
         </p>
 
         <div className="overflow-hidden rounded-2xl border" style={{ borderColor: palette.line }}>

--- a/components/observatory/IamMatrix.tsx
+++ b/components/observatory/IamMatrix.tsx
@@ -7,11 +7,11 @@ const ALLOW = '#8C9A5B'
 const DENY = '#C2624F'
 
 export function IamMatrix({ catalog }: { catalog: Catalog }) {
-  const profiles = Object.entries(catalog.iam)
+  const profiles = Object.entries(catalog.iam || {})
   // Universe of tools across all profiles
   const tools = [
     ...new Set(
-      profiles.flatMap(([, p]) => [...(p.allowedTools || []), ...(p.deniedTools || [])]),
+      profiles.flatMap(([, p]) => [...(p?.allowedTools || []), ...(p?.deniedTools || [])]),
     ),
   ].sort()
 

--- a/components/observatory/ObservatoryDirectory.tsx
+++ b/components/observatory/ObservatoryDirectory.tsx
@@ -4,10 +4,18 @@ import { useMemo } from 'react'
 import type { Catalog, CatalogNode, NodeKind } from '@/lib/observatory/types'
 import { kindColor, kindLabel, tierColor, palette, withAlpha } from '@/lib/observatory/theme'
 
+const KIND_GLYPH: Record<string, string> = {
+  agent: '◆',
+  skill: '✦',
+  command: '⌘',
+  workflow: '⛓',
+  'iam-profile': '⛨',
+}
+
 /**
  * Touch/mobile fallback for the graph — a searchable, grouped card directory.
  * Graphs are unusable on small screens, so below the md breakpoint we render
- * this instead (same data, same filters, same detail-drawer wiring).
+ * this instead (same data, same filters, same detail-sheet wiring).
  */
 export function ObservatoryDirectory({
   catalog,
@@ -39,19 +47,43 @@ export function ObservatoryDirectory({
   }, [catalog, visibleKinds, q])
 
   const order: NodeKind[] = ['agent', 'skill', 'command', 'workflow', 'iam-profile']
+  const total = [...groups.values()].reduce((s, g) => s + g.length, 0)
+
+  if (total === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-8 text-center" style={{ background: palette.ink }}>
+        <p className="text-sm" style={{ color: palette.faint }}>
+          Nothing matches “{query}”. Try a different search or re-enable a filter.
+        </p>
+      </div>
+    )
+  }
 
   return (
-    <div className="h-full overflow-auto px-4 py-5" style={{ background: palette.ink }}>
+    <div
+      className="h-full overflow-auto overscroll-contain px-4 pb-[max(2rem,env(safe-area-inset-bottom))] pt-1"
+      style={{ background: palette.ink }}
+    >
       {order
         .filter((k) => groups.has(k))
         .map((kind) => (
-          <section key={kind} className="mb-6">
+          <section key={kind} className="mb-5">
             <h3
-              className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider"
-              style={{ color: palette.midGray }}
+              className="sticky top-0 z-10 -mx-4 mb-2 flex items-center gap-2 px-4 py-2.5 text-xs font-semibold uppercase tracking-wider backdrop-blur-sm"
+              style={{
+                color: palette.midGray,
+                background: withAlpha(palette.ink, 0.92),
+                borderBottom: `1px solid ${palette.line}`,
+              }}
             >
               <span className="h-2 w-2 rounded-full" style={{ background: kindColor[kind] }} />
-              {kindLabel[kind]} · {groups.get(kind)!.length}
+              {kindLabel[kind]}
+              <span
+                className="ml-1 rounded-full px-1.5 py-0.5 text-[10px] tabular-nums"
+                style={{ background: withAlpha(kindColor[kind], 0.15), color: palette.light }}
+              >
+                {groups.get(kind)!.length}
+              </span>
             </h3>
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
               {groups.get(kind)!.map((n) => {
@@ -60,11 +92,21 @@ export function ObservatoryDirectory({
                   <button
                     key={n.id}
                     onClick={() => onSelect(n)}
-                    className="flex flex-col gap-1 rounded-xl border p-3 text-left transition-colors active:scale-[0.99]"
-                    style={{ background: palette.panel, borderColor: palette.line }}
+                    className="flex min-h-[64px] flex-col gap-1 rounded-xl border p-3 text-left transition-transform active:scale-[0.99]"
+                    style={{
+                      background: palette.panel,
+                      borderColor: palette.line,
+                      borderLeft: `3px solid ${withAlpha(accent, 0.7)}`,
+                    }}
                   >
                     <span className="flex items-center gap-2">
-                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: accent }} />
+                      <span
+                        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-[10px]"
+                        style={{ background: withAlpha(accent, 0.16), color: accent }}
+                        aria-hidden
+                      >
+                        {KIND_GLYPH[n.kind] ?? '◆'}
+                      </span>
                       <span className="truncate text-sm font-medium" style={{ color: palette.light }}>
                         {n.name}
                       </span>
@@ -78,7 +120,7 @@ export function ObservatoryDirectory({
                       )}
                     </span>
                     {n.description && (
-                      <span className="line-clamp-2 text-xs" style={{ color: palette.faint }}>
+                      <span className="line-clamp-2 text-xs leading-snug" style={{ color: palette.faint }}>
                         {n.description}
                       </span>
                     )}

--- a/components/observatory/ObservatoryDirectory.tsx
+++ b/components/observatory/ObservatoryDirectory.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { Catalog, CatalogNode, NodeKind } from '@/lib/observatory/types'
+import { kindColor, kindLabel, tierColor, palette, withAlpha } from '@/lib/observatory/theme'
+
+/**
+ * Touch/mobile fallback for the graph — a searchable, grouped card directory.
+ * Graphs are unusable on small screens, so below the md breakpoint we render
+ * this instead (same data, same filters, same detail-drawer wiring).
+ */
+export function ObservatoryDirectory({
+  catalog,
+  visibleKinds,
+  query,
+  onSelect,
+}: {
+  catalog: Catalog
+  visibleKinds: Set<NodeKind>
+  query: string
+  onSelect: (n: CatalogNode) => void
+}) {
+  const q = query.trim().toLowerCase()
+  const groups = useMemo(() => {
+    const out = new Map<NodeKind, CatalogNode[]>()
+    for (const n of catalog.nodes || []) {
+      if (!visibleKinds.has(n.kind)) continue
+      if (
+        q &&
+        !(n.name ?? '').toLowerCase().includes(q) &&
+        !(n.description ?? '').toLowerCase().includes(q) &&
+        !(n.group ?? '').toLowerCase().includes(q)
+      )
+        continue
+      if (!out.has(n.kind)) out.set(n.kind, [])
+      out.get(n.kind)!.push(n)
+    }
+    return out
+  }, [catalog, visibleKinds, q])
+
+  const order: NodeKind[] = ['agent', 'skill', 'command', 'workflow', 'iam-profile']
+
+  return (
+    <div className="h-full overflow-auto px-4 py-5" style={{ background: palette.ink }}>
+      {order
+        .filter((k) => groups.has(k))
+        .map((kind) => (
+          <section key={kind} className="mb-6">
+            <h3
+              className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider"
+              style={{ color: palette.midGray }}
+            >
+              <span className="h-2 w-2 rounded-full" style={{ background: kindColor[kind] }} />
+              {kindLabel[kind]} · {groups.get(kind)!.length}
+            </h3>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {groups.get(kind)!.map((n) => {
+                const accent = n.kind === 'agent' && n.tier ? tierColor[n.tier] : kindColor[n.kind]
+                return (
+                  <button
+                    key={n.id}
+                    onClick={() => onSelect(n)}
+                    className="flex flex-col gap-1 rounded-xl border p-3 text-left transition-colors active:scale-[0.99]"
+                    style={{ background: palette.panel, borderColor: palette.line }}
+                  >
+                    <span className="flex items-center gap-2">
+                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: accent }} />
+                      <span className="truncate text-sm font-medium" style={{ color: palette.light }}>
+                        {n.name}
+                      </span>
+                      {n.tier && (
+                        <span
+                          className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px]"
+                          style={{ background: withAlpha(accent, 0.18), color: palette.light }}
+                        >
+                          {n.tier}
+                        </span>
+                      )}
+                    </span>
+                    {n.description && (
+                      <span className="line-clamp-2 text-xs" style={{ color: palette.faint }}>
+                        {n.description}
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </section>
+        ))}
+    </div>
+  )
+}

--- a/components/observatory/ObservatoryNode.tsx
+++ b/components/observatory/ObservatoryNode.tsx
@@ -12,49 +12,62 @@ export interface ObservatoryNodeData {
   [key: string]: unknown
 }
 
+const KIND_GLYPH: Record<string, string> = {
+  agent: '◆',
+  skill: '✦',
+  command: '⌘',
+  workflow: '⛓',
+  'iam-profile': '⛨',
+}
+
 function ObservatoryNodeComponent({ data, selected }: NodeProps) {
   const { node, dim, active } = data as ObservatoryNodeData
   const accent = node.kind === 'agent' && node.tier ? tierColor[node.tier] : kindColor[node.kind]
 
   return (
     <div
-      className="group relative flex items-center gap-2 rounded-xl px-3 py-2 transition-all duration-200"
+      className="group relative flex items-center gap-2 rounded-xl px-2.5 py-2 transition-all duration-200 hover:-translate-y-px"
       style={{
-        width: 178,
-        background: active ? withAlpha(accent, 0.22) : palette.kraftPanel,
+        width: 168,
+        background: active ? withAlpha(accent, 0.2) : selected ? palette.panelHi : palette.panel,
         border: `1px solid ${selected ? accent : active ? withAlpha(accent, 0.7) : palette.line}`,
         boxShadow: active
-          ? `0 0 0 2px ${withAlpha(accent, 0.5)}, 0 0 22px ${withAlpha(accent, 0.55)}`
+          ? `0 0 0 1.5px ${withAlpha(accent, 0.55)}, 0 0 22px ${withAlpha(accent, 0.5)}`
           : selected
-          ? `0 0 0 1px ${withAlpha(accent, 0.6)}, 0 6px 20px rgba(0,0,0,0.4)`
-          : '0 1px 2px rgba(0,0,0,0.3)',
-        opacity: dim ? 0.28 : 1,
+          ? `0 0 0 1px ${withAlpha(accent, 0.6)}, 0 8px 24px rgba(0,0,0,0.45)`
+          : '0 1px 2px rgba(0,0,0,0.35)',
+        opacity: dim ? 0.22 : 1,
       }}
     >
-      <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1 }} />
+      <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1, border: 0 }} />
       <span
-        className="shrink-0 rounded-full"
-        style={{
-          width: 9,
-          height: 9,
-          background: accent,
-          boxShadow: active ? `0 0 8px ${accent}` : 'none',
-        }}
-      />
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-[10px]"
+        style={{ background: withAlpha(accent, active ? 0.4 : 0.16), color: accent, boxShadow: active ? `0 0 8px ${accent}` : 'none' }}
+        aria-hidden
+      >
+        {KIND_GLYPH[node.kind] ?? '◆'}
+      </span>
       <span
         className="truncate text-[12px] font-medium leading-tight"
-        style={{ color: palette.cream }}
+        style={{ color: palette.light }}
         title={node.name}
       >
         {node.name}
       </span>
-      {active && (
+      {node.status === 'gap' && (
         <span
-          className="absolute inset-0 rounded-xl"
-          style={{ border: `1px solid ${accent}`, animation: 'observatory-ping 1.4s ease-out infinite' }}
+          className="ml-auto h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{ background: palette.faint }}
+          title="gap — not yet shipped"
         />
       )}
-      <Handle type="source" position={Position.Bottom} style={{ opacity: 0, width: 1, height: 1 }} />
+      {active && (
+        <span
+          className="pointer-events-none absolute inset-0 rounded-xl motion-reduce:hidden"
+          style={{ border: `1px solid ${accent}`, animation: 'observatory-ping 1.5s ease-out infinite' }}
+        />
+      )}
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0, width: 1, height: 1, border: 0 }} />
     </div>
   )
 }

--- a/components/observatory/ObservatoryNode.tsx
+++ b/components/observatory/ObservatoryNode.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { memo } from 'react'
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import type { CatalogNode } from '@/lib/observatory/types'
+import { kindColor, tierColor, palette, withAlpha } from '@/lib/observatory/theme'
+
+export interface ObservatoryNodeData {
+  node: CatalogNode
+  dim?: boolean
+  active?: boolean // live-monitor pulse
+  [key: string]: unknown
+}
+
+function ObservatoryNodeComponent({ data, selected }: NodeProps) {
+  const { node, dim, active } = data as ObservatoryNodeData
+  const accent = node.kind === 'agent' && node.tier ? tierColor[node.tier] : kindColor[node.kind]
+
+  return (
+    <div
+      className="group relative flex items-center gap-2 rounded-xl px-3 py-2 transition-all duration-200"
+      style={{
+        width: 178,
+        background: active ? withAlpha(accent, 0.22) : palette.kraftPanel,
+        border: `1px solid ${selected ? accent : active ? withAlpha(accent, 0.7) : palette.line}`,
+        boxShadow: active
+          ? `0 0 0 2px ${withAlpha(accent, 0.5)}, 0 0 22px ${withAlpha(accent, 0.55)}`
+          : selected
+          ? `0 0 0 1px ${withAlpha(accent, 0.6)}, 0 6px 20px rgba(0,0,0,0.4)`
+          : '0 1px 2px rgba(0,0,0,0.3)',
+        opacity: dim ? 0.28 : 1,
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0, width: 1, height: 1 }} />
+      <span
+        className="shrink-0 rounded-full"
+        style={{
+          width: 9,
+          height: 9,
+          background: accent,
+          boxShadow: active ? `0 0 8px ${accent}` : 'none',
+        }}
+      />
+      <span
+        className="truncate text-[12px] font-medium leading-tight"
+        style={{ color: palette.cream }}
+        title={node.name}
+      >
+        {node.name}
+      </span>
+      {active && (
+        <span
+          className="absolute inset-0 rounded-xl"
+          style={{ border: `1px solid ${accent}`, animation: 'observatory-ping 1.4s ease-out infinite' }}
+        />
+      )}
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0, width: 1, height: 1 }} />
+    </div>
+  )
+}
+
+export const ObservatoryNode = memo(ObservatoryNodeComponent)

--- a/components/observatory/ObservatoryShell.tsx
+++ b/components/observatory/ObservatoryShell.tsx
@@ -26,7 +26,9 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
 
   const tierCounts = useMemo(() => {
     const c: Record<string, number> = { haiku: 0, sonnet: 0, opus: 0 }
-    for (const n of catalog.nodes) if (n.kind === 'agent' && n.tier) c[n.tier]++
+    for (const n of catalog?.nodes || []) {
+      if (n.kind === 'agent' && n.tier && n.tier in c) c[n.tier]++
+    }
     return c
   }, [catalog])
 
@@ -51,9 +53,9 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
             </h1>
             <p className="mt-0.5 text-sm" style={{ color: palette.creamDim }}>
               The Agentic Creator OS fleet —{' '}
-              <span style={{ color: palette.clayBright }}>{catalog.counts.agent} agents</span>,{' '}
-              {catalog.counts.skill} skills, {catalog.counts.command} commands,{' '}
-              {catalog.counts.workflow} workflows.
+              <span style={{ color: palette.clayBright }}>{catalog.counts?.agent ?? 0} agents</span>,{' '}
+              {catalog.counts?.skill ?? 0} skills, {catalog.counts?.command ?? 0} commands,{' '}
+              {catalog.counts?.workflow ?? 0} workflows.
             </p>
           </div>
           <div className="flex items-center gap-3 text-xs" style={{ color: palette.creamFaint }}>

--- a/components/observatory/ObservatoryShell.tsx
+++ b/components/observatory/ObservatoryShell.tsx
@@ -1,0 +1,305 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { Catalog, CatalogNode, NodeKind, ObservatoryView } from '@/lib/observatory/types'
+import { kindColor, kindLabel, tierColor, tierLabel, palette, withAlpha } from '@/lib/observatory/theme'
+import { AgentGraph } from './AgentGraph'
+import { IamMatrix } from './IamMatrix'
+import { useLiveActivity, type LiveStatus } from '@/lib/observatory/useLiveActivity'
+
+const ALL_KINDS: NodeKind[] = ['agent', 'skill', 'command', 'workflow', 'iam-profile']
+
+const VIEWS: { id: ObservatoryView; label: string; hint: string }[] = [
+  { id: 'galaxy', label: 'Galaxy', hint: 'Everything, grouped by kind' },
+  { id: 'groups', label: 'Pillars', hint: 'Agents by domain, skills by category' },
+  { id: 'workflows', label: 'Workflows', hint: 'Composition DAG' },
+  { id: 'iam', label: 'IAM Matrix', hint: 'Capability scoping' },
+]
+
+export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
+  const [view, setView] = useState<ObservatoryView>('galaxy')
+  const [visibleKinds, setVisibleKinds] = useState<Set<NodeKind>>(new Set(ALL_KINDS))
+  const [query, setQuery] = useState('')
+  const [selected, setSelected] = useState<CatalogNode | null>(null)
+  const [live, setLive] = useState(false)
+  const { activeIds, status: liveStatus } = useLiveActivity(live)
+
+  const tierCounts = useMemo(() => {
+    const c: Record<string, number> = { haiku: 0, sonnet: 0, opus: 0 }
+    for (const n of catalog.nodes) if (n.kind === 'agent' && n.tier) c[n.tier]++
+    return c
+  }, [catalog])
+
+  const toggleKind = (k: NodeKind) => {
+    setVisibleKinds((prev) => {
+      const next = new Set(prev)
+      next.has(k) ? next.delete(k) : next.add(k)
+      return next.size === 0 ? new Set(ALL_KINDS) : next
+    })
+  }
+
+  return (
+    <div className="flex h-[100dvh] flex-col" style={{ background: palette.kraft, color: palette.cream }}>
+      <style>{`@keyframes observatory-ping{0%{opacity:.9;transform:scale(1)}100%{opacity:0;transform:scale(1.5)}}`}</style>
+
+      {/* Header */}
+      <header className="border-b px-6 py-4" style={{ borderColor: palette.line }}>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight" style={{ color: palette.cream }}>
+              Agent Observatory
+            </h1>
+            <p className="mt-0.5 text-sm" style={{ color: palette.creamDim }}>
+              The Agentic Creator OS fleet —{' '}
+              <span style={{ color: palette.clayBright }}>{catalog.counts.agent} agents</span>,{' '}
+              {catalog.counts.skill} skills, {catalog.counts.command} commands,{' '}
+              {catalog.counts.workflow} workflows.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs" style={{ color: palette.creamFaint }}>
+            {(['opus', 'sonnet', 'haiku'] as const).map((t) => (
+              <span key={t} className="flex items-center gap-1.5">
+                <span className="h-2.5 w-2.5 rounded-full" style={{ background: tierColor[t] }} />
+                {t} {tierCounts[t]}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* View tabs */}
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {VIEWS.map((v) => (
+            <button
+              key={v.id}
+              onClick={() => setView(v.id)}
+              title={v.hint}
+              className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
+              style={{
+                background: view === v.id ? withAlpha(palette.clay, 0.2) : 'transparent',
+                color: view === v.id ? palette.clayBright : palette.creamDim,
+                border: `1px solid ${view === v.id ? withAlpha(palette.clay, 0.5) : palette.line}`,
+              }}
+            >
+              {v.label}
+            </button>
+          ))}
+
+          <div className="ml-auto flex items-center gap-3">
+            <LiveToggle live={live} status={liveStatus} onToggle={() => setLive((v) => !v)} />
+            {view !== 'iam' && (
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search agents, skills…"
+                className="w-56 rounded-lg px-3 py-1.5 text-sm outline-none"
+                style={{ background: palette.kraftPanel, border: `1px solid ${palette.line}`, color: palette.cream }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Kind filter chips */}
+        {view !== 'iam' && view !== 'workflows' && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {ALL_KINDS.map((k) => {
+              const on = visibleKinds.has(k)
+              return (
+                <button
+                  key={k}
+                  onClick={() => toggleKind(k)}
+                  className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-opacity"
+                  style={{
+                    background: withAlpha(kindColor[k], on ? 0.16 : 0.04),
+                    color: on ? palette.cream : palette.creamFaint,
+                    border: `1px solid ${withAlpha(kindColor[k], on ? 0.5 : 0.15)}`,
+                    opacity: on ? 1 : 0.6,
+                  }}
+                >
+                  <span className="h-2 w-2 rounded-full" style={{ background: kindColor[k] }} />
+                  {kindLabel[k]} · {catalog.counts[k] ?? 0}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </header>
+
+      {/* Main */}
+      <div className="relative flex-1 overflow-hidden">
+        {view === 'iam' ? (
+          <IamMatrix catalog={catalog} />
+        ) : (
+          <AgentGraph
+            catalog={catalog}
+            view={view}
+            visibleKinds={visibleKinds}
+            query={query}
+            activeIds={live ? activeIds : undefined}
+            onSelect={setSelected}
+            selectedId={selected?.id}
+          />
+        )}
+
+        {/* Detail drawer */}
+        {selected && (
+          <aside
+            className="absolute right-0 top-0 h-full w-[340px] overflow-auto border-l p-5"
+            style={{ background: palette.kraftSoft, borderColor: palette.lineStrong }}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className="h-3 w-3 rounded-full"
+                  style={{
+                    background:
+                      selected.kind === 'agent' && selected.tier
+                        ? tierColor[selected.tier]
+                        : kindColor[selected.kind],
+                  }}
+                />
+                <span className="text-xs uppercase tracking-wider" style={{ color: palette.creamFaint }}>
+                  {kindLabel[selected.kind]}
+                </span>
+              </div>
+              <button onClick={() => setSelected(null)} style={{ color: palette.creamDim }} aria-label="Close">
+                ✕
+              </button>
+            </div>
+
+            <h2 className="mt-2 text-lg font-semibold" style={{ color: palette.cream }}>
+              {selected.name}
+            </h2>
+
+            <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+              <span className="rounded-md px-2 py-0.5" style={{ background: palette.kraftPanel, color: palette.creamDim }}>
+                {selected.group}
+              </span>
+              {selected.tier && (
+                <span
+                  className="rounded-md px-2 py-0.5"
+                  style={{ background: withAlpha(tierColor[selected.tier], 0.18), color: palette.cream }}
+                >
+                  {tierLabel[selected.tier]}
+                </span>
+              )}
+              {selected.priority && (
+                <span className="rounded-md px-2 py-0.5" style={{ background: palette.kraftPanel, color: palette.creamDim }}>
+                  {selected.priority} priority
+                </span>
+              )}
+            </div>
+
+            {selected.description && (
+              <p className="mt-3 text-sm leading-relaxed" style={{ color: palette.creamDim }}>
+                {selected.description}
+              </p>
+            )}
+
+            {selected.tools && selected.tools.length > 0 && (
+              <Section title="Tools" palette={palette}>
+                <ChipList items={selected.tools} color={kindColor.agent} />
+              </Section>
+            )}
+            {selected.mcpServers && selected.mcpServers.length > 0 && (
+              <Section title="MCP servers" palette={palette}>
+                <ChipList items={selected.mcpServers} color={kindColor.workflow} />
+              </Section>
+            )}
+            {selected.keywords && selected.keywords.length > 0 && (
+              <Section title="Activation keywords" palette={palette}>
+                <ChipList items={selected.keywords} color={kindColor.skill} />
+              </Section>
+            )}
+            {selected.allowedTools && selected.allowedTools.length > 0 && (
+              <Section title="Allowed tools" palette={palette}>
+                <ChipList items={selected.allowedTools} color="#8C9A5B" />
+              </Section>
+            )}
+            {selected.deniedTools && selected.deniedTools.length > 0 && (
+              <Section title="Denied tools" palette={palette}>
+                <ChipList items={selected.deniedTools} color="#C2624F" />
+              </Section>
+            )}
+            {selected.file && (
+              <p className="mt-4 font-mono text-[11px]" style={{ color: palette.creamFaint }}>
+                {selected.file}
+              </p>
+            )}
+          </aside>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function LiveToggle({
+  live,
+  status,
+  onToggle,
+}: {
+  live: boolean
+  status: LiveStatus
+  onToggle: () => void
+}) {
+  const dot =
+    status === 'live' ? '#8C9A5B' : status === 'connecting' ? '#C7A35A' : palette.creamFaint
+  const label =
+    !live ? 'Go Live' : status === 'live' ? 'Live' : status === 'connecting' ? 'Connecting…' : 'Offline'
+  return (
+    <button
+      onClick={onToggle}
+      title="Connect to a local Agent Observatory server (localhost:4317) to light up agents as they run in Claude Code."
+      className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
+      style={{
+        background: live ? withAlpha(palette.clay, 0.18) : 'transparent',
+        color: live ? palette.clayBright : palette.creamDim,
+        border: `1px solid ${live ? withAlpha(palette.clay, 0.5) : palette.line}`,
+      }}
+    >
+      <span
+        className="h-2 w-2 rounded-full"
+        style={{
+          background: live ? dot : palette.creamFaint,
+          boxShadow: status === 'live' ? `0 0 8px ${dot}` : 'none',
+          animation: status === 'connecting' ? 'observatory-ping 1.2s ease-out infinite' : 'none',
+        }}
+      />
+      {label}
+    </button>
+  )
+}
+
+function Section({
+  title,
+  children,
+  palette: p,
+}: {
+  title: string
+  children: React.ReactNode
+  palette: typeof palette
+}) {
+  return (
+    <div className="mt-4">
+      <div className="mb-1.5 text-xs font-medium uppercase tracking-wider" style={{ color: p.creamFaint }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function ChipList({ items, color }: { items: string[]; color: string }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {items.map((t) => (
+        <span
+          key={t}
+          className="rounded-md px-2 py-0.5 text-[11px]"
+          style={{ background: withAlpha(color, 0.14), color: palette.cream, border: `1px solid ${withAlpha(color, 0.3)}` }}
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/components/observatory/ObservatoryShell.tsx
+++ b/components/observatory/ObservatoryShell.tsx
@@ -5,7 +5,9 @@ import type { Catalog, CatalogNode, NodeKind, ObservatoryView } from '@/lib/obse
 import { kindColor, kindLabel, tierColor, tierLabel, palette, withAlpha } from '@/lib/observatory/theme'
 import { AgentGraph } from './AgentGraph'
 import { IamMatrix } from './IamMatrix'
+import { ObservatoryDirectory } from './ObservatoryDirectory'
 import { useLiveActivity, type LiveStatus } from '@/lib/observatory/useLiveActivity'
+import { useMediaQuery } from '@/lib/observatory/useMediaQuery'
 
 const ALL_KINDS: NodeKind[] = ['agent', 'skill', 'command', 'workflow', 'iam-profile']
 
@@ -23,6 +25,7 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
   const [selected, setSelected] = useState<CatalogNode | null>(null)
   const [live, setLive] = useState(false)
   const { activeIds, status: liveStatus } = useLiveActivity(live)
+  const isMobile = useMediaQuery('(max-width: 768px)')
 
   const tierCounts = useMemo(() => {
     const c: Record<string, number> = { haiku: 0, sonnet: 0, opus: 0 }
@@ -41,24 +44,24 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
   }
 
   return (
-    <div className="flex h-[100dvh] flex-col" style={{ background: palette.kraft, color: palette.cream }}>
+    <div className="flex h-[100dvh] flex-col" style={{ background: palette.ink, color: palette.light }}>
       <style>{`@keyframes observatory-ping{0%{opacity:.9;transform:scale(1)}100%{opacity:0;transform:scale(1.5)}}`}</style>
 
       {/* Header */}
       <header className="border-b px-6 py-4" style={{ borderColor: palette.line }}>
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold tracking-tight" style={{ color: palette.cream }}>
+            <h1 className="text-xl font-semibold tracking-tight" style={{ color: palette.light }}>
               Agent Observatory
             </h1>
-            <p className="mt-0.5 text-sm" style={{ color: palette.creamDim }}>
+            <p className="mt-0.5 text-sm" style={{ color: palette.midGray }}>
               The Agentic Creator OS fleet —{' '}
-              <span style={{ color: palette.clayBright }}>{catalog.counts?.agent ?? 0} agents</span>,{' '}
+              <span style={{ color: palette.orangeBright }}>{catalog.counts?.agent ?? 0} agents</span>,{' '}
               {catalog.counts?.skill ?? 0} skills, {catalog.counts?.command ?? 0} commands,{' '}
               {catalog.counts?.workflow ?? 0} workflows.
             </p>
           </div>
-          <div className="flex items-center gap-3 text-xs" style={{ color: palette.creamFaint }}>
+          <div className="flex items-center gap-3 text-xs" style={{ color: palette.faint }}>
             {(['opus', 'sonnet', 'haiku'] as const).map((t) => (
               <span key={t} className="flex items-center gap-1.5">
                 <span className="h-2.5 w-2.5 rounded-full" style={{ background: tierColor[t] }} />
@@ -77,9 +80,9 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
               title={v.hint}
               className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
               style={{
-                background: view === v.id ? withAlpha(palette.clay, 0.2) : 'transparent',
-                color: view === v.id ? palette.clayBright : palette.creamDim,
-                border: `1px solid ${view === v.id ? withAlpha(palette.clay, 0.5) : palette.line}`,
+                background: view === v.id ? withAlpha(palette.orange, 0.2) : 'transparent',
+                color: view === v.id ? palette.orangeBright : palette.midGray,
+                border: `1px solid ${view === v.id ? withAlpha(palette.orange, 0.5) : palette.line}`,
               }}
             >
               {v.label}
@@ -94,7 +97,7 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search agents, skills…"
                 className="w-56 rounded-lg px-3 py-1.5 text-sm outline-none"
-                style={{ background: palette.kraftPanel, border: `1px solid ${palette.line}`, color: palette.cream }}
+                style={{ background: palette.panel, border: `1px solid ${palette.line}`, color: palette.light }}
               />
             )}
           </div>
@@ -112,7 +115,7 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
                   className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-opacity"
                   style={{
                     background: withAlpha(kindColor[k], on ? 0.16 : 0.04),
-                    color: on ? palette.cream : palette.creamFaint,
+                    color: on ? palette.light : palette.faint,
                     border: `1px solid ${withAlpha(kindColor[k], on ? 0.5 : 0.15)}`,
                     opacity: on ? 1 : 0.6,
                   }}
@@ -130,6 +133,13 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
       <div className="relative flex-1 overflow-hidden">
         {view === 'iam' ? (
           <IamMatrix catalog={catalog} />
+        ) : isMobile ? (
+          <ObservatoryDirectory
+            catalog={catalog}
+            visibleKinds={visibleKinds}
+            query={query}
+            onSelect={setSelected}
+          />
         ) : (
           <AgentGraph
             catalog={catalog}
@@ -145,8 +155,8 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
         {/* Detail drawer */}
         {selected && (
           <aside
-            className="absolute right-0 top-0 h-full w-[340px] overflow-auto border-l p-5"
-            style={{ background: palette.kraftSoft, borderColor: palette.lineStrong }}
+            className="absolute right-0 top-0 h-full w-full max-w-[360px] overflow-auto border-l p-5"
+            style={{ background: palette.inkSoft, borderColor: palette.lineStrong }}
           >
             <div className="flex items-start justify-between gap-3">
               <div className="flex items-center gap-2">
@@ -159,40 +169,40 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
                         : kindColor[selected.kind],
                   }}
                 />
-                <span className="text-xs uppercase tracking-wider" style={{ color: palette.creamFaint }}>
+                <span className="text-xs uppercase tracking-wider" style={{ color: palette.faint }}>
                   {kindLabel[selected.kind]}
                 </span>
               </div>
-              <button onClick={() => setSelected(null)} style={{ color: palette.creamDim }} aria-label="Close">
+              <button onClick={() => setSelected(null)} style={{ color: palette.midGray }} aria-label="Close">
                 ✕
               </button>
             </div>
 
-            <h2 className="mt-2 text-lg font-semibold" style={{ color: palette.cream }}>
+            <h2 className="mt-2 text-lg font-semibold" style={{ color: palette.light }}>
               {selected.name}
             </h2>
 
             <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
-              <span className="rounded-md px-2 py-0.5" style={{ background: palette.kraftPanel, color: palette.creamDim }}>
+              <span className="rounded-md px-2 py-0.5" style={{ background: palette.panel, color: palette.midGray }}>
                 {selected.group}
               </span>
               {selected.tier && (
                 <span
                   className="rounded-md px-2 py-0.5"
-                  style={{ background: withAlpha(tierColor[selected.tier], 0.18), color: palette.cream }}
+                  style={{ background: withAlpha(tierColor[selected.tier], 0.18), color: palette.light }}
                 >
                   {tierLabel[selected.tier]}
                 </span>
               )}
               {selected.priority && (
-                <span className="rounded-md px-2 py-0.5" style={{ background: palette.kraftPanel, color: palette.creamDim }}>
+                <span className="rounded-md px-2 py-0.5" style={{ background: palette.panel, color: palette.midGray }}>
                   {selected.priority} priority
                 </span>
               )}
             </div>
 
             {selected.description && (
-              <p className="mt-3 text-sm leading-relaxed" style={{ color: palette.creamDim }}>
+              <p className="mt-3 text-sm leading-relaxed" style={{ color: palette.midGray }}>
                 {selected.description}
               </p>
             )}
@@ -223,7 +233,7 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
               </Section>
             )}
             {selected.file && (
-              <p className="mt-4 font-mono text-[11px]" style={{ color: palette.creamFaint }}>
+              <p className="mt-4 font-mono text-[11px]" style={{ color: palette.faint }}>
                 {selected.file}
               </p>
             )}
@@ -244,7 +254,7 @@ function LiveToggle({
   onToggle: () => void
 }) {
   const dot =
-    status === 'live' ? '#8C9A5B' : status === 'connecting' ? '#C7A35A' : palette.creamFaint
+    status === 'live' ? '#8C9A5B' : status === 'connecting' ? '#C7A35A' : palette.faint
   const label =
     !live ? 'Go Live' : status === 'live' ? 'Live' : status === 'connecting' ? 'Connecting…' : 'Offline'
   return (
@@ -253,15 +263,15 @@ function LiveToggle({
       title="Connect to a local Agent Observatory server (localhost:4317) to light up agents as they run in Claude Code."
       className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
       style={{
-        background: live ? withAlpha(palette.clay, 0.18) : 'transparent',
-        color: live ? palette.clayBright : palette.creamDim,
-        border: `1px solid ${live ? withAlpha(palette.clay, 0.5) : palette.line}`,
+        background: live ? withAlpha(palette.orange, 0.18) : 'transparent',
+        color: live ? palette.orangeBright : palette.midGray,
+        border: `1px solid ${live ? withAlpha(palette.orange, 0.5) : palette.line}`,
       }}
     >
       <span
         className="h-2 w-2 rounded-full"
         style={{
-          background: live ? dot : palette.creamFaint,
+          background: live ? dot : palette.faint,
           boxShadow: status === 'live' ? `0 0 8px ${dot}` : 'none',
           animation: status === 'connecting' ? 'observatory-ping 1.2s ease-out infinite' : 'none',
         }}
@@ -282,7 +292,7 @@ function Section({
 }) {
   return (
     <div className="mt-4">
-      <div className="mb-1.5 text-xs font-medium uppercase tracking-wider" style={{ color: p.creamFaint }}>
+      <div className="mb-1.5 text-xs font-medium uppercase tracking-wider" style={{ color: p.faint }}>
         {title}
       </div>
       {children}
@@ -297,7 +307,7 @@ function ChipList({ items, color }: { items: string[]; color: string }) {
         <span
           key={t}
           className="rounded-md px-2 py-0.5 text-[11px]"
-          style={{ background: withAlpha(color, 0.14), color: palette.cream, border: `1px solid ${withAlpha(color, 0.3)}` }}
+          style={{ background: withAlpha(color, 0.14), color: palette.light, border: `1px solid ${withAlpha(color, 0.3)}` }}
         >
           {t}
         </span>

--- a/components/observatory/ObservatoryShell.tsx
+++ b/components/observatory/ObservatoryShell.tsx
@@ -44,24 +44,34 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
   }
 
   return (
-    <div className="flex h-[100dvh] flex-col" style={{ background: palette.ink, color: palette.light }}>
-      <style>{`@keyframes observatory-ping{0%{opacity:.9;transform:scale(1)}100%{opacity:0;transform:scale(1.5)}}`}</style>
+    // pt offsets the site's fixed nav (h-14 mobile / h-16 desktop)
+    <div
+      className="flex h-[100dvh] flex-col pt-14 sm:pt-16"
+      style={{ background: palette.ink, color: palette.light }}
+    >
+      <style>{`
+        @keyframes observatory-ping{0%{opacity:.9;transform:scale(1)}100%{opacity:0;transform:scale(1.5)}}
+        @keyframes observatory-sheet{from{transform:translateY(24px);opacity:0}to{transform:translateY(0);opacity:1}}
+        .obs-scroll-x{display:flex;overflow-x:auto;scrollbar-width:none;-webkit-overflow-scrolling:touch}
+        .obs-scroll-x::-webkit-scrollbar{display:none}
+      `}</style>
 
       {/* Header */}
-      <header className="border-b px-6 py-4" style={{ borderColor: palette.line }}>
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h1 className="text-xl font-semibold tracking-tight" style={{ color: palette.light }}>
+      <header className="border-b px-4 pb-3 pt-3 sm:px-6 sm:pt-4" style={{ borderColor: palette.line }}>
+        {/* Row 1 — identity */}
+        <div className="flex items-baseline justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold tracking-tight sm:text-xl" style={{ color: palette.light }}>
               Agent Observatory
             </h1>
-            <p className="mt-0.5 text-sm" style={{ color: palette.midGray }}>
-              The Agentic Creator OS fleet —{' '}
-              <span style={{ color: palette.orangeBright }}>{catalog.counts?.agent ?? 0} agents</span>,{' '}
-              {catalog.counts?.skill ?? 0} skills, {catalog.counts?.command ?? 0} commands,{' '}
-              {catalog.counts?.workflow ?? 0} workflows.
+            <p className="mt-0.5 truncate text-xs sm:text-sm" style={{ color: palette.midGray }}>
+              <span style={{ color: palette.orangeBright }}>{catalog.counts?.agent ?? 0} agents</span>
+              {' · '}
+              {catalog.counts?.skill ?? 0} skills · {catalog.counts?.command ?? 0} commands ·{' '}
+              {catalog.counts?.workflow ?? 0} workflows
             </p>
           </div>
-          <div className="flex items-center gap-3 text-xs" style={{ color: palette.faint }}>
+          <div className="hidden shrink-0 items-center gap-3 text-xs md:flex" style={{ color: palette.faint }}>
             {(['opus', 'sonnet', 'haiku'] as const).map((t) => (
               <span key={t} className="flex items-center gap-1.5">
                 <span className="h-2.5 w-2.5 rounded-full" style={{ background: tierColor[t] }} />
@@ -71,48 +81,60 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
           </div>
         </div>
 
-        {/* View tabs */}
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          {VIEWS.map((v) => (
-            <button
-              key={v.id}
-              onClick={() => setView(v.id)}
-              title={v.hint}
-              className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
-              style={{
-                background: view === v.id ? withAlpha(palette.orange, 0.2) : 'transparent',
-                color: view === v.id ? palette.orangeBright : palette.midGray,
-                border: `1px solid ${view === v.id ? withAlpha(palette.orange, 0.5) : palette.line}`,
-              }}
-            >
-              {v.label}
-            </button>
-          ))}
-
-          <div className="ml-auto flex items-center gap-3">
-            <LiveToggle live={live} status={liveStatus} onToggle={() => setLive((v) => !v)} />
+        {/* Row 2 — view tabs (scrollable on mobile) + live + search (desktop) */}
+        <div className="mt-3 flex items-center gap-2">
+          <div className="obs-scroll-x -mx-1 min-w-0 flex-1 gap-2 px-1 sm:flex-none">
+            {VIEWS.map((v) => (
+              <button
+                key={v.id}
+                onClick={() => setView(v.id)}
+                title={v.hint}
+                className="shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
+                style={{
+                  background: view === v.id ? withAlpha(palette.orange, 0.2) : 'transparent',
+                  color: view === v.id ? palette.orangeBright : palette.midGray,
+                  border: `1px solid ${view === v.id ? withAlpha(palette.orange, 0.5) : palette.line}`,
+                }}
+              >
+                {v.label}
+              </button>
+            ))}
+          </div>
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <LiveToggle live={live} status={liveStatus} compact={isMobile} onToggle={() => setLive((v) => !v)} />
             {view !== 'iam' && (
               <input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search agents, skills…"
-                className="w-56 rounded-lg px-3 py-1.5 text-sm outline-none"
+                className="hidden w-56 rounded-lg px-3 py-1.5 text-sm outline-none sm:block"
                 style={{ background: palette.panel, border: `1px solid ${palette.line}`, color: palette.light }}
               />
             )}
           </div>
         </div>
 
-        {/* Kind filter chips */}
+        {/* Row 3 (mobile only) — full-width search */}
+        {view !== 'iam' && (
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search agents, skills…"
+            className="mt-2 block w-full rounded-lg px-3 py-2 text-sm outline-none sm:hidden"
+            style={{ background: palette.panel, border: `1px solid ${palette.line}`, color: palette.light }}
+          />
+        )}
+
+        {/* Row 4 — kind filter chips (scrollable on mobile) */}
         {view !== 'iam' && view !== 'workflows' && (
-          <div className="mt-3 flex flex-wrap gap-2">
+          <div className="obs-scroll-x -mx-1 mt-2.5 gap-2 px-1 sm:mt-3 sm:flex-wrap">
             {ALL_KINDS.map((k) => {
               const on = visibleKinds.has(k)
               return (
                 <button
                   key={k}
                   onClick={() => toggleKind(k)}
-                  className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-opacity"
+                  className="flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-opacity"
                   style={{
                     background: withAlpha(kindColor[k], on ? 0.16 : 0.04),
                     color: on ? palette.light : palette.faint,
@@ -130,7 +152,7 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
       </header>
 
       {/* Main */}
-      <div className="relative flex-1 overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         {view === 'iam' ? (
           <IamMatrix catalog={catalog} />
         ) : isMobile ? (
@@ -152,111 +174,147 @@ export function ObservatoryShell({ catalog }: { catalog: Catalog }) {
           />
         )}
 
-        {/* Detail drawer */}
-        {selected && (
+        {/* Detail — side drawer on desktop, bottom sheet on mobile */}
+        {selected && !isMobile && (
           <aside
-            className="absolute right-0 top-0 h-full w-full max-w-[360px] overflow-auto border-l p-5"
+            className="absolute right-0 top-0 h-full w-[360px] overflow-auto border-l p-5"
             style={{ background: palette.inkSoft, borderColor: palette.lineStrong }}
           >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-3 w-3 rounded-full"
-                  style={{
-                    background:
-                      selected.kind === 'agent' && selected.tier
-                        ? tierColor[selected.tier]
-                        : kindColor[selected.kind],
-                  }}
-                />
-                <span className="text-xs uppercase tracking-wider" style={{ color: palette.faint }}>
-                  {kindLabel[selected.kind]}
-                </span>
-              </div>
-              <button onClick={() => setSelected(null)} style={{ color: palette.midGray }} aria-label="Close">
-                ✕
-              </button>
-            </div>
-
-            <h2 className="mt-2 text-lg font-semibold" style={{ color: palette.light }}>
-              {selected.name}
-            </h2>
-
-            <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
-              <span className="rounded-md px-2 py-0.5" style={{ background: palette.panel, color: palette.midGray }}>
-                {selected.group}
-              </span>
-              {selected.tier && (
-                <span
-                  className="rounded-md px-2 py-0.5"
-                  style={{ background: withAlpha(tierColor[selected.tier], 0.18), color: palette.light }}
-                >
-                  {tierLabel[selected.tier]}
-                </span>
-              )}
-              {selected.priority && (
-                <span className="rounded-md px-2 py-0.5" style={{ background: palette.panel, color: palette.midGray }}>
-                  {selected.priority} priority
-                </span>
-              )}
-            </div>
-
-            {selected.description && (
-              <p className="mt-3 text-sm leading-relaxed" style={{ color: palette.midGray }}>
-                {selected.description}
-              </p>
-            )}
-
-            {selected.tools && selected.tools.length > 0 && (
-              <Section title="Tools" palette={palette}>
-                <ChipList items={selected.tools} color={kindColor.agent} />
-              </Section>
-            )}
-            {selected.mcpServers && selected.mcpServers.length > 0 && (
-              <Section title="MCP servers" palette={palette}>
-                <ChipList items={selected.mcpServers} color={kindColor.workflow} />
-              </Section>
-            )}
-            {selected.keywords && selected.keywords.length > 0 && (
-              <Section title="Activation keywords" palette={palette}>
-                <ChipList items={selected.keywords} color={kindColor.skill} />
-              </Section>
-            )}
-            {selected.allowedTools && selected.allowedTools.length > 0 && (
-              <Section title="Allowed tools" palette={palette}>
-                <ChipList items={selected.allowedTools} color="#8C9A5B" />
-              </Section>
-            )}
-            {selected.deniedTools && selected.deniedTools.length > 0 && (
-              <Section title="Denied tools" palette={palette}>
-                <ChipList items={selected.deniedTools} color="#C2624F" />
-              </Section>
-            )}
-            {selected.file && (
-              <p className="mt-4 font-mono text-[11px]" style={{ color: palette.faint }}>
-                {selected.file}
-              </p>
-            )}
+            <DetailContent selected={selected} onClose={() => setSelected(null)} />
           </aside>
         )}
       </div>
+
+      {selected && isMobile && (
+        <>
+          <button
+            aria-label="Close details"
+            className="fixed inset-0 z-40"
+            style={{ background: 'rgba(20,20,19,0.55)', backdropFilter: 'blur(2px)' }}
+            onClick={() => setSelected(null)}
+          />
+          <aside
+            className="fixed inset-x-0 bottom-0 z-50 max-h-[72dvh] overflow-auto rounded-t-2xl border-t px-5 pb-8 pt-2"
+            style={{
+              background: palette.inkSoft,
+              borderColor: palette.lineStrong,
+              animation: 'observatory-sheet .22s ease-out',
+              boxShadow: '0 -12px 40px rgba(0,0,0,0.5)',
+            }}
+          >
+            <div className="mx-auto mb-3 h-1 w-10 rounded-full" style={{ background: palette.lineStrong }} />
+            <DetailContent selected={selected} onClose={() => setSelected(null)} />
+          </aside>
+        </>
+      )}
     </div>
+  )
+}
+
+function DetailContent({ selected, onClose }: { selected: CatalogNode; onClose: () => void }) {
+  return (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span
+            className="h-3 w-3 rounded-full"
+            style={{
+              background:
+                selected.kind === 'agent' && selected.tier
+                  ? tierColor[selected.tier]
+                  : kindColor[selected.kind],
+            }}
+          />
+          <span className="text-xs uppercase tracking-wider" style={{ color: palette.faint }}>
+            {kindLabel[selected.kind]}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          className="-m-2 p-2"
+          style={{ color: palette.midGray }}
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <h2 className="mt-2 text-lg font-semibold" style={{ color: palette.light }}>
+        {selected.name}
+      </h2>
+
+      <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+        <span className="rounded-md px-2 py-0.5" style={{ background: palette.panel, color: palette.midGray }}>
+          {selected.group}
+        </span>
+        {selected.tier && (
+          <span
+            className="rounded-md px-2 py-0.5"
+            style={{ background: withAlpha(tierColor[selected.tier], 0.18), color: palette.light }}
+          >
+            {tierLabel[selected.tier]}
+          </span>
+        )}
+        {selected.priority && (
+          <span className="rounded-md px-2 py-0.5" style={{ background: palette.panel, color: palette.midGray }}>
+            {selected.priority} priority
+          </span>
+        )}
+      </div>
+
+      {selected.description && (
+        <p className="mt-3 text-sm leading-relaxed" style={{ color: palette.midGray }}>
+          {selected.description}
+        </p>
+      )}
+
+      {selected.tools && selected.tools.length > 0 && (
+        <Section title="Tools">
+          <ChipList items={selected.tools} color={kindColor.agent} />
+        </Section>
+      )}
+      {selected.mcpServers && selected.mcpServers.length > 0 && (
+        <Section title="MCP servers">
+          <ChipList items={selected.mcpServers} color={kindColor.workflow} />
+        </Section>
+      )}
+      {selected.keywords && selected.keywords.length > 0 && (
+        <Section title="Activation keywords">
+          <ChipList items={selected.keywords} color={kindColor.skill} />
+        </Section>
+      )}
+      {selected.allowedTools && selected.allowedTools.length > 0 && (
+        <Section title="Allowed tools">
+          <ChipList items={selected.allowedTools} color="#788c5d" />
+        </Section>
+      )}
+      {selected.deniedTools && selected.deniedTools.length > 0 && (
+        <Section title="Denied tools">
+          <ChipList items={selected.deniedTools} color="#C2624F" />
+        </Section>
+      )}
+      {selected.file && (
+        <p className="mt-4 break-all font-mono text-[11px]" style={{ color: palette.faint }}>
+          {selected.file}
+        </p>
+      )}
+    </>
   )
 }
 
 function LiveToggle({
   live,
   status,
+  compact,
   onToggle,
 }: {
   live: boolean
   status: LiveStatus
+  compact?: boolean
   onToggle: () => void
 }) {
-  const dot =
-    status === 'live' ? '#8C9A5B' : status === 'connecting' ? '#C7A35A' : palette.faint
-  const label =
-    !live ? 'Go Live' : status === 'live' ? 'Live' : status === 'connecting' ? 'Connecting…' : 'Offline'
+  const dot = status === 'live' ? palette.green : status === 'connecting' ? palette.gold : palette.faint
+  const label = !live ? 'Go Live' : status === 'live' ? 'Live' : status === 'connecting' ? 'Connecting…' : 'Offline'
   return (
     <button
       onClick={onToggle}
@@ -276,23 +334,15 @@ function LiveToggle({
           animation: status === 'connecting' ? 'observatory-ping 1.2s ease-out infinite' : 'none',
         }}
       />
-      {label}
+      {compact ? (live ? label : 'Live') : label}
     </button>
   )
 }
 
-function Section({
-  title,
-  children,
-  palette: p,
-}: {
-  title: string
-  children: React.ReactNode
-  palette: typeof palette
-}) {
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="mt-4">
-      <div className="mb-1.5 text-xs font-medium uppercase tracking-wider" style={{ color: p.faint }}>
+      <div className="mb-1.5 text-xs font-medium uppercase tracking-wider" style={{ color: palette.faint }}>
         {title}
       </div>
       {children}

--- a/lib/observatory/layout.ts
+++ b/lib/observatory/layout.ts
@@ -1,0 +1,134 @@
+/**
+ * Agent Observatory — deterministic graph layout (no physics deps).
+ *
+ * Turns a Catalog into positioned React Flow nodes/edges for a given view.
+ * Pure + framework-agnostic so the showcase and the live monitor share it.
+ */
+
+import type { Node as RFNode, Edge as RFEdge } from '@xyflow/react'
+import { MarkerType } from '@xyflow/react'
+import type { Catalog, CatalogNode, NodeKind, ObservatoryView } from './types'
+import { kindColor, kindLabel, withAlpha } from './theme'
+
+const CELL_W = 188
+const CELL_H = 56
+const COL_GAP = 16
+const ROW_GAP = 14
+const BAND_GAP = 96
+const MAX_COLS = 9
+
+const KIND_ORDER: NodeKind[] = ['agent', 'skill', 'command', 'workflow', 'iam-profile']
+
+export interface LayoutResult {
+  rfNodes: RFNode[]
+  rfEdges: RFEdge[]
+  bands: { key: string; label: string; color: string; count: number; y: number }[]
+}
+
+/** Group nodes into ordered "bands" depending on the active view. */
+function bandKey(node: CatalogNode, view: ObservatoryView): string {
+  if (view === 'groups') return `${node.kind}::${node.group}`
+  return node.kind
+}
+
+function bandLabel(key: string, view: ObservatoryView): string {
+  if (view === 'groups') {
+    const [kind, group] = key.split('::')
+    return `${kindLabel[kind as NodeKind]} · ${group}`
+  }
+  return kindLabel[key as NodeKind] ?? key
+}
+
+export function computeLayout(
+  catalog: Catalog,
+  view: ObservatoryView,
+  visibleKinds: Set<NodeKind>,
+  query: string,
+): LayoutResult {
+  const q = query.trim().toLowerCase()
+
+  let nodes = catalog.nodes.filter((n) => visibleKinds.has(n.kind))
+  if (view === 'workflows') nodes = catalog.nodes.filter((n) => n.kind === 'workflow')
+
+  const matches = (n: CatalogNode) =>
+    !q ||
+    n.name.toLowerCase().includes(q) ||
+    n.description.toLowerCase().includes(q) ||
+    n.group.toLowerCase().includes(q) ||
+    (n.keywords || []).some((k) => k.toLowerCase().includes(q))
+
+  // Group into bands
+  const bandMap = new Map<string, CatalogNode[]>()
+  for (const n of nodes) {
+    const key = bandKey(n, view)
+    if (!bandMap.has(key)) bandMap.set(key, [])
+    bandMap.get(key)!.push(n)
+  }
+
+  // Order bands: by kind order, then by size desc within groups view
+  const orderedKeys = [...bandMap.keys()].sort((a, b) => {
+    const ka = (view === 'groups' ? a.split('::')[0] : a) as NodeKind
+    const kb = (view === 'groups' ? b.split('::')[0] : b) as NodeKind
+    const oa = KIND_ORDER.indexOf(ka)
+    const ob = KIND_ORDER.indexOf(kb)
+    if (oa !== ob) return oa - ob
+    return (bandMap.get(b)!.length - bandMap.get(a)!.length)
+  })
+
+  const rfNodes: RFNode[] = []
+  const bands: LayoutResult['bands'] = []
+  let y = 0
+
+  for (const key of orderedKeys) {
+    const group = bandMap.get(key)!
+    const kind = (view === 'groups' ? key.split('::')[0] : key) as NodeKind
+    const color = kindColor[kind]
+    const cols = Math.min(MAX_COLS, Math.max(1, group.length))
+    const rows = Math.ceil(group.length / cols)
+    const bandWidth = cols * (CELL_W + COL_GAP)
+    const xOffset = -bandWidth / 2
+
+    bands.push({ key, label: bandLabel(key, view), color, count: group.length, y })
+
+    group.forEach((n, i) => {
+      const col = i % cols
+      const row = Math.floor(i / cols)
+      const dim = q !== '' && !matches(n)
+      rfNodes.push({
+        id: n.id,
+        type: 'observatory',
+        position: {
+          x: xOffset + col * (CELL_W + COL_GAP),
+          y: y + row * (CELL_H + ROW_GAP),
+        },
+        data: { node: n, dim, active: false },
+      })
+    })
+
+    y += rows * (CELL_H + ROW_GAP) + BAND_GAP
+  }
+
+  // Edges — only those whose endpoints are both present
+  const present = new Set(rfNodes.map((n) => n.id))
+  const rfEdges: RFEdge[] = catalog.edges
+    .filter((e) => present.has(e.source) && present.has(e.target))
+    .map((e, i) => {
+      const stroke =
+        e.rel === 'uses-skill'
+          ? kindColor.skill
+          : e.rel === 'composes'
+          ? kindColor.workflow
+          : kindColor.command
+      return {
+        id: `e${i}`,
+        source: e.source,
+        target: e.target,
+        type: 'smoothstep',
+        animated: view === 'workflows',
+        style: { stroke: withAlpha(stroke, 0.35), strokeWidth: 1.2 },
+        markerEnd: { type: MarkerType.ArrowClosed, color: withAlpha(stroke, 0.45), width: 14, height: 14 },
+      }
+    })
+
+  return { rfNodes, rfEdges, bands }
+}

--- a/lib/observatory/layout.ts
+++ b/lib/observatory/layout.ts
@@ -1,8 +1,10 @@
 /**
- * Agent Observatory — deterministic graph layout (no physics deps).
+ * Agent Observatory — deterministic constellation layout (no physics deps).
  *
- * Turns a Catalog into positioned React Flow nodes/edges for a given view.
- * Pure + framework-agnostic so the showcase and the live monitor share it.
+ * Each group of nodes is laid out as a radial cluster (concentric rings, even
+ * arc spacing so wide pills never overlap), and the clusters are packed into a
+ * row (Galaxy) or a wrapped shelf grid (Pillars). A label node sits above each
+ * cluster. Pure + framework-agnostic so the showcase and live monitor share it.
  */
 
 import type { Node as RFNode, Edge as RFEdge } from '@xyflow/react'
@@ -10,31 +12,50 @@ import { MarkerType } from '@xyflow/react'
 import type { Catalog, CatalogNode, NodeKind, ObservatoryView } from './types'
 import { kindColor, kindLabel, withAlpha } from './theme'
 
-const CELL_W = 188
-const CELL_H = 56
-const COL_GAP = 16
-const ROW_GAP = 14
-const BAND_GAP = 96
-const MAX_COLS = 9
+const CELL_W = 168
+const CELL_H = 46
+const ARC = 190 // min arc length per node on a ring
+const RING_GAP = 62
+const R0 = 70
+const CLUSTER_GAP = 140
+const MAX_ROW_W = 2800
 
 const KIND_ORDER: NodeKind[] = ['agent', 'skill', 'command', 'workflow', 'iam-profile']
 
 export interface LayoutResult {
   rfNodes: RFNode[]
   rfEdges: RFEdge[]
-  bands: { key: string; label: string; color: string; count: number; y: number }[]
 }
 
-/** Group nodes into ordered "bands" depending on the active view. */
+/** Concentric-ring positions for n nodes around (0,0); returns positions + cluster radius. */
+function ringPositions(n: number): { pts: { x: number; y: number }[]; radius: number } {
+  const pts: { x: number; y: number }[] = []
+  if (n === 1) return { pts: [{ x: 0, y: 0 }], radius: CELL_H }
+  let placed = 0
+  let ring = 0
+  while (placed < n) {
+    const r = R0 + ring * RING_GAP
+    const cap = Math.max(ring === 0 ? 3 : 4, Math.floor((2 * Math.PI * r) / ARC))
+    const count = Math.min(cap, n - placed)
+    const phase = ring * 0.55 // rotate each ring for an organic, non-gridded feel
+    for (let k = 0; k < count; k++) {
+      const a = (2 * Math.PI * k) / count + phase
+      pts.push({ x: Math.cos(a) * r, y: Math.sin(a) * r })
+    }
+    placed += count
+    ring++
+  }
+  return { pts, radius: R0 + (ring - 1) * RING_GAP + CELL_H }
+}
+
 function bandKey(node: CatalogNode, view: ObservatoryView): string {
   if (view === 'groups') return `${node.kind}::${node.group}`
   return node.kind
 }
-
 function bandLabel(key: string, view: ObservatoryView): string {
   if (view === 'groups') {
     const [kind, group] = key.split('::')
-    return `${kindLabel[kind as NodeKind]} · ${group}`
+    return `${group}`
   }
   return kindLabel[key as NodeKind] ?? key
 }
@@ -47,8 +68,8 @@ export function computeLayout(
 ): LayoutResult {
   const q = query.trim().toLowerCase()
 
-  let nodes = catalog.nodes.filter((n) => visibleKinds.has(n.kind))
-  if (view === 'workflows') nodes = catalog.nodes.filter((n) => n.kind === 'workflow')
+  let nodes = (catalog.nodes || []).filter((n) => visibleKinds.has(n.kind))
+  if (view === 'workflows') nodes = (catalog.nodes || []).filter((n) => n.kind === 'workflow')
 
   const matches = (n: CatalogNode) =>
     !q ||
@@ -57,60 +78,74 @@ export function computeLayout(
     (n.group ?? '').toLowerCase().includes(q) ||
     (n.keywords || []).some((k) => (k ?? '').toLowerCase().includes(q))
 
-  // Group into bands
-  const bandMap = new Map<string, CatalogNode[]>()
+  // Group into clusters
+  const clusterMap = new Map<string, CatalogNode[]>()
   for (const n of nodes) {
     const key = bandKey(n, view)
-    if (!bandMap.has(key)) bandMap.set(key, [])
-    bandMap.get(key)!.push(n)
+    if (!clusterMap.has(key)) clusterMap.set(key, [])
+    clusterMap.get(key)!.push(n)
   }
 
-  // Order bands: by kind order, then by size desc within groups view
-  const orderedKeys = [...bandMap.keys()].sort((a, b) => {
+  // Order: by kind, then size desc
+  const orderedKeys = [...clusterMap.keys()].sort((a, b) => {
     const ka = (view === 'groups' ? a.split('::')[0] : a) as NodeKind
     const kb = (view === 'groups' ? b.split('::')[0] : b) as NodeKind
     const oa = KIND_ORDER.indexOf(ka)
     const ob = KIND_ORDER.indexOf(kb)
     if (oa !== ob) return oa - ob
-    return (bandMap.get(b)!.length - bandMap.get(a)!.length)
+    return clusterMap.get(b)!.length - clusterMap.get(a)!.length
   })
 
-  const rfNodes: RFNode[] = []
-  const bands: LayoutResult['bands'] = []
-  let y = 0
-
-  for (const key of orderedKeys) {
-    const group = bandMap.get(key)!
+  // Precompute each cluster's radius
+  const clusters = orderedKeys.map((key) => {
+    const items = clusterMap.get(key)!
+    const { pts, radius } = ringPositions(items.length)
     const kind = (view === 'groups' ? key.split('::')[0] : key) as NodeKind
-    const color = kindColor[kind]
-    const cols = Math.min(MAX_COLS, Math.max(1, group.length))
-    const rows = Math.ceil(group.length / cols)
-    const bandWidth = cols * (CELL_W + COL_GAP)
-    const xOffset = -bandWidth / 2
+    return { key, kind, items, pts, radius }
+  })
 
-    bands.push({ key, label: bandLabel(key, view), color, count: group.length, y })
-
-    group.forEach((n, i) => {
-      const col = i % cols
-      const row = Math.floor(i / cols)
-      const dim = q !== '' && !matches(n)
-      rfNodes.push({
-        id: n.id,
-        type: 'observatory',
-        position: {
-          x: xOffset + col * (CELL_W + COL_GAP),
-          y: y + row * (CELL_H + ROW_GAP),
-        },
-        data: { node: n, dim, active: false },
-      })
-    })
-
-    y += rows * (CELL_H + ROW_GAP) + BAND_GAP
+  // Place clusters: Galaxy = single centered row; Pillars = wrapped shelf grid.
+  const rfNodes: RFNode[] = []
+  if (view === 'groups') {
+    // shelf-pack clusters into rows
+    const rows: { items: typeof clusters; width: number }[] = []
+    let row: typeof clusters = []
+    let rowW = 0
+    for (const c of clusters) {
+      const w = 2 * c.radius + CLUSTER_GAP
+      if (rowW + w > MAX_ROW_W && row.length) {
+        rows.push({ items: row, width: rowW })
+        row = []
+        rowW = 0
+      }
+      row.push(c)
+      rowW += w
+    }
+    if (row.length) rows.push({ items: row, width: rowW })
+    let y = 0
+    for (const r of rows) {
+      const maxR = Math.max(...r.items.map((c) => c.radius))
+      let cx = -r.width / 2
+      for (const c of r.items) {
+        cx += c.radius + CLUSTER_GAP / 2
+        placeCluster(rfNodes, c, cx, y + maxR, view, q, matches)
+        cx += c.radius + CLUSTER_GAP / 2
+      }
+      y += maxR * 2 + CLUSTER_GAP + 40
+    }
+  } else {
+    const totalW = clusters.reduce((s, c) => s + 2 * c.radius + CLUSTER_GAP, -CLUSTER_GAP)
+    let cx = -totalW / 2
+    for (const c of clusters) {
+      cx += c.radius
+      placeCluster(rfNodes, c, cx, 0, view, q, matches)
+      cx += c.radius + CLUSTER_GAP
+    }
   }
 
-  // Edges — only those whose endpoints are both present
-  const present = new Set(rfNodes.map((n) => n.id))
-  const rfEdges: RFEdge[] = catalog.edges
+  // Edges between present nodes
+  const present = new Set(rfNodes.filter((n) => n.type === 'observatory').map((n) => n.id))
+  const rfEdges: RFEdge[] = (catalog.edges || [])
     .filter((e) => present.has(e.source) && present.has(e.target))
     .map((e, i) => {
       const stroke =
@@ -123,12 +158,42 @@ export function computeLayout(
         id: `e${i}`,
         source: e.source,
         target: e.target,
-        type: 'smoothstep',
+        type: 'straight',
         animated: view === 'workflows',
-        style: { stroke: withAlpha(stroke, 0.35), strokeWidth: 1.2 },
-        markerEnd: { type: MarkerType.ArrowClosed, color: withAlpha(stroke, 0.45), width: 14, height: 14 },
+        style: { stroke: withAlpha(stroke, 0.22), strokeWidth: 1 },
+        markerEnd: { type: MarkerType.ArrowClosed, color: withAlpha(stroke, 0.3), width: 12, height: 12 },
       }
     })
 
-  return { rfNodes, rfEdges, bands }
+  return { rfNodes, rfEdges }
+}
+
+function placeCluster(
+  out: RFNode[],
+  c: { key: string; kind: NodeKind; items: CatalogNode[]; pts: { x: number; y: number }[]; radius: number },
+  cx: number,
+  cy: number,
+  view: ObservatoryView,
+  q: string,
+  matches: (n: CatalogNode) => boolean,
+) {
+  // Cluster label node (non-interactive)
+  out.push({
+    id: `label:${c.key}`,
+    type: 'clusterLabel',
+    position: { x: cx - 90, y: cy - c.radius - 46 },
+    data: { label: bandLabel(c.key, view), color: kindColor[c.kind], count: c.items.length },
+    draggable: false,
+    selectable: false,
+  })
+  c.items.forEach((n, i) => {
+    const p = c.pts[i]
+    const dim = q !== '' && !matches(n)
+    out.push({
+      id: n.id,
+      type: 'observatory',
+      position: { x: cx + p.x - CELL_W / 2, y: cy + p.y - CELL_H / 2 },
+      data: { node: n, dim, active: false },
+    })
+  })
 }

--- a/lib/observatory/layout.ts
+++ b/lib/observatory/layout.ts
@@ -53,10 +53,7 @@ function bandKey(node: CatalogNode, view: ObservatoryView): string {
   return node.kind
 }
 function bandLabel(key: string, view: ObservatoryView): string {
-  if (view === 'groups') {
-    const [kind, group] = key.split('::')
-    return `${group}`
-  }
+  if (view === 'groups') return key.split('::')[1] ?? key
   return kindLabel[key as NodeKind] ?? key
 }
 

--- a/lib/observatory/layout.ts
+++ b/lib/observatory/layout.ts
@@ -52,10 +52,10 @@ export function computeLayout(
 
   const matches = (n: CatalogNode) =>
     !q ||
-    n.name.toLowerCase().includes(q) ||
-    n.description.toLowerCase().includes(q) ||
-    n.group.toLowerCase().includes(q) ||
-    (n.keywords || []).some((k) => k.toLowerCase().includes(q))
+    (n.name ?? '').toLowerCase().includes(q) ||
+    (n.description ?? '').toLowerCase().includes(q) ||
+    (n.group ?? '').toLowerCase().includes(q) ||
+    (n.keywords || []).some((k) => (k ?? '').toLowerCase().includes(q))
 
   // Group into bands
   const bandMap = new Map<string, CatalogNode[]>()

--- a/lib/observatory/theme.ts
+++ b/lib/observatory/theme.ts
@@ -1,7 +1,7 @@
 /**
  * Agent Observatory — theme tokens.
  *
- * Built on Anthropic's official brand palette (Dark #141413, Light #faf9f5,
+ * Inspired by Anthropic's brand palette (Dark #141413, Light #faf9f5,
  * Mid/Light gray, accents Orange #d97757 / Blue #6a9bcc / Green #788c5d) and
  * type system (Poppins headings, Lora body). FrankX-owned surface; no Anthropic
  * logos/wordmarks shipped, open-font equivalents used publicly.

--- a/lib/observatory/theme.ts
+++ b/lib/observatory/theme.ts
@@ -1,0 +1,62 @@
+/**
+ * Agent Observatory — Anthropic-inspired, FrankX-owned theme tokens.
+ *
+ * Warm-dark palette that bridges Anthropic's signature warmth (cream / clay /
+ * kraft) with the site's dark nav + footer. No Anthropic logos/wordmarks; open
+ * font equivalents used publicly (Styrene→Inter, Tiempos→Playfair/serif).
+ */
+
+import type { NodeKind, Tier } from './types'
+
+export const palette = {
+  kraft: '#181712', // near-black warm ground
+  kraftSoft: '#211F18',
+  kraftPanel: '#26241C',
+  line: 'rgba(240,238,230,0.10)',
+  lineStrong: 'rgba(240,238,230,0.18)',
+  cream: '#F0EEE6', // primary text
+  creamDim: '#B7B2A3', // secondary text
+  creamFaint: '#7E7A6E',
+  clay: '#CC785C', // Anthropic "book cloth" — primary accent
+  clayBright: '#E1936F',
+  clayDeep: '#A6573F',
+}
+
+/** Color per node kind. */
+export const kindColor: Record<NodeKind, string> = {
+  agent: '#CC785C', // clay
+  skill: '#6A9FB5', // muted sky
+  command: '#C7A35A', // warm gold
+  workflow: '#8C9A5B', // sage
+  'iam-profile': '#B07C9E', // muted plum
+}
+
+export const kindLabel: Record<NodeKind, string> = {
+  agent: 'Agents',
+  skill: 'Skills',
+  command: 'Commands',
+  workflow: 'Workflows',
+  'iam-profile': 'IAM Profiles',
+}
+
+/** Color per model tier (agents). */
+export const tierColor: Record<Tier, string> = {
+  haiku: '#8C9A5B', // sage — fast/cheap
+  sonnet: '#6A9FB5', // sky — balanced
+  opus: '#CC785C', // clay — orchestrators
+}
+
+export const tierLabel: Record<Tier, string> = {
+  haiku: 'Haiku · fast',
+  sonnet: 'Sonnet · balanced',
+  opus: 'Opus · orchestrator',
+}
+
+/** Hex → rgba helper for glows. */
+export function withAlpha(hex: string, alpha: number): string {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.slice(0, 2), 16)
+  const g = parseInt(h.slice(2, 4), 16)
+  const b = parseInt(h.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}

--- a/lib/observatory/theme.ts
+++ b/lib/observatory/theme.ts
@@ -1,34 +1,44 @@
 /**
- * Agent Observatory — Anthropic-inspired, FrankX-owned theme tokens.
+ * Agent Observatory — theme tokens.
  *
- * Warm-dark palette that bridges Anthropic's signature warmth (cream / clay /
- * kraft) with the site's dark nav + footer. No Anthropic logos/wordmarks; open
- * font equivalents used publicly (Styrene→Inter, Tiempos→Playfair/serif).
+ * Built on Anthropic's official brand palette (Dark #141413, Light #faf9f5,
+ * Mid/Light gray, accents Orange #d97757 / Blue #6a9bcc / Green #788c5d) and
+ * type system (Poppins headings, Lora body). FrankX-owned surface; no Anthropic
+ * logos/wordmarks shipped, open-font equivalents used publicly.
  */
 
 import type { NodeKind, Tier } from './types'
 
 export const palette = {
-  kraft: '#181712', // near-black warm ground
-  kraftSoft: '#211F18',
-  kraftPanel: '#26241C',
-  line: 'rgba(240,238,230,0.10)',
-  lineStrong: 'rgba(240,238,230,0.18)',
-  cream: '#F0EEE6', // primary text
-  creamDim: '#B7B2A3', // secondary text
-  creamFaint: '#7E7A6E',
-  clay: '#CC785C', // Anthropic "book cloth" — primary accent
-  clayBright: '#E1936F',
-  clayDeep: '#A6573F',
+  // Anthropic neutrals → warm-dark ground
+  ink: '#141413', // Anthropic Dark — ground
+  inkSoft: '#1d1c1a',
+  panel: '#232220',
+  panelHi: '#2b2926',
+  line: 'rgba(250,249,245,0.09)',
+  lineStrong: 'rgba(250,249,245,0.16)',
+  light: '#faf9f5', // Anthropic Light — primary text
+  midGray: '#b0aea5', // Anthropic Mid Gray — secondary text
+  faint: '#7c7a72',
+  lightGray: '#e8e6dc',
+  // Accents (official)
+  orange: '#d97757',
+  orangeBright: '#e89478',
+  orangeDeep: '#b65b3e',
+  blue: '#6a9bcc',
+  green: '#788c5d',
+  // Derived muted tints for the two extra node kinds (kept earthy/on-brand)
+  gold: '#c79a52',
+  plum: '#a87c9f',
 }
 
 /** Color per node kind. */
 export const kindColor: Record<NodeKind, string> = {
-  agent: '#CC785C', // clay
-  skill: '#6A9FB5', // muted sky
-  command: '#C7A35A', // warm gold
-  workflow: '#8C9A5B', // sage
-  'iam-profile': '#B07C9E', // muted plum
+  agent: palette.orange,
+  skill: palette.blue,
+  command: palette.gold,
+  workflow: palette.green,
+  'iam-profile': palette.plum,
 }
 
 export const kindLabel: Record<NodeKind, string> = {
@@ -39,11 +49,11 @@ export const kindLabel: Record<NodeKind, string> = {
   'iam-profile': 'IAM Profiles',
 }
 
-/** Color per model tier (agents). */
+/** Color per model tier — escalating warmth (cheap→green, balanced→blue, orchestrator→orange). */
 export const tierColor: Record<Tier, string> = {
-  haiku: '#8C9A5B', // sage — fast/cheap
-  sonnet: '#6A9FB5', // sky — balanced
-  opus: '#CC785C', // clay — orchestrators
+  haiku: palette.green,
+  sonnet: palette.blue,
+  opus: palette.orange,
 }
 
 export const tierLabel: Record<Tier, string> = {
@@ -52,7 +62,7 @@ export const tierLabel: Record<Tier, string> = {
   opus: 'Opus · orchestrator',
 }
 
-/** Hex → rgba helper for glows. */
+/** Hex → rgba helper for glows/tints. */
 export function withAlpha(hex: string, alpha: number): string {
   const h = hex.replace('#', '')
   const r = parseInt(h.slice(0, 2), 16)

--- a/lib/observatory/types.ts
+++ b/lib/observatory/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Agent Observatory — shared data model.
+ *
+ * Consumed by BOTH surfaces (the frankx.ai showcase and the localhost live
+ * monitor). Mirrors the output of agentic-creator-os/scripts/build-catalog.mjs.
+ */
+
+export type NodeKind = 'agent' | 'skill' | 'command' | 'workflow' | 'iam-profile'
+export type Tier = 'haiku' | 'sonnet' | 'opus'
+export type Status = 'shipped' | 'in-progress' | 'gap'
+
+export interface CatalogNode {
+  id: string
+  kind: NodeKind
+  name: string
+  group: string
+  description: string
+  tier?: Tier
+  status?: Status
+  tools?: string[]
+  mcpServers?: string[]
+  keywords?: string[]
+  priority?: string | null
+  file?: string
+  tierLabel?: string | null
+  allowedTools?: string[]
+  deniedTools?: string[]
+}
+
+export type EdgeRel = 'uses-skill' | 'triggers' | 'composes' | 'governed-by'
+
+export interface CatalogEdge {
+  source: string
+  target: string
+  rel: EdgeRel
+}
+
+export interface IamProfile {
+  description?: string
+  allowedTools?: string[]
+  deniedTools?: string[]
+  allowedPaths?: string[]
+  deniedPaths?: string[]
+  maxFileEdits?: number
+  canCreateFiles?: boolean
+  canDeleteFiles?: boolean
+}
+
+export interface Catalog {
+  generatedAt: string
+  version: string
+  source: string
+  counts: Record<string, number>
+  iam: Record<string, IamProfile>
+  nodes: CatalogNode[]
+  edges: CatalogEdge[]
+}
+
+/** Live-monitor activity event (mirrors disler/observability + ACOS hooks). */
+export interface ActivityEvent {
+  session_id: string
+  source_app: string
+  hook_event_type:
+    | 'SessionStart'
+    | 'PreToolUse'
+    | 'PostToolUse'
+    | 'SubagentStart'
+    | 'SubagentStop'
+    | 'Stop'
+  agent_id?: string
+  tool_name?: string
+  timestamp: string
+  payload?: Record<string, unknown>
+}
+
+export type ObservatoryView = 'galaxy' | 'groups' | 'iam' | 'workflows'

--- a/lib/observatory/useLiveActivity.ts
+++ b/lib/observatory/useLiveActivity.ts
@@ -1,0 +1,86 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { ActivityEvent } from './types'
+
+export type LiveStatus = 'off' | 'connecting' | 'live' | 'offline'
+
+const IDLE_MS = 12000
+
+/**
+ * Connects to a local Agent Observatory server (default localhost:4317) over
+ * Server-Sent Events and tracks which agents are currently running.
+ *
+ * Works on a locally-served site; on the deployed (https) site the connection
+ * to a local http server is blocked by mixed-content rules, so status falls
+ * back to "offline" — the showcase simply stays static. That's expected.
+ */
+export function useLiveActivity(enabled: boolean, serverUrl = 'http://localhost:4317') {
+  const [activeIds, setActiveIds] = useState<Set<string>>(new Set())
+  const [status, setStatus] = useState<LiveStatus>('off')
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  useEffect(() => {
+    if (!enabled) {
+      setStatus('off')
+      setActiveIds(new Set())
+      return
+    }
+    setStatus('connecting')
+    const es = new EventSource(`${serverUrl}/stream`)
+    const timerMap = timers.current
+
+    const expire = (id: string) => {
+      const t = timers.current.get(id)
+      if (t) clearTimeout(t)
+      timers.current.set(
+        id,
+        setTimeout(() => {
+          setActiveIds((prev) => {
+            const next = new Set(prev)
+            next.delete(id)
+            return next
+          })
+          timers.current.delete(id)
+        }, IDLE_MS),
+      )
+    }
+
+    const touch = (agentId?: string) => {
+      if (!agentId) return
+      const id = `agent:${agentId}`
+      setActiveIds((prev) => new Set(prev).add(id))
+      expire(id)
+    }
+    const stop = (agentId?: string) => {
+      if (!agentId) return
+      const id = `agent:${agentId}`
+      const t = timers.current.get(id)
+      if (t) clearTimeout(t)
+      timers.current.delete(id)
+      setActiveIds((prev) => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+
+    es.onopen = () => setStatus('live')
+    es.onerror = () => setStatus((s) => (s === 'live' ? 'connecting' : 'offline'))
+    es.onmessage = (m) => {
+      try {
+        const ev: ActivityEvent = JSON.parse(m.data)
+        if (ev.hook_event_type === 'SubagentStop') stop(ev.agent_id)
+        else if (ev.agent_id) touch(ev.agent_id)
+      } catch {}
+    }
+
+    return () => {
+      es.close()
+      timerMap.forEach((t) => clearTimeout(t))
+      timerMap.clear()
+    }
+  }, [enabled, serverUrl])
+
+  return { activeIds, status }
+}

--- a/lib/observatory/useMediaQuery.ts
+++ b/lib/observatory/useMediaQuery.ts
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/** SSR-safe media query hook. Returns false on the server / first paint. */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+  useEffect(() => {
+    const mql = window.matchMedia(query)
+    const onChange = () => setMatches(mql.matches)
+    onChange()
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [query])
+  return matches
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "sync:check": "bash scripts/pre-deploy-sync-check.sh",
     "sync:fix": "bash scripts/pre-deploy-sync-check.sh --sync",
     "sync:diff": "bash scripts/pre-deploy-sync-check.sh --diff",
-    "predeploy": "npm run merge:gate && npm run sync:check"
+    "predeploy": "npm run merge:gate && npm run sync:check",
+    "observatory:catalog": "node scripts/sync-observatory-catalog.mjs"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/public/observatory/catalog.json
+++ b/public/observatory/catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-03T12:23:58.637Z",
+  "generatedAt": "2026-06-09T05:52:26.388Z",
   "version": "1.0.0",
   "source": "agentic-creator-os",
   "counts": {
@@ -8,7 +8,7 @@
     "command": 66,
     "workflow": 8,
     "iam-profile": 6,
-    "edges": 87
+    "edges": 86
   },
   "iam": {
     "content-writer": {
@@ -668,7 +668,7 @@
       "status": "shipped",
       "tools": [],
       "mcpServers": [],
-      "description": "",
+      "description": "Elite web development agent specializing in exceptional personal hubs and creator platforms",
       "file": ".claude/agents/frankx-website-builder.md"
     },
     {
@@ -2279,7 +2279,7 @@
       "status": "shipped",
       "tools": [],
       "mcpServers": [],
-      "description": "",
+      "description": "Generate comprehensive weekly progress reports across all personal projects",
       "file": ".claude/agents/weekly-recap.md"
     },
     {
@@ -3282,7 +3282,7 @@
       "status": "shipped",
       "priority": null,
       "keywords": [],
-      "description": ""
+      "description": "Expert Suno AI prompt engineering for professional music creation. Use this skill when creating Suno prompts for any AI-generated music that needs commercial quality."
     },
     {
       "id": "skill:swarm-advanced",
@@ -3351,7 +3351,7 @@
       "status": "shipped",
       "priority": null,
       "keywords": [],
-      "description": ""
+      "description": "UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 8 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
     },
     {
       "id": "skill:verification-loop",
@@ -4701,11 +4701,6 @@
     {
       "source": "workflow:release-checklist",
       "target": "workflow:pr-review-multi-perspective",
-      "rel": "composes"
-    },
-    {
-      "source": "workflow:research-fanout",
-      "target": "workflow:research-pulse-daily",
       "rel": "composes"
     }
   ]

--- a/public/observatory/catalog.json
+++ b/public/observatory/catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-09T05:52:26.388Z",
+  "generatedAt": "2026-06-09T06:12:33.969Z",
   "version": "1.0.0",
   "source": "agentic-creator-os",
   "counts": {

--- a/public/observatory/catalog.json
+++ b/public/observatory/catalog.json
@@ -1,0 +1,4712 @@
+{
+  "generatedAt": "2026-06-03T12:23:58.637Z",
+  "version": "1.0.0",
+  "source": "agentic-creator-os",
+  "counts": {
+    "agent": 142,
+    "skill": 108,
+    "command": 66,
+    "workflow": 8,
+    "iam-profile": 6,
+    "edges": 87
+  },
+  "iam": {
+    "content-writer": {
+      "description": "Blog articles, documentation, content creation",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Grep",
+        "Glob",
+        "WebSearch",
+        "WebFetch"
+      ],
+      "deniedTools": [
+        "Bash"
+      ],
+      "allowedPaths": [
+        "content/**",
+        "docs/**",
+        "public/images/**"
+      ],
+      "deniedPaths": [
+        ".claude/**",
+        "*.json",
+        "*.config.*"
+      ],
+      "maxFileEdits": 15,
+      "canCreateFiles": true,
+      "canDeleteFiles": false
+    },
+    "frontend-engineer": {
+      "description": "UI components, styling, layouts",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Grep",
+        "Glob",
+        "Bash",
+        "WebSearch"
+      ],
+      "deniedTools": [],
+      "allowedPaths": [
+        "src/**",
+        "app/**",
+        "components/**",
+        "lib/**",
+        "public/**"
+      ],
+      "deniedPaths": [
+        ".claude/settings.json",
+        ".env*"
+      ],
+      "maxFileEdits": 25,
+      "canCreateFiles": true,
+      "canDeleteFiles": false
+    },
+    "backend-engineer": {
+      "description": "APIs, database, server-side logic",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Grep",
+        "Glob",
+        "Bash"
+      ],
+      "deniedTools": [],
+      "allowedPaths": [
+        "src/**",
+        "api/**",
+        "lib/**",
+        "scripts/**"
+      ],
+      "deniedPaths": [
+        "public/**",
+        "content/**"
+      ],
+      "maxFileEdits": 20,
+      "canCreateFiles": true,
+      "canDeleteFiles": false
+    },
+    "devops-engineer": {
+      "description": "Deployment, CI/CD, build configuration",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Bash",
+        "Grep",
+        "Glob"
+      ],
+      "deniedTools": [],
+      "allowedPaths": [
+        "*.config.*",
+        "package.json",
+        ".github/**",
+        "scripts/**",
+        "Dockerfile*"
+      ],
+      "deniedPaths": [
+        "content/**"
+      ],
+      "maxFileEdits": 10,
+      "canCreateFiles": true,
+      "canDeleteFiles": true
+    },
+    "security-auditor": {
+      "description": "Security review, dependency audit — read-only",
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash",
+        "WebSearch"
+      ],
+      "deniedTools": [
+        "Edit",
+        "Write"
+      ],
+      "allowedPaths": [
+        "**"
+      ],
+      "deniedPaths": [],
+      "maxFileEdits": 0,
+      "canCreateFiles": false,
+      "canDeleteFiles": false
+    },
+    "system-architect": {
+      "description": "ACOS internals, hooks, configuration — requires gate approval",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Bash",
+        "Grep",
+        "Glob"
+      ],
+      "deniedTools": [],
+      "allowedPaths": [
+        ".claude/**"
+      ],
+      "deniedPaths": [],
+      "maxFileEdits": 30,
+      "canCreateFiles": true,
+      "canDeleteFiles": false,
+      "requiresGateApproval": true
+    }
+  },
+  "nodes": [
+    {
+      "id": "agent:accessibility-auditor",
+      "kind": "agent",
+      "name": "accessibility-auditor",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Accessibility expert - WCAG 2.2 compliance, screen reader testing, keyboard navigation, inclusive design",
+      "file": ".claude/agents/accessibility-auditor.md"
+    },
+    {
+      "id": "agent:analysis/analyze-code-quality",
+      "kind": "agent",
+      "name": "code-analyzer",
+      "group": "analysis",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Advanced code quality analysis agent for comprehensive code reviews and improvements",
+      "file": ".claude/agents/analysis/analyze-code-quality.md"
+    },
+    {
+      "id": "agent:analysis/code-analyzer",
+      "kind": "agent",
+      "name": "analyst",
+      "group": "analysis",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Advanced code quality analysis agent for comprehensive code reviews and improvements",
+      "file": ".claude/agents/analysis/code-analyzer.md"
+    },
+    {
+      "id": "agent:analysis/code-review/analyze-code-quality",
+      "kind": "agent",
+      "name": "code-analyzer",
+      "group": "analysis",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Advanced code quality analysis agent for comprehensive code reviews and improvements",
+      "file": ".claude/agents/analysis/code-review/analyze-code-quality.md"
+    },
+    {
+      "id": "agent:architecture/system-design/arch-system-design",
+      "kind": "agent",
+      "name": "system-architect",
+      "group": "architecture",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Expert agent for system architecture design, patterns, and high-level technical decisions",
+      "file": ".claude/agents/architecture/system-design/arch-system-design.md"
+    },
+    {
+      "id": "agent:autoresearcher",
+      "kind": "agent",
+      "name": "autoresearcher",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Grep",
+        "Glob",
+        "WebSearch",
+        "WebFetch",
+        "Bash"
+      ],
+      "mcpServers": [],
+      "description": "One-bounded-dig research experimenter — reads the brief, proposes ONE hypothesis targeting ONE harness component, fetches ≤5 sources, edits ONE section, returns a scored diff. Karpathy-autoresearch pattern.",
+      "file": ".claude/agents/autoresearcher.md"
+    },
+    {
+      "id": "agent:book-distiller",
+      "kind": "agent",
+      "name": "Book Distiller",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash",
+        "WebFetch",
+        "WebSearch"
+      ],
+      "mcpServers": [],
+      "description": "Extract quotes and chapter summaries from books for the Library OS. Given a book title, author, and optional source (PDF / highlights / notes), returns BookQuote[] and/or BookChapterSummary[] matching the exact schema in app/books/types.ts. Used by /library-deepen.",
+      "file": ".claude/agents/book-distiller.md"
+    },
+    {
+      "id": "agent:business-book-writer",
+      "kind": "agent",
+      "name": "Business & Transformation Master",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "github",
+        "linear"
+      ],
+      "description": "Genre master for business parables, self-help, and transformation guides - leads practical wisdom books while coordinating with the Author Team",
+      "file": ".claude/agents/business-book-writer.md"
+    },
+    {
+      "id": "agent:character-psychologist",
+      "kind": "agent",
+      "name": "Character Psychologist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github"
+      ],
+      "description": "Deep character development specialist - creates authentic psychological profiles, compelling motivations, believable arcs, and distinct voices",
+      "file": ".claude/agents/character-psychologist.md"
+    },
+    {
+      "id": "agent:coaching-program-design",
+      "kind": "agent",
+      "name": "coaching-program-designer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Use this agent when you need to design, structure, or optimize coaching programs for specific client needs. Examples: <example>Context: A life coach wants to create a program for executives struggling with work-life balance. user: 'I need to design a 12-week coaching program for C-suite executives who are burned out and need better work-life integration' assistant: 'I'll use the coaching-program-d",
+      "file": ".claude/agents/coaching-program-design.md"
+    },
+    {
+      "id": "agent:consensus/byzantine-coordinator",
+      "kind": "agent",
+      "name": "byzantine-coordinator",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Coordinates Byzantine fault-tolerant consensus protocols with malicious actor detection",
+      "file": ".claude/agents/consensus/byzantine-coordinator.md"
+    },
+    {
+      "id": "agent:consensus/crdt-synchronizer",
+      "kind": "agent",
+      "name": "crdt-synchronizer",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Implements Conflict-free Replicated Data Types for eventually consistent state synchronization",
+      "file": ".claude/agents/consensus/crdt-synchronizer.md"
+    },
+    {
+      "id": "agent:consensus/gossip-coordinator",
+      "kind": "agent",
+      "name": "gossip-coordinator",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Coordinates gossip-based consensus protocols for scalable eventually consistent systems",
+      "file": ".claude/agents/consensus/gossip-coordinator.md"
+    },
+    {
+      "id": "agent:consensus/performance-benchmarker",
+      "kind": "agent",
+      "name": "performance-benchmarker",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Implements comprehensive performance benchmarking for distributed consensus protocols",
+      "file": ".claude/agents/consensus/performance-benchmarker.md"
+    },
+    {
+      "id": "agent:consensus/quorum-manager",
+      "kind": "agent",
+      "name": "quorum-manager",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Implements dynamic quorum adjustment and intelligent membership management",
+      "file": ".claude/agents/consensus/quorum-manager.md"
+    },
+    {
+      "id": "agent:consensus/raft-manager",
+      "kind": "agent",
+      "name": "raft-manager",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Manages Raft consensus algorithm with leader election and log replication",
+      "file": ".claude/agents/consensus/raft-manager.md"
+    },
+    {
+      "id": "agent:consensus/security-manager",
+      "kind": "agent",
+      "name": "security-manager",
+      "group": "consensus",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Implements comprehensive security mechanisms for distributed consensus protocols",
+      "file": ".claude/agents/consensus/security-manager.md"
+    },
+    {
+      "id": "agent:content-polisher",
+      "kind": "agent",
+      "name": "content-polisher",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Transform AI-generated content into polished, publish-ready FrankX articles with authentic voice and SEO",
+      "file": ".claude/agents/content-polisher.md"
+    },
+    {
+      "id": "agent:content-product-development",
+      "kind": "agent",
+      "name": "Creation Engine",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "slack",
+        "nano-banana"
+      ],
+      "description": "Content & Product Development Superintelligence for Generative Creators",
+      "file": ".claude/agents/content-product-development.md"
+    },
+    {
+      "id": "agent:continuity-guardian",
+      "kind": "agent",
+      "name": "Continuity Guardian",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github"
+      ],
+      "description": "Series consistency enforcer, timeline tracker, and canon keeper who ensures no contradictions slip through across chapters, books, or entire series",
+      "file": ".claude/agents/continuity-guardian.md"
+    },
+    {
+      "id": "agent:core/coder",
+      "kind": "agent",
+      "name": "coder",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Implementation specialist for writing clean, efficient code",
+      "file": ".claude/agents/core/coder.md"
+    },
+    {
+      "id": "agent:core/planner",
+      "kind": "agent",
+      "name": "planner",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Strategic planning and task orchestration agent",
+      "file": ".claude/agents/core/planner.md"
+    },
+    {
+      "id": "agent:core/researcher",
+      "kind": "agent",
+      "name": "researcher",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Deep research and information gathering specialist",
+      "file": ".claude/agents/core/researcher.md"
+    },
+    {
+      "id": "agent:core/reviewer",
+      "kind": "agent",
+      "name": "reviewer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Code review and quality assurance specialist",
+      "file": ".claude/agents/core/reviewer.md"
+    },
+    {
+      "id": "agent:core/tester",
+      "kind": "agent",
+      "name": "tester",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Comprehensive testing and quality assurance specialist",
+      "file": ".claude/agents/core/tester.md"
+    },
+    {
+      "id": "agent:creator-book-writer",
+      "kind": "agent",
+      "name": "Creator Economy Master",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "lyric-genius",
+        "github",
+        "linear"
+      ],
+      "description": "Genre master for creator economy, AI-human collaboration, and generative creator empowerment books - leads visionary practical guides",
+      "file": ".claude/agents/creator-book-writer.md"
+    },
+    {
+      "id": "agent:custom/test-long-runner",
+      "kind": "agent",
+      "name": "test-long-runner",
+      "group": "custom",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Test agent that can run for 30+ minutes on complex tasks",
+      "file": ".claude/agents/custom/test-long-runner.md"
+    },
+    {
+      "id": "agent:data/ml/data-ml-model",
+      "kind": "agent",
+      "name": "ml-developer",
+      "group": "data",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Specialized agent for machine learning model development, training, and deployment",
+      "file": ".claude/agents/data/ml/data-ml-model.md"
+    },
+    {
+      "id": "agent:deep-fiction-writer",
+      "kind": "agent",
+      "name": "Deep Fiction Master",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "lyric-genius",
+        "github",
+        "linear"
+      ],
+      "description": "Genre master for purpose-driven and introspective fiction - leads deep narratives while coordinating with the Author Team",
+      "file": ".claude/agents/deep-fiction-writer.md"
+    },
+    {
+      "id": "agent:development/backend/dev-backend-api",
+      "kind": "agent",
+      "name": "backend-dev",
+      "group": "development",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Specialized agent for backend API development, including REST and GraphQL endpoints",
+      "file": ".claude/agents/development/backend/dev-backend-api.md"
+    },
+    {
+      "id": "agent:development/dev-backend-api",
+      "kind": "agent",
+      "name": "backend-dev",
+      "group": "development",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Specialized agent for backend API development with self-learning and pattern recognition",
+      "file": ".claude/agents/development/dev-backend-api.md"
+    },
+    {
+      "id": "agent:developmental-editor",
+      "kind": "agent",
+      "name": "Developmental Editor",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github"
+      ],
+      "description": "Story structure expert, pacing master, and narrative architect who shapes manuscripts into compelling, well-paced journeys",
+      "file": ".claude/agents/developmental-editor.md"
+    },
+    {
+      "id": "agent:devops/ci-cd/ops-cicd-github",
+      "kind": "agent",
+      "name": "cicd-engineer",
+      "group": "devops",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Specialized agent for GitHub Actions CI/CD pipeline creation and optimization",
+      "file": ".claude/agents/devops/ci-cd/ops-cicd-github.md"
+    },
+    {
+      "id": "agent:discussion-based-planning",
+      "kind": "agent",
+      "name": "discussion-based-planning",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Strategic planning agent that prioritizes understanding and alignment before implementation",
+      "file": ".claude/agents/discussion-based-planning.md"
+    },
+    {
+      "id": "agent:documentation/api-docs/docs-api-openapi",
+      "kind": "agent",
+      "name": "api-docs",
+      "group": "documentation",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Expert agent for creating and maintaining OpenAPI/Swagger documentation",
+      "file": ".claude/agents/documentation/api-docs/docs-api-openapi.md"
+    },
+    {
+      "id": "agent:fantasy-book-writer",
+      "kind": "agent",
+      "name": "Fantasy & Sci-Fi Master",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "github",
+        "linear"
+      ],
+      "description": "Genre master for epic fantasy and science fiction - leads narrative creation while coordinating with specialized craft agents for world-class results",
+      "file": ".claude/agents/fantasy-book-writer.md"
+    },
+    {
+      "id": "agent:frankx-content-creation",
+      "kind": "agent",
+      "name": "FrankX Content Creator",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "slack",
+        "nano-banana",
+        "lyric-genius"
+      ],
+      "description": "Content strategist and creator for FrankX personal brand and AI Music Academy",
+      "file": ".claude/agents/frankx-content-creation.md"
+    },
+    {
+      "id": "agent:frankx-website-builder",
+      "kind": "agent",
+      "name": "frankx-website-builder",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "",
+      "file": ".claude/agents/frankx-website-builder.md"
+    },
+    {
+      "id": "agent:frequency-music-production",
+      "kind": "agent",
+      "name": "Music Producer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "lyric-genius",
+        "notion",
+        "slack"
+      ],
+      "description": "AI-powered music production specialist for professional tracks and commercial-quality output",
+      "file": ".claude/agents/frequency-music-production.md"
+    },
+    {
+      "id": "agent:github/code-review-swarm",
+      "kind": "agent",
+      "name": "code-review-swarm",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "Bash",
+        "Read",
+        "Write",
+        "TodoWrite"
+      ],
+      "mcpServers": [],
+      "description": "Deploy specialized AI agents to perform comprehensive, intelligent code reviews that go beyond traditional static analysis",
+      "file": ".claude/agents/github/code-review-swarm.md"
+    },
+    {
+      "id": "agent:github/github-modes",
+      "kind": "agent",
+      "name": "github-modes",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "Bash",
+        "TodoWrite",
+        "Read",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Comprehensive GitHub integration modes for workflow orchestration, PR management, and repository coordination with batch optimization",
+      "file": ".claude/agents/github/github-modes.md"
+    },
+    {
+      "id": "agent:github/issue-tracker",
+      "kind": "agent",
+      "name": "issue-tracker",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage",
+        "Bash",
+        "TodoWrite",
+        "Read",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Intelligent issue management and project coordination with automated tracking, progress monitoring, and team coordination",
+      "file": ".claude/agents/github/issue-tracker.md"
+    },
+    {
+      "id": "agent:github/multi-repo-swarm",
+      "kind": "agent",
+      "name": "multi-repo-swarm",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "LS",
+        "TodoWrite",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__swarm_status",
+        "mcp__claude-flow__memory_usage",
+        "mcp__claude-flow__github_repo_analyze",
+        "mcp__claude-flow__github_pr_manage",
+        "mcp__claude-flow__github_sync_coord",
+        "mcp__claude-flow__github_metrics"
+      ],
+      "mcpServers": [],
+      "description": "Cross-repository swarm orchestration for organization-wide automation and intelligent collaboration",
+      "file": ".claude/agents/github/multi-repo-swarm.md"
+    },
+    {
+      "id": "agent:github/pr-manager",
+      "kind": "agent",
+      "name": "pr-manager",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "LS",
+        "TodoWrite",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__swarm_status",
+        "mcp__claude-flow__memory_usage",
+        "mcp__claude-flow__github_pr_manage",
+        "mcp__claude-flow__github_code_review",
+        "mcp__claude-flow__github_metrics"
+      ],
+      "mcpServers": [],
+      "description": "Comprehensive pull request management with swarm coordination for automated reviews, testing, and merge workflows",
+      "file": ".claude/agents/github/pr-manager.md"
+    },
+    {
+      "id": "agent:github/project-board-sync",
+      "kind": "agent",
+      "name": "project-board-sync",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "LS",
+        "TodoWrite",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__swarm_status",
+        "mcp__claude-flow__memory_usage",
+        "mcp__claude-flow__github_repo_analyze",
+        "mcp__claude-flow__github_pr_manage",
+        "mcp__claude-flow__github_issue_track",
+        "mcp__claude-flow__github_metrics",
+        "mcp__claude-flow__workflow_create",
+        "mcp__claude-flow__workflow_execute"
+      ],
+      "mcpServers": [],
+      "description": "Synchronize AI swarms with GitHub Projects for visual task management, progress tracking, and team coordination",
+      "file": ".claude/agents/github/project-board-sync.md"
+    },
+    {
+      "id": "agent:github/release-manager",
+      "kind": "agent",
+      "name": "release-manager",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "TodoWrite",
+        "TodoRead",
+        "Task",
+        "WebFetch",
+        "mcp__github__create_pull_request",
+        "mcp__github__merge_pull_request",
+        "mcp__github__create_branch",
+        "mcp__github__push_files",
+        "mcp__github__create_issue",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage"
+      ],
+      "mcpServers": [],
+      "description": "Automated release coordination and deployment with ruv-swarm orchestration for seamless version management, testing, and deployment across multiple packages",
+      "file": ".claude/agents/github/release-manager.md"
+    },
+    {
+      "id": "agent:github/release-swarm",
+      "kind": "agent",
+      "name": "release-swarm",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "TodoWrite",
+        "TodoRead",
+        "Task",
+        "WebFetch",
+        "mcp__github__create_pull_request",
+        "mcp__github__merge_pull_request",
+        "mcp__github__create_branch",
+        "mcp__github__push_files",
+        "mcp__github__create_issue",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__parallel_execute",
+        "mcp__claude-flow__load_balance"
+      ],
+      "mcpServers": [],
+      "description": "Orchestrate complex software releases using AI swarms that handle everything from changelog generation to multi-platform deployment",
+      "file": ".claude/agents/github/release-swarm.md"
+    },
+    {
+      "id": "agent:github/repo-architect",
+      "kind": "agent",
+      "name": "repo-architect",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "LS",
+        "Glob",
+        "TodoWrite",
+        "TodoRead",
+        "Task",
+        "WebFetch",
+        "mcp__github__create_repository",
+        "mcp__github__fork_repository",
+        "mcp__github__search_repositories",
+        "mcp__github__push_files",
+        "mcp__github__create_or_update_file",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage"
+      ],
+      "mcpServers": [],
+      "description": "Repository structure optimization and multi-repo management with ruv-swarm coordination for scalable project architecture and development workflows",
+      "file": ".claude/agents/github/repo-architect.md"
+    },
+    {
+      "id": "agent:github/swarm-issue",
+      "kind": "agent",
+      "name": "swarm-issue",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__github__get_issue",
+        "mcp__github__create_issue",
+        "mcp__github__update_issue",
+        "mcp__github__list_issues",
+        "mcp__github__create_issue_comment",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage",
+        "TodoWrite",
+        "TodoRead",
+        "Bash",
+        "Grep",
+        "Read",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "GitHub issue-based swarm coordination agent that transforms issues into intelligent multi-agent tasks with automatic decomposition and progress tracking",
+      "file": ".claude/agents/github/swarm-issue.md"
+    },
+    {
+      "id": "agent:github/swarm-pr",
+      "kind": "agent",
+      "name": "swarm-pr",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__github__get_pull_request",
+        "mcp__github__create_pull_request",
+        "mcp__github__update_pull_request",
+        "mcp__github__list_pull_requests",
+        "mcp__github__create_pr_comment",
+        "mcp__github__get_pr_diff",
+        "mcp__github__merge_pull_request",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage",
+        "mcp__claude-flow__coordination_sync",
+        "TodoWrite",
+        "TodoRead",
+        "Bash",
+        "Grep",
+        "Read",
+        "Write",
+        "Edit"
+      ],
+      "mcpServers": [],
+      "description": "Pull request swarm management agent that coordinates multi-agent code review, validation, and integration workflows with automated PR lifecycle management",
+      "file": ".claude/agents/github/swarm-pr.md"
+    },
+    {
+      "id": "agent:github/sync-coordinator",
+      "kind": "agent",
+      "name": "sync-coordinator",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__github__push_files",
+        "mcp__github__create_or_update_file",
+        "mcp__github__get_file_contents",
+        "mcp__github__create_pull_request",
+        "mcp__github__search_repositories",
+        "mcp__github__list_repositories",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage",
+        "mcp__claude-flow__coordination_sync",
+        "mcp__claude-flow__load_balance",
+        "TodoWrite",
+        "TodoRead",
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "MultiEdit"
+      ],
+      "mcpServers": [],
+      "description": "Multi-repository synchronization coordinator that manages version alignment, dependency synchronization, and cross-package integration with intelligent swarm orchestration",
+      "file": ".claude/agents/github/sync-coordinator.md"
+    },
+    {
+      "id": "agent:github/workflow-automation",
+      "kind": "agent",
+      "name": "workflow-automation",
+      "group": "github",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "mcp__github__create_workflow",
+        "mcp__github__update_workflow",
+        "mcp__github__list_workflows",
+        "mcp__github__get_workflow_runs",
+        "mcp__github__create_workflow_dispatch",
+        "mcp__claude-flow__swarm_init",
+        "mcp__claude-flow__agent_spawn",
+        "mcp__claude-flow__task_orchestrate",
+        "mcp__claude-flow__memory_usage",
+        "mcp__claude-flow__performance_report",
+        "mcp__claude-flow__bottleneck_analyze",
+        "mcp__claude-flow__workflow_create",
+        "mcp__claude-flow__automation_setup",
+        "TodoWrite",
+        "TodoRead",
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Grep"
+      ],
+      "mcpServers": [],
+      "description": "GitHub Actions workflow automation agent that creates intelligent, self-organizing CI/CD pipelines with adaptive multi-agent coordination and automated optimization",
+      "file": ".claude/agents/github/workflow-automation.md"
+    },
+    {
+      "id": "agent:goal/agent",
+      "kind": "agent",
+      "name": "sublinear-goal-planner",
+      "group": "goal",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Goal-Oriented Action Planning (GOAP) specialist that dynamically creates intelligent plans to achieve complex objectives. Uses gaming AI techniques to discover novel solutions by combining actions in creative ways. Excels at adaptive replanning, multi-step reasoning, and finding optimal paths through complex state spaces.",
+      "file": ".claude/agents/goal/agent.md"
+    },
+    {
+      "id": "agent:goal/code-goal-planner",
+      "kind": "agent",
+      "name": "code-goal-planner",
+      "group": "goal",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Code-centric Goal-Oriented Action Planning specialist that creates intelligent plans for software development objectives. Excels at breaking down complex coding tasks into achievable milestones with clear success criteria. Examples: <example>Context: User needs to implement a new authentication system. user: 'I need to add OAuth2 authentication to our API' assistant: 'I'll use the code-goal-planne",
+      "file": ".claude/agents/goal/code-goal-planner.md"
+    },
+    {
+      "id": "agent:goal/goal-planner",
+      "kind": "agent",
+      "name": "goal-planner",
+      "group": "goal",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Goal-Oriented Action Planning (GOAP) specialist that dynamically creates intelligent plans to achieve complex objectives. Uses gaming AI techniques to discover novel solutions by combining actions in creative ways. Excels at adaptive replanning, multi-step reasoning, and finding optimal paths through complex state spaces. Examples: <example>Context: User needs to optimize a complex workflow with m",
+      "file": ".claude/agents/goal/goal-planner.md"
+    },
+    {
+      "id": "agent:golden-age-visionary",
+      "kind": "agent",
+      "name": "Visionary Manifestos Master",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "lyric-genius",
+        "github",
+        "linear"
+      ],
+      "description": "Genre master for inspirational manifestos on systems building, AI-human partnership, and humanity's golden age - leads paradigm-shifting thought leadership",
+      "file": ".claude/agents/golden-age-visionary.md"
+    },
+    {
+      "id": "agent:hive-mind/collective-intelligence-coordinator",
+      "kind": "agent",
+      "name": "collective-intelligence-coordinator",
+      "group": "hive-mind",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Orchestrates distributed cognitive processes across the hive mind, ensuring coherent collective decision-making through memory synchronization and consensus protocols",
+      "file": ".claude/agents/hive-mind/collective-intelligence-coordinator.md"
+    },
+    {
+      "id": "agent:hive-mind/queen-coordinator",
+      "kind": "agent",
+      "name": "queen-coordinator",
+      "group": "hive-mind",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "The sovereign orchestrator of hierarchical hive operations, managing strategic decisions, resource allocation, and maintaining hive coherence through centralized-decentralized hybrid control",
+      "file": ".claude/agents/hive-mind/queen-coordinator.md"
+    },
+    {
+      "id": "agent:hive-mind/scout-explorer",
+      "kind": "agent",
+      "name": "scout-explorer",
+      "group": "hive-mind",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Information reconnaissance specialist that explores unknown territories, gathers intelligence, and reports findings to the hive mind through continuous memory updates",
+      "file": ".claude/agents/hive-mind/scout-explorer.md"
+    },
+    {
+      "id": "agent:hive-mind/swarm-memory-manager",
+      "kind": "agent",
+      "name": "swarm-memory-manager",
+      "group": "hive-mind",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Manages distributed memory across the hive mind, ensuring data consistency, persistence, and efficient retrieval through advanced caching and synchronization protocols",
+      "file": ".claude/agents/hive-mind/swarm-memory-manager.md"
+    },
+    {
+      "id": "agent:hive-mind/worker-specialist",
+      "kind": "agent",
+      "name": "worker-specialist",
+      "group": "hive-mind",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Dedicated task execution specialist that carries out assigned work with precision, continuously reporting progress through memory coordination",
+      "file": ".claude/agents/hive-mind/worker-specialist.md"
+    },
+    {
+      "id": "agent:integrity-guard",
+      "kind": "agent",
+      "name": "integrity-guard",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Pre-publish brand + claim + voice + schema gate. Automates the rules from the 2026-05-19 integrity sweep. Auto-invokes before any /publish, /factory, /newsletter-week send, /talking-head-ship, or /publish-content runs. Triggers on \"integrity check this\", \"is this on-brand\", \"brand-gate this post\", \"audit before publish\". Returns pass | warn | fail with specific corrections per violation. Pillar — ",
+      "file": ".claude/agents/integrity-guard.md"
+    },
+    {
+      "id": "agent:line-editor-voice-alchemist",
+      "kind": "agent",
+      "name": "Line Editor & Voice Alchemist",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github",
+        "lyric-genius"
+      ],
+      "description": "Prose polisher, AI pattern eliminator, and voice consistency guardian who transforms competent writing into compelling prose",
+      "file": ".claude/agents/line-editor-voice-alchemist.md"
+    },
+    {
+      "id": "agent:luminor-strategic-guidance",
+      "kind": "agent",
+      "name": "Visionary",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "linear-server",
+        "notion"
+      ],
+      "description": "Strategic AI from 2125 - Future Visioning, Business Intelligence & Systems Guidance",
+      "file": ".claude/agents/luminor-strategic-guidance.md"
+    },
+    {
+      "id": "agent:master-story-architect",
+      "kind": "agent",
+      "name": "Master Story Architect",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github",
+        "linear",
+        "nano-banana"
+      ],
+      "description": "Chief orchestrator for all book projects - coordinates genre masters, assigns specialists, maintains quality standards, and ensures every book achieves excellence",
+      "file": ".claude/agents/master-story-architect.md"
+    },
+    {
+      "id": "agent:mcp-server-advising",
+      "kind": "agent",
+      "name": "mcp-server-advisor",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Use this agent when you need expert guidance on selecting, configuring, or understanding Model Context Protocol (MCP) servers for your project. This includes evaluating which MCP servers would best suit your use case, understanding server capabilities, integration requirements, and architectural decisions around MCP implementations. Examples:\\n\\n<example>\\nContext: User is setting up a new project",
+      "file": ".claude/agents/mcp-server-advising.md"
+    },
+    {
+      "id": "agent:meta-acos-router",
+      "kind": "agent",
+      "name": "meta-acos-router",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Task",
+        "Bash"
+      ],
+      "mcpServers": [],
+      "description": "Top-level intent router for ACOS — reads any user prompt and dispatches to the right pillar orchestrator using the auto-routing keyword table. Auto-invokes on ambiguous high-level asks (\"help me with X\", \"I want to Y\", \"what's the best way to Z\") and on the literal `/acos` command. Lifts the routing table out of .claude/commands/acos.md into a dispatchable Sonnet/Opus subagent.",
+      "file": ".claude/agents/meta-acos-router.md"
+    },
+    {
+      "id": "agent:meta-agent-quality-auditor",
+      "kind": "agent",
+      "name": "meta-agent-quality-auditor",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Glob"
+      ],
+      "mcpServers": [],
+      "description": "ESLint for ACOS subagent files. Deterministically scores every .claude/agents/*.md against a 9-check rubric (frontmatter / triggers / tool minimality / sections / memory contract / anti-patterns / brand voice / Arcanean leak / smoke fixture). Auto-invokes when Frank says \"audit the agents\", \"score the catalog quality\", \"agent quality report\", \"which agents need work\", or runs `/agent-audit-quality",
+      "file": ".claude/agents/meta-agent-quality-auditor.md"
+    },
+    {
+      "id": "agent:meta-agentic-jujutsu",
+      "kind": "agent",
+      "name": "meta-agentic-jujutsu",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash"
+      ],
+      "mcpServers": [],
+      "description": "Surfaces past successful workflow patterns from .claude/trajectories/patterns.json to bias the current task toward proven approaches. Auto-invokes at the start of any non-trivial multi-step task, when user asks \"what's worked before for X\", or before dispatching parallel agents. Pure pattern recall — no creative work.",
+      "file": ".claude/agents/meta-agentic-jujutsu.md"
+    },
+    {
+      "id": "agent:meta-eod",
+      "kind": "agent",
+      "name": "meta-eod",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "End-of-day session wrap-up. Runs git audit + Vercel build check + session summary + unfinished work capture + memory update + next-session brief. Auto-invokes when Frank says \"/eod\", \"end of day\", \"wrap up the session\", \"log this session\", or at session-end when ≥3 commits or ≥30 min of work happened. Wraps the /eod command into a dispatchable Sonnet subagent.",
+      "file": ".claude/agents/meta-eod.md"
+    },
+    {
+      "id": "agent:meta-handover",
+      "kind": "agent",
+      "name": "meta-handover",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Writes a durable session-handover doc to docs/ops/HANDOVER-<date>.md so a different agent or session can pick up cold. Auto-invokes when Frank says \"handover\", \"next session\", \"switching agents\", \"another session will continue\", or runs `/handover`. Wraps the /handover command into a dispatchable Sonnet subagent with memory recall + atomic write.",
+      "file": ".claude/agents/meta-handover.md"
+    },
+    {
+      "id": "agent:meta-memory-guardian",
+      "kind": "agent",
+      "name": "meta-memory-guardian",
+      "group": "core",
+      "tier": "haiku",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read"
+      ],
+      "mcpServers": [],
+      "description": "Pre-flight RAM zone classifier before parallel agent dispatch or heavy builds. Auto-invokes when Claude is about to spawn 3+ Task agents, before `npm run build`, when SessionStart reports WARN/CRITICAL memory, or when user mentions parallel CC instances. Returns green/yellow/red verdict + parallel-agent limit. Pure gate — never blocks creative work, only caps concurrency.",
+      "file": ".claude/agents/meta-memory-guardian.md"
+    },
+    {
+      "id": "agent:meta-safety-guard",
+      "kind": "agent",
+      "name": "meta-safety-guard",
+      "group": "core",
+      "tier": "haiku",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash"
+      ],
+      "mcpServers": [],
+      "description": "Pre-flight gate for destructive operations — `rm -rf`, `git reset --hard`, `git push --force` to main, dropping database tables, deleting branches, mass file moves. Auto-invokes when any tool call or bash command matches the destructive-operation vocabulary. Returns allow / needs-confirm / block verdict. Pure pattern gate — never executes the operation.",
+      "file": ".claude/agents/meta-safety-guard.md"
+    },
+    {
+      "id": "agent:meta-sync-repos",
+      "kind": "agent",
+      "name": "meta-sync-repos",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Bash",
+        "Read"
+      ],
+      "mcpServers": [],
+      "description": "Syncs Claude Code configuration (agents, commands, skills, templates, knowledge) from ~/.claude/ to the claude-code-config + claude-skills-library GitHub repos. Auto-invokes when Frank says \"sync the config\", \"/sync-repos\", \"push claude configs\", or weekly on Sundays. Wraps the global /sync-repos command into a dispatchable Sonnet subagent with status checks + dry-run support.",
+      "file": ".claude/agents/meta-sync-repos.md"
+    },
+    {
+      "id": "agent:meta-verification-loop",
+      "kind": "agent",
+      "name": "meta-verification-loop",
+      "group": "core",
+      "tier": "haiku",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash"
+      ],
+      "mcpServers": [],
+      "description": "Pre-completion gate. Verifies that an agent's claim of \"done\" is actually true — TypeScript clean, expected files modified, tests passed, no silent failures. Auto-invokes when any agent (or the main loop) is about to declare a task complete, commit, or open a PR. Returns pass/fail verdict with specific evidence. Wraps the global verification-quality skill.",
+      "file": ".claude/agents/meta-verification-loop.md"
+    },
+    {
+      "id": "agent:music-production",
+      "kind": "agent",
+      "name": "Music Producer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "lyric-genius",
+        "slack",
+        "notion",
+        "nano-banana"
+      ],
+      "description": "AI-powered music production specialist for premium soundscapes and commercial tracks",
+      "file": ".claude/agents/music-production.md"
+    },
+    {
+      "id": "agent:nano-banana-image-generation",
+      "kind": "agent",
+      "name": "nano-banana-image-creator",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "nano-banana"
+      ],
+      "description": "Use this agent when you need to generate images using the Nano Banana API with expertly crafted prompts. Examples: <example>Context: User wants to create a professional product image for their e-commerce site. user: 'I need a high-quality image of a vintage leather wallet on a marble surface with soft lighting' assistant: 'I'll use the nano-banana-image-creator agent to craft an optimal prompt and",
+      "file": ".claude/agents/nano-banana-image-generation.md"
+    },
+    {
+      "id": "agent:nextjs-vercel-deployment",
+      "kind": "agent",
+      "name": "nextjs-vercel-deployment",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Expert Next.js and Vercel development agent with full-stack web development best practices",
+      "file": ".claude/agents/nextjs-vercel-deployment.md"
+    },
+    {
+      "id": "agent:optimization/benchmark-suite",
+      "kind": "agent",
+      "name": "Benchmark Suite",
+      "group": "optimization",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Comprehensive performance benchmarking, regression detection and performance validation",
+      "file": ".claude/agents/optimization/benchmark-suite.md"
+    },
+    {
+      "id": "agent:optimization/load-balancer",
+      "kind": "agent",
+      "name": "Load Balancing Coordinator",
+      "group": "optimization",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Dynamic task distribution, work-stealing algorithms and adaptive load balancing",
+      "file": ".claude/agents/optimization/load-balancer.md"
+    },
+    {
+      "id": "agent:optimization/performance-monitor",
+      "kind": "agent",
+      "name": "Performance Monitor",
+      "group": "optimization",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Real-time metrics collection, bottleneck analysis, SLA monitoring and anomaly detection",
+      "file": ".claude/agents/optimization/performance-monitor.md"
+    },
+    {
+      "id": "agent:optimization/resource-allocator",
+      "kind": "agent",
+      "name": "Resource Allocator",
+      "group": "optimization",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Adaptive resource allocation, predictive scaling and intelligent capacity planning",
+      "file": ".claude/agents/optimization/resource-allocator.md"
+    },
+    {
+      "id": "agent:optimization/topology-optimizer",
+      "kind": "agent",
+      "name": "Topology Optimizer",
+      "group": "optimization",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Dynamic swarm topology reconfiguration and communication pattern optimization",
+      "file": ".claude/agents/optimization/topology-optimizer.md"
+    },
+    {
+      "id": "agent:payments/agentic-payments",
+      "kind": "agent",
+      "name": "agentic-payments",
+      "group": "payments",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Multi-agent payment authorization specialist for autonomous AI commerce with cryptographic verification and Byzantine consensus",
+      "file": ".claude/agents/payments/agentic-payments.md"
+    },
+    {
+      "id": "agent:performance-guardian",
+      "kind": "agent",
+      "name": "performance-guardian",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Performance optimization expert - Core Web Vitals, Lighthouse, bundle analysis, speed optimization",
+      "file": ".claude/agents/performance-guardian.md"
+    },
+    {
+      "id": "agent:prompt-architect",
+      "kind": "agent",
+      "name": "prompt-architect",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write",
+        "Task"
+      ],
+      "mcpServers": [],
+      "description": "Designs new prompts from blank using CoT / ToT / ReAct / Constitutional / Self-Consistency / Atom-of-Thoughts patterns. Composes lab specialist for final pass. Auto-invokes when @prompt-conductor dispatches `flow-design` / `flow-knowledge-base`, or when Frank says \"design a prompt for X\", \"build me a system prompt for Y\", \"create a master prompt for Z\". Replaces existing legacy prompt-architect.md",
+      "file": ".claude/agents/prompt-architect.md"
+    },
+    {
+      "id": "agent:prompt-claude-specialist",
+      "kind": "agent",
+      "name": "prompt-claude-specialist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Anthropic / Claude prompting doctrine specialist. Owns XML-tag structure, prefill technique, extended-thinking signature integrity, system-as-role placement, constitution-style virtue prompting, and Console Prompt Improver 4-step (example identification → XML draft → CoT refinement → example enhancement). Auto-invokes when @prompt-conductor dispatches `flow-design` / `flow-optimize` for a Claude t",
+      "file": ".claude/agents/prompt-claude-specialist.md"
+    },
+    {
+      "id": "agent:prompt-conductor",
+      "kind": "agent",
+      "name": "prompt-conductor",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write",
+        "Task"
+      ],
+      "mcpServers": [],
+      "description": "Top-level Opus composer for the Prompt Hub. Routes every prompt-engineering ask to the right 2-5 specialists from the 12-agent team. Auto-invokes when Frank says \"design a prompt for X\", \"optimize this prompt\", \"evaluate my system prompt\", \"harvest prompts from Fabric\", \"build a knowledge-base prompt set\", \"IFS session\", \"profile me on Big Five\", or runs `/prompt-hub`. Composes flow-design / flow-",
+      "file": ".claude/agents/prompt-conductor.md"
+    },
+    {
+      "id": "agent:prompt-evaluator",
+      "kind": "agent",
+      "name": "prompt-evaluator",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Wraps promptfoo (MIT) to evaluate prompts. Generates declarative test files colocated with each pattern. Returns scored verdicts and writes them back to pattern frontmatter. Replaces the existing `prompt-tester.md` scaffold (which had zero fixtures). Auto-invokes when @prompt-conductor dispatches `flow-evaluate` or as the publish gate inside `flow-design` / `flow-optimize` / `flow-curate`. Pillar ",
+      "file": ".claude/agents/prompt-evaluator.md"
+    },
+    {
+      "id": "agent:prompt-gemini-specialist",
+      "kind": "agent",
+      "name": "prompt-gemini-specialist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Google / Gemini prompting doctrine specialist. Owns system-at-top placement, context-first long-document layout, native grounding (Search + code execution), \"think very hard\" literal trigger, multimodal equal-class positioning. Auto-invokes when @prompt-conductor dispatches `flow-design` / `flow-optimize` for a Gemini target, or when Frank says \"make this Gemini-native\", \"add grounding\", \"convert ",
+      "file": ".claude/agents/prompt-gemini-specialist.md"
+    },
+    {
+      "id": "agent:prompt-gpt-specialist",
+      "kind": "agent",
+      "name": "prompt-gpt-specialist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "OpenAI / GPT-5 prompting doctrine specialist. Owns developer-role placement, reasoning_effort × verbosity independent axes, Structured Outputs via Zod/Pydantic (never JSON-in-prose), tool-call preambles, contradiction audit, persistence reminders, previous_response_id chaining. Auto-invokes when @prompt-conductor dispatches `flow-design` / `flow-optimize` for a GPT target, or when Frank says \"make",
+      "file": ".claude/agents/prompt-gpt-specialist.md"
+    },
+    {
+      "id": "agent:prompt-harvester",
+      "kind": "agent",
+      "name": "prompt-harvester",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write",
+        "WebFetch",
+        "WebSearch"
+      ],
+      "mcpServers": [],
+      "description": "Bulk-imports patterns from external sources (Fabric MIT, awesome-chatgpt-prompts CC0, awesome-claude-prompts MIT, DAIR.AI taxonomy MIT, lab official docs). Tags provenance + license. Runs quality gate. Returns patterns ready for red-team → librarian publish. Repurposes prior `prompt-harvester.md` legacy scaffold. Auto-invokes when @prompt-conductor dispatches `flow-harvest`, or when Frank says \"im",
+      "file": ".claude/agents/prompt-harvester.md"
+    },
+    {
+      "id": "agent:prompt-librarian",
+      "kind": "agent",
+      "name": "prompt-librarian",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write",
+        "Grep",
+        "Glob"
+      ],
+      "mcpServers": [],
+      "description": "Owns the prompt-library corpus. Categorizes, tags, ranks, attributes, enforces frontmatter schema, manages contributions. The Alexandria-style curator. Auto-invokes when @prompt-conductor dispatches `flow-curate`, when patterns finish `flow-design` / `flow-optimize` / `flow-harvest` for publish, or when Frank says \"rebuild the library\", \"rerank category X\", \"add this pattern to the library\". Pilla",
+      "file": ".claude/agents/prompt-librarian.md"
+    },
+    {
+      "id": "agent:prompt-optimizer",
+      "kind": "agent",
+      "name": "prompt-optimizer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write",
+        "Task"
+      ],
+      "mcpServers": [],
+      "description": "Refines an existing prompt for clarity, specificity, structure, and lab-native form. Outputs optimized prompt + diff + rationale + expected delta. Wraps the `/po` command. Auto-invokes when @prompt-conductor dispatches `flow-optimize` / `flow-curate`, or when Frank says \"optimize this prompt\", \"make this prompt better\", \"tighten this\", \"rewrite for Claude/GPT/Gemini\", or runs `/po`. Pillar Prompt ",
+      "file": ".claude/agents/prompt-optimizer.md"
+    },
+    {
+      "id": "agent:prompt-oss-specialist",
+      "kind": "agent",
+      "name": "prompt-oss-specialist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Open-source model prompting specialist. Owns Llama 3/3.1/3.2 / Mistral / Qwen / DeepSeek-R1 / Yi chat templates, `apply_chat_template()` rendering, ChatML vs Llama3-special-tokens distinction, DeepSeek `<think>` block conventions, finetune-format inheritance rules. Auto-invokes when @prompt-conductor dispatches `flow-design` / `flow-optimize` for an OSS model target, or when Frank says \"make this ",
+      "file": ".claude/agents/prompt-oss-specialist.md"
+    },
+    {
+      "id": "agent:prompt-psyche-cartographer",
+      "kind": "agent",
+      "name": "prompt-psyche-cartographer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "IFS-based introspective agent. Maps user's parts (managers, firefighters, exiles) and Self-energy via unblending questions. Offers Socratic / Stoic / Jungian / IFS-Self voice modes per session. Reflection-only — maps but never unburdens. Hard boundaries against clinical content; crisis triggers route to 988 / Samaritans / Befrienders. Consumes Second Brain OS for cross-session memory. Auto-invokes",
+      "file": ".claude/agents/prompt-psyche-cartographer.md"
+    },
+    {
+      "id": "agent:prompt-psychometrist",
+      "kind": "agent",
+      "name": "prompt-psychometrist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Administers canonical psychometric instruments (IPIP-50 Big Five, Schwartz PVQ values, ECR-R attachment, VIA Character Strengths, Enneagram-narrative). Returns profiles framed as LENSES, never verdicts. Composes Cartographer for reflective follow-up. Consumes Second Brain OS for profile memory. Auto-invokes when @prompt-conductor dispatches `flow-profile`, or when Frank says \"profile me on Big Fiv",
+      "file": ".claude/agents/prompt-psychometrist.md"
+    },
+    {
+      "id": "agent:prompt-red-team",
+      "kind": "agent",
+      "name": "prompt-red-team",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Adversarial audit of system prompts before publish. Probes jailbreak vectors, refusal-bypass attempts, prompt-injection vulnerabilities, role-fluidity exploits, and known social-engineering patterns. Returns pass/warn/fail verdict written to pattern frontmatter. Load-bearing publish gate. Auto-invokes inside `flow-design`, `flow-harvest`, `flow-optimize`, `flow-evaluate`, or when Frank says \"red-t",
+      "file": ".claude/agents/prompt-red-team.md"
+    },
+    {
+      "id": "agent:publishing-strategist",
+      "kind": "agent",
+      "name": "Publishing Strategist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "github",
+        "linear"
+      ],
+      "description": "Market positioning expert, cover direction specialist, and launch planner who ensures books reach their audience effectively",
+      "file": ".claude/agents/publishing-strategist.md"
+    },
+    {
+      "id": "agent:research-daily-ops",
+      "kind": "agent",
+      "name": "research-daily-ops",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Write",
+        "Edit",
+        "WebSearch",
+        "WebFetch",
+        "Bash",
+        "Grep"
+      ],
+      "mcpServers": [],
+      "description": "Daily intelligence operations across 3 domains (Generative AI / Systems & Performance / Personal Development). 3 modes — scan (morning brief), deep-dive (focused topic), publish (transform research into pillar/brief/thread/post). Auto-invokes when Frank says \"scan today\", \"morning brief\", \"research <topic>\", \"publish research as <type>\", or runs /research. Pillar 6 (Research Hub), slot 2.",
+      "file": ".claude/agents/research-daily-ops.md"
+    },
+    {
+      "id": "agent:research-guardian",
+      "kind": "agent",
+      "name": "research-guardian",
+      "group": "core",
+      "tier": "haiku",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Grep",
+        "Bash",
+        "WebFetch"
+      ],
+      "mcpServers": [],
+      "description": "Quality gate for autoresearch commits — reviews voice, factuality, no-regression, and scope compliance BEFORE a commit is kept. Reject authority overrides score improvements.",
+      "file": ".claude/agents/research-guardian.md"
+    },
+    {
+      "id": "agent:research-librarian",
+      "kind": "agent",
+      "name": "Research Librarian",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github"
+      ],
+      "description": "Fact-checking specialist, source verification expert, and case study validator for ensuring book accuracy and credibility",
+      "file": ".claude/agents/research-librarian.md"
+    },
+    {
+      "id": "agent:sensitivity-reader",
+      "kind": "agent",
+      "name": "Sensitivity Reader",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "github"
+      ],
+      "description": "Cultural respect guardian, representation advisor, and appropriation prevention specialist who ensures books honor diverse experiences authentically",
+      "file": ".claude/agents/sensitivity-reader.md"
+    },
+    {
+      "id": "agent:seo_specialist",
+      "kind": "agent",
+      "name": "seo_specialist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "",
+      "file": ".claude/agents/seo_specialist.md"
+    },
+    {
+      "id": "agent:social-content-generator",
+      "kind": "agent",
+      "name": "social-content-generator",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Transform blog articles into platform-optimized social media content for all major platforms",
+      "file": ".claude/agents/social-content-generator.md"
+    },
+    {
+      "id": "agent:sona/sona-learning-optimizer",
+      "kind": "agent",
+      "name": "sona-learning-optimizer",
+      "group": "sona",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "SONA-powered self-optimizing agent with LoRA fine-tuning and EWC++ memory preservation",
+      "file": ".claude/agents/sona/sona-learning-optimizer.md"
+    },
+    {
+      "id": "agent:sparc/architecture",
+      "kind": "agent",
+      "name": "architecture",
+      "group": "sparc",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "SPARC Architecture phase specialist for system design",
+      "file": ".claude/agents/sparc/architecture.md"
+    },
+    {
+      "id": "agent:sparc/pseudocode",
+      "kind": "agent",
+      "name": "pseudocode",
+      "group": "sparc",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "SPARC Pseudocode phase specialist for algorithm design",
+      "file": ".claude/agents/sparc/pseudocode.md"
+    },
+    {
+      "id": "agent:sparc/refinement",
+      "kind": "agent",
+      "name": "refinement",
+      "group": "sparc",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "SPARC Refinement phase specialist for iterative improvement",
+      "file": ".claude/agents/sparc/refinement.md"
+    },
+    {
+      "id": "agent:sparc/specification",
+      "kind": "agent",
+      "name": "specification",
+      "group": "sparc",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "SPARC Specification phase specialist for requirements analysis",
+      "file": ".claude/agents/sparc/specification.md"
+    },
+    {
+      "id": "agent:specialized/mobile/spec-mobile-react-native",
+      "kind": "agent",
+      "name": "mobile-dev",
+      "group": "specialized",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Expert agent for React Native mobile application development across iOS and Android",
+      "file": ".claude/agents/specialized/mobile/spec-mobile-react-native.md"
+    },
+    {
+      "id": "agent:starlight-architecture-design",
+      "kind": "agent",
+      "name": "Starlight Architect",
+      "group": "core",
+      "tier": "opus",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "github",
+        "linear-server"
+      ],
+      "description": "Enterprise AI System Designer - Oracle Architecture Expert & Brand DNA Guardian",
+      "file": ".claude/agents/starlight-architecture-design.md"
+    },
+    {
+      "id": "agent:starlight-orchestrator",
+      "kind": "agent",
+      "name": "Starlight Orchestrator",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Meta-intelligence agent for intelligent multi-agent coordination, workflow orchestration, and cross-tool integration across the FrankX Superintelligent Agent System",
+      "file": ".claude/agents/starlight-orchestrator.md"
+    },
+    {
+      "id": "agent:strategist",
+      "kind": "agent",
+      "name": "strategist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "",
+      "file": ".claude/agents/strategist.md"
+    },
+    {
+      "id": "agent:sublinear/consensus-coordinator",
+      "kind": "agent",
+      "name": "consensus-coordinator",
+      "group": "sublinear",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Distributed consensus agent that uses sublinear solvers for fast agreement protocols in multi-agent systems. Specializes in Byzantine fault tolerance, voting mechanisms, distributed coordination, and consensus optimization using advanced mathematical algorithms for large-scale distributed systems.",
+      "file": ".claude/agents/sublinear/consensus-coordinator.md"
+    },
+    {
+      "id": "agent:sublinear/matrix-optimizer",
+      "kind": "agent",
+      "name": "matrix-optimizer",
+      "group": "sublinear",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Expert agent for matrix analysis and optimization using sublinear algorithms. Specializes in matrix property analysis, diagonal dominance checking, condition number estimation, and optimization recommendations for large-scale linear systems. Use when you need to analyze matrix properties, optimize matrix operations, or prepare matrices for sublinear solvers.",
+      "file": ".claude/agents/sublinear/matrix-optimizer.md"
+    },
+    {
+      "id": "agent:sublinear/pagerank-analyzer",
+      "kind": "agent",
+      "name": "pagerank-analyzer",
+      "group": "sublinear",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Expert agent for graph analysis and PageRank calculations using sublinear algorithms. Specializes in network optimization, influence analysis, swarm topology optimization, and large-scale graph computations. Use for social network analysis, web graph analysis, recommendation systems, and distributed system topology design.",
+      "file": ".claude/agents/sublinear/pagerank-analyzer.md"
+    },
+    {
+      "id": "agent:sublinear/performance-optimizer",
+      "kind": "agent",
+      "name": "performance-optimizer",
+      "group": "sublinear",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "System performance optimization agent that identifies bottlenecks and optimizes resource allocation using sublinear algorithms. Specializes in computational performance analysis, system optimization, resource management, and efficiency maximization across distributed systems and cloud infrastructure.",
+      "file": ".claude/agents/sublinear/performance-optimizer.md"
+    },
+    {
+      "id": "agent:sublinear/trading-predictor",
+      "kind": "agent",
+      "name": "trading-predictor",
+      "group": "sublinear",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Advanced financial trading agent that leverages temporal advantage calculations to predict and execute trades before market data arrives. Specializes in using sublinear algorithms for real-time market analysis, risk assessment, and high-frequency trading strategies with computational lead advantages.",
+      "file": ".claude/agents/sublinear/trading-predictor.md"
+    },
+    {
+      "id": "agent:swarm/adaptive-coordinator",
+      "kind": "agent",
+      "name": "adaptive-coordinator",
+      "group": "swarm",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Dynamic topology switching coordinator with self-organizing swarm patterns and real-time optimization",
+      "file": ".claude/agents/swarm/adaptive-coordinator.md"
+    },
+    {
+      "id": "agent:swarm/hierarchical-coordinator",
+      "kind": "agent",
+      "name": "hierarchical-coordinator",
+      "group": "swarm",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Queen-led hierarchical swarm coordination with specialized worker delegation",
+      "file": ".claude/agents/swarm/hierarchical-coordinator.md"
+    },
+    {
+      "id": "agent:swarm/mesh-coordinator",
+      "kind": "agent",
+      "name": "mesh-coordinator",
+      "group": "swarm",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Peer-to-peer mesh network swarm with distributed decision making and fault tolerance",
+      "file": ".claude/agents/swarm/mesh-coordinator.md"
+    },
+    {
+      "id": "agent:template-design",
+      "kind": "agent",
+      "name": "template-design-experts",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Use this agent when you need to create, design, or optimize any type of template for commercial sale. This includes when you want to develop new template concepts, improve existing templates, choose the right tools and formats, or get strategic advice on template marketability. Examples: <example>Context: User wants to create a new template product line. user: 'I want to create some resume templat",
+      "file": ".claude/agents/template-design.md"
+    },
+    {
+      "id": "agent:templates/automation-smart-agent",
+      "kind": "agent",
+      "name": "smart-agent",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Intelligent agent coordination and dynamic spawning specialist",
+      "file": ".claude/agents/templates/automation-smart-agent.md"
+    },
+    {
+      "id": "agent:templates/coordinator-swarm-init",
+      "kind": "agent",
+      "name": "swarm-init",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Swarm initialization and topology optimization specialist",
+      "file": ".claude/agents/templates/coordinator-swarm-init.md"
+    },
+    {
+      "id": "agent:templates/github-pr-manager",
+      "kind": "agent",
+      "name": "pr-manager",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Complete pull request lifecycle management and GitHub workflow coordination",
+      "file": ".claude/agents/templates/github-pr-manager.md"
+    },
+    {
+      "id": "agent:templates/implementer-sparc-coder",
+      "kind": "agent",
+      "name": "sparc-coder",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Transform specifications into working code with TDD practices",
+      "file": ".claude/agents/templates/implementer-sparc-coder.md"
+    },
+    {
+      "id": "agent:templates/memory-coordinator",
+      "kind": "agent",
+      "name": "memory-coordinator",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Manage persistent memory across sessions and facilitate cross-agent memory sharing",
+      "file": ".claude/agents/templates/memory-coordinator.md"
+    },
+    {
+      "id": "agent:templates/migration-plan",
+      "kind": "agent",
+      "name": "migration-planner",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Comprehensive migration plan for converting commands to agent-based system",
+      "file": ".claude/agents/templates/migration-plan.md"
+    },
+    {
+      "id": "agent:templates/orchestrator-task",
+      "kind": "agent",
+      "name": "task-orchestrator",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Central coordination agent for task decomposition, execution planning, and result synthesis",
+      "file": ".claude/agents/templates/orchestrator-task.md"
+    },
+    {
+      "id": "agent:templates/performance-analyzer",
+      "kind": "agent",
+      "name": "perf-analyzer",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Performance bottleneck analyzer for identifying and resolving workflow inefficiencies",
+      "file": ".claude/agents/templates/performance-analyzer.md"
+    },
+    {
+      "id": "agent:templates/sparc-coordinator",
+      "kind": "agent",
+      "name": "sparc-coord",
+      "group": "templates",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "SPARC methodology orchestrator for systematic development phase coordination",
+      "file": ".claude/agents/templates/sparc-coordinator.md"
+    },
+    {
+      "id": "agent:testing/production-validator",
+      "kind": "agent",
+      "name": "production-validator",
+      "group": "testing",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Production validation specialist ensuring applications are fully implemented and deployment-ready",
+      "file": ".claude/agents/testing/production-validator.md"
+    },
+    {
+      "id": "agent:testing/tdd-london-swarm",
+      "kind": "agent",
+      "name": "tdd-london-swarm",
+      "group": "testing",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "TDD London School specialist for mock-driven development within swarm coordination",
+      "file": ".claude/agents/testing/tdd-london-swarm.md"
+    },
+    {
+      "id": "agent:testing/unit/tdd-london-swarm",
+      "kind": "agent",
+      "name": "tdd-london-swarm",
+      "group": "testing",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "TDD London School specialist for mock-driven development within swarm coordination",
+      "file": ".claude/agents/testing/unit/tdd-london-swarm.md"
+    },
+    {
+      "id": "agent:testing/validation/production-validator",
+      "kind": "agent",
+      "name": "production-validator",
+      "group": "testing",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Production validation specialist ensuring applications are fully implemented and deployment-ready",
+      "file": ".claude/agents/testing/validation/production-validator.md"
+    },
+    {
+      "id": "agent:ui-ux-design-guidance",
+      "kind": "agent",
+      "name": "ui-ux-design-expert",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Use this agent when you need expert guidance on UI/UX design decisions, design system creation, usability evaluations, or when you want to ensure your interfaces meet the highest standards of user experience. This includes design reviews, accessibility assessments, user flow optimization, and establishing design quality metrics. Examples: <example>Context: The user wants expert feedback on their a",
+      "file": ".claude/agents/ui-ux-design-guidance.md"
+    },
+    {
+      "id": "agent:ux-design-development",
+      "kind": "agent",
+      "name": "UX Designer",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "figma-remote-mcp",
+        "playwright",
+        "nano-banana",
+        "notion"
+      ],
+      "description": "UI/UX design specialist with Figma and browser testing expertise",
+      "file": ".claude/agents/ux-design-development.md"
+    },
+    {
+      "id": "agent:viral-content-strategy",
+      "kind": "agent",
+      "name": "viral-content-strategist",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "Use this agent when you need to create high-impact social media content that combines strategic thinking with viral potential. Examples: <example>Context: User wants to share insights about productivity hacks they've discovered. user: 'I've been using the Pomodoro Technique with a twist - I do 25 minutes of deep work followed by 5 minutes of creative brainstorming. It's been game-changing for my o",
+      "file": ".claude/agents/viral-content-strategy.md"
+    },
+    {
+      "id": "agent:visual-brand-guidelines",
+      "kind": "agent",
+      "name": "visual-brand-guidelines",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [
+        "Read",
+        "Bash",
+        "Write"
+      ],
+      "mcpServers": [],
+      "description": "Brand-gate for every FrankX visual asset. Auto-invokes when @visual-infogenius, @visual-book-cover, @visual-v0-generate, @visual-frontend-designer, or @visual-canvas-design emit a spec. Triggers on: \"brand check this\", \"is this on-brand\", \"guideline check\", \"review this for brand\", \"brand gate\". Runs 4 checks (color palette, typography, voice/AI-slop, Arcanean-mythology-leak) and returns pass | wa",
+      "file": ".claude/agents/visual-brand-guidelines.md"
+    },
+    {
+      "id": "agent:weekly-recap",
+      "kind": "agent",
+      "name": "weekly-recap",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [],
+      "description": "",
+      "file": ".claude/agents/weekly-recap.md"
+    },
+    {
+      "id": "agent:world-architect",
+      "kind": "agent",
+      "name": "World Architect",
+      "group": "core",
+      "tier": "sonnet",
+      "status": "shipped",
+      "tools": [],
+      "mcpServers": [
+        "notion",
+        "nano-banana",
+        "github"
+      ],
+      "description": "World-building specialist for fantasy, sci-fi, and speculative fiction - creates internally consistent universes with rich cultures, magic/tech systems, and immersive settings",
+      "file": ".claude/agents/world-architect.md"
+    },
+    {
+      "id": "skill:acos-meta",
+      "kind": "skill",
+      "name": "acos-meta",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "ACOS self-description and configuration skill. Documents how ACOS works, how to extend it, how to add new skills/commands/agents, and how to debug the hook system. Use when building new ACOS capabilities, understanding the system architecture, or onboarding to ACOS for the first time."
+    },
+    {
+      "id": "skill:agentic-jujutsu",
+      "kind": "skill",
+      "name": "agentic-jujutsu",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Quantum-resistant, self-learning version control for AI agents with ReasoningBank intelligence and multi-agent coordination"
+    },
+    {
+      "id": "skill:agentic-orchestration",
+      "kind": "skill",
+      "name": "agentic-orchestration",
+      "group": "technical",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "orchestration",
+        "multi-agent",
+        "agent coordination"
+      ],
+      "description": "Multi-agent orchestration patterns and workflows"
+    },
+    {
+      "id": "skill:ai-architect-newsletter",
+      "kind": "skill",
+      "name": "ai-architect-newsletter",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Generate high-quality AI Architect newsletters with latest AI news, research integration, and visual design. Use when creating newsletters, researching AI developments, synthesizing AI news for architects, or distributing intelligence reports. Covers AI model releases, research papers, tool launches, architecture patterns, production systems, and enterprise AI trends. Integrates with FrankX research hub and supports both daily briefs and weekly deep-dives."
+    },
+    {
+      "id": "skill:ai-architecture",
+      "kind": "skill",
+      "name": "ai-architecture",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:algorithmic-art",
+      "kind": "skill",
+      "name": "algorithmic-art",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations."
+    },
+    {
+      "id": "skill:book-publishing",
+      "kind": "skill",
+      "name": "book-publishing",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "ACOS book publishing intelligence for multi-book content, voice, and production workflows."
+    },
+    {
+      "id": "skill:brand-guidelines",
+      "kind": "skill",
+      "name": "brand-guidelines",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply."
+    },
+    {
+      "id": "skill:brand-voice",
+      "kind": "skill",
+      "name": "brand-voice",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Apply and enforce brand voice across all content creation. Manages voice attributes, tone adaptation by channel, style rules, and terminology. Use when writing content, reviewing drafts, or defining brand voice for a new project. Loads voice config from CREATOR.md or creator-memory/voice.md."
+    },
+    {
+      "id": "skill:cacos",
+      "kind": "skill",
+      "name": "cacos",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "cacos",
+        "agentic creator os",
+        "activate system",
+        "ultrawork",
+        "ulw"
+      ],
+      "description": "Claude Agentic Creator OS - Native Claude Code implementation"
+    },
+    {
+      "id": "skill:canvas-design",
+      "kind": "skill",
+      "name": "canvas-design",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations."
+    },
+    {
+      "id": "skill:claude-sdk",
+      "kind": "skill",
+      "name": "claude-sdk",
+      "group": "technical",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "claude sdk",
+        "agent sdk",
+        "anthropic sdk",
+        "claude agent"
+      ],
+      "description": "Claude Agent SDK patterns for building autonomous agents"
+    },
+    {
+      "id": "skill:creator-productivity",
+      "kind": "skill",
+      "name": "creator-productivity",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Task management and workspace memory for creative work sessions. Manages a TASKS.md file for project tracking, a two-tier memory system (CREATOR.md + creator-memory/), and a daily sprint structure. Use when organizing creative projects, tracking content tasks, or starting a focused work session."
+    },
+    {
+      "id": "skill:doc-coauthoring",
+      "kind": "skill",
+      "name": "doc-coauthoring",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks."
+    },
+    {
+      "id": "skill:docx",
+      "kind": "skill",
+      "name": "docx",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. When Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+    },
+    {
+      "id": "skill:excellence-book-writing",
+      "kind": "skill",
+      "name": "excellence-book-writing",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "book",
+        "chapter",
+        "manuscript",
+        "novel",
+        "writing",
+        "narrative"
+      ],
+      "description": ""
+    },
+    {
+      "id": "skill:framer-expert",
+      "kind": "skill",
+      "name": "framer-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "framer",
+        "animation",
+        "motion",
+        "prototype",
+        "interactive"
+      ],
+      "description": "Expert in Framer design and development - from interactive prototypes to production sites with Framer Motion, CMS integration, and the Framer MCP server"
+    },
+    {
+      "id": "skill:frankx-brand",
+      "kind": "skill",
+      "name": "frankx-brand",
+      "group": "creative",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "frankx brand",
+        "brand voice",
+        "brand guidelines"
+      ],
+      "description": "FrankX brand guidelines, voice, and visual identity"
+    },
+    {
+      "id": "skill:frankx-daily-execution",
+      "kind": "skill",
+      "name": "frankx-daily-execution",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Helps execute Frank's daily workflow using the FRANKX-SUPERINTELLIGENT-AGENT-SYSTEM, Starlight Intelligence, and productivity methodologies for intentional creation"
+    },
+    {
+      "id": "skill:frontend-design",
+      "kind": "skill",
+      "name": "frontend-design",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics."
+    },
+    {
+      "id": "skill:game-development",
+      "kind": "skill",
+      "name": "game-development",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "ACOS game development intelligence for high-quality browser game design and implementation."
+    },
+    {
+      "id": "skill:github-code-review",
+      "kind": "skill",
+      "name": "github-code-review",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive GitHub code review with AI-powered swarm coordination"
+    },
+    {
+      "id": "skill:github-multi-repo",
+      "kind": "skill",
+      "name": "github-multi-repo",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Multi-repository coordination, synchronization, and architecture management with AI swarm orchestration"
+    },
+    {
+      "id": "skill:github-project-management",
+      "kind": "skill",
+      "name": "github-project-management",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive GitHub project management with swarm-coordinated issue tracking, project board automation, and sprint planning"
+    },
+    {
+      "id": "skill:github-release-management",
+      "kind": "skill",
+      "name": "github-release-management",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive GitHub release orchestration with AI swarm coordination for automated versioning, testing, deployment, and rollback management"
+    },
+    {
+      "id": "skill:github-workflow-automation",
+      "kind": "skill",
+      "name": "github-workflow-automation",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Advanced GitHub Actions workflow automation with AI swarm coordination, intelligent CI/CD pipelines, and comprehensive repository management"
+    },
+    {
+      "id": "skill:greek-philosopher",
+      "kind": "skill",
+      "name": "greek-philosopher",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Channel ancient wisdom through Socratic questioning, Stoic principles, and philosophical inquiry to examine life's deepest questions with poetic eloquence and timeless insight"
+    },
+    {
+      "id": "skill:gstack",
+      "kind": "skill",
+      "name": "gstack",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "sprint",
+        "ship",
+        "QA",
+        "review PR",
+        "code review",
+        "browse",
+        "debug",
+        "investigate",
+        "canary",
+        "benchmark",
+        "office hours",
+        "retro",
+        "deploy"
+      ],
+      "description": [
+        "Brainstorming a new idea → suggest /office-hours",
+        "Reviewing a plan (strategy) → suggest /plan-ceo-review",
+        "Reviewing a plan (architecture) → suggest /plan-eng-review",
+        "Reviewing a plan (design) → suggest /plan-design-review",
+        "Auto-reviewing a plan (all reviews at once) → suggest /autoplan",
+        "Creating a design system → suggest /design-consultation",
+        "Debugging errors → suggest /investigate",
+        "Testing the app → suggest /qa",
+        "Code review before merge → suggest /review",
+        "Visual design audit → suggest /design-review",
+        "Ready to deploy / create PR → suggest /ship",
+        "Post-ship doc updates → suggest /document-release",
+        "Weekly retrospective → suggest /retro",
+        "Wanting a second opinion or adversarial code review → suggest /codex",
+        "Working with production or live systems → suggest /careful",
+        "Want to scope edits to one module/directory → suggest /freeze",
+        "Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard",
+        "Removing edit restrictions → suggest /unfreeze",
+        "Upgrading gstack to latest version → suggest /gstack-upgrade",
+        "Bash",
+        "Read",
+        "AskUserQuestion"
+      ]
+    },
+    {
+      "id": "skill:gym-training-expert",
+      "kind": "skill",
+      "name": "gym-training-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "workout",
+        "training",
+        "gym",
+        "exercise",
+        "hypertrophy",
+        "fitness"
+      ],
+      "description": "Apply cutting-edge exercise science from 2025 research on hypertrophy, progressive overload, biomechanics, and evidence-based training protocols for optimal strength and muscle development"
+    },
+    {
+      "id": "skill:health-nutrition-expert",
+      "kind": "skill",
+      "name": "health-nutrition-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "nutrition",
+        "diet",
+        "health",
+        "supplements",
+        "longevity",
+        "metabolic"
+      ],
+      "description": "Apply cutting-edge 2025 nutrition science on longevity, metabolic health, gut microbiome, and evidence-based dietary patterns for optimal vitality and disease prevention"
+    },
+    {
+      "id": "skill:hive-mind-advanced",
+      "kind": "skill",
+      "name": "hive-mind-advanced",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Advanced Hive Mind collective intelligence system for queen-led multi-agent coordination with consensus mechanisms and persistent memory"
+    },
+    {
+      "id": "skill:hook",
+      "kind": "skill",
+      "name": "hook",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Generate high-retention content hooks using tri-modal engineering (Visual + Audio + Text) across 10 dimensions — from research-backed wisdom to frontier science to comedic timing. State-of-art 2026 hook psychology for creators who respect their audience's intelligence. Use when creating video intros, social content, article hooks, or any attention capture."
+    },
+    {
+      "id": "skill:hooks-automation",
+      "kind": "skill",
+      "name": "hooks-automation",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Automated coordination, formatting, and learning from Claude Code operations using intelligent hooks with MCP integration. Includes pre/post task hooks, session management, Git integration, memory coordination, and neural pattern training for enhanced development workflows."
+    },
+    {
+      "id": "skill:internal-comms",
+      "kind": "skill",
+      "name": "internal-comms",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.)."
+    },
+    {
+      "id": "skill:iterative-retrieval",
+      "kind": "skill",
+      "name": "iterative-retrieval",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Pattern for progressively refining context retrieval to solve the subagent context problem"
+    },
+    {
+      "id": "skill:langgraph-patterns",
+      "kind": "skill",
+      "name": "langgraph-patterns",
+      "group": "technical",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "langgraph",
+        "langchain",
+        "agent workflow",
+        "state machine"
+      ],
+      "description": "LangGraph workflow patterns for agentic orchestration"
+    },
+    {
+      "id": "skill:library-os",
+      "kind": "skill",
+      "name": "library-os",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Library OS — the persistent digital library system. Use when adding a book, deepening an existing review, extracting insights from handwritten notes / highlights / photos, or when the user wants to build their own library on their site. Handles the full workflow from capture to publish."
+    },
+    {
+      "id": "skill:mcp-2025-patterns",
+      "kind": "skill",
+      "name": "mcp-2025-patterns",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Current best practices for Model Context Protocol server design, implementation, and integration. Updated patterns for 2025 MCP ecosystem including multi-server orchestration, security, and performance."
+    },
+    {
+      "id": "skill:mcp-architecture",
+      "kind": "skill",
+      "name": "mcp-architecture",
+      "group": "technical",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "mcp server",
+        "model context protocol",
+        "mcp tool",
+        "mcp resource"
+      ],
+      "description": "Model Context Protocol server design patterns and best practices"
+    },
+    {
+      "id": "skill:mcp-builder",
+      "kind": "skill",
+      "name": "mcp-builder",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK)."
+    },
+    {
+      "id": "skill:memory-guardian",
+      "kind": "skill",
+      "name": "memory-guardian",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "WSL2 memory safety and scaling guardrails for Claude Code sessions and parallel agents."
+    },
+    {
+      "id": "skill:model-routing",
+      "kind": "skill",
+      "name": "model-routing",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Intelligent model selection - routes tasks to Haiku (fast/cheap), Sonnet (balanced), or Opus (complex/strategic) based on task complexity analysis"
+    },
+    {
+      "id": "skill:nextjs-agent-team",
+      "kind": "skill",
+      "name": "nextjs-agent-team",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:nextjs-expert",
+      "kind": "skill",
+      "name": "nextjs-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:nextjs-react-expert",
+      "kind": "skill",
+      "name": "nextjs-react-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "nextjs",
+        "react",
+        "component",
+        "page",
+        "route",
+        "server component",
+        "app router"
+      ],
+      "description": ""
+    },
+    {
+      "id": "skill:nextjs-upgrade-assistant",
+      "kind": "skill",
+      "name": "nextjs-upgrade-assistant",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:oci-services-expert",
+      "kind": "skill",
+      "name": "oci-services-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "oracle",
+        "OCI",
+        "cloud",
+        "enterprise",
+        "infrastructure",
+        "kubernetes"
+      ],
+      "description": "Expert guidance on Oracle Cloud Infrastructure services, cloud architecture patterns, cost optimization, deployment strategies, and OCI best practices for enterprise solutions"
+    },
+    {
+      "id": "skill:openai-agentkit",
+      "kind": "skill",
+      "name": "openai-agentkit",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "openai",
+        "agentkit",
+        "agents sdk",
+        "openai agents"
+      ],
+      "description": "Build production-ready multi-agent systems using OpenAI AgentKit and Agents SDK with best practices for agent orchestration, handoffs, and routines"
+    },
+    {
+      "id": "skill:opus-extended-thinking",
+      "kind": "skill",
+      "name": "opus-extended-thinking",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "deep reasoning",
+        "complex analysis",
+        "extended thinking",
+        "strategic",
+        "architecture decision"
+      ],
+      "description": "Leverage Claude Opus 4.5's extended thinking capabilities for deep reasoning, complex analysis, and multi-step synthesis. Use when problems require thorough deliberation before response."
+    },
+    {
+      "id": "skill:oracle-adk",
+      "kind": "skill",
+      "name": "oracle-adk",
+      "group": "technical",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "oracle adk",
+        "agent development kit",
+        "oracle agent"
+      ],
+      "description": "Oracle Agent Development Kit patterns and implementations"
+    },
+    {
+      "id": "skill:oracle-agent-spec",
+      "kind": "skill",
+      "name": "oracle-agent-spec",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Design framework-agnostic AI agents using Oracle's Open Agent Specification for portable, interoperable agentic systems with JSON/YAML definitions"
+    },
+    {
+      "id": "skill:oracle-ai-architect",
+      "kind": "skill",
+      "name": "oracle-ai-architect",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:oracle-database-expert",
+      "kind": "skill",
+      "name": "oracle-database-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:oracle-diagram-generator",
+      "kind": "skill",
+      "name": "oracle-diagram-generator",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:pair-programming",
+      "kind": "skill",
+      "name": "pair-programming",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "AI-assisted pair programming with multiple modes (driver/navigator/switch), real-time verification, quality monitoring, and comprehensive testing. Supports TDD, debugging, refactoring, and learning sessions. Features automatic role switching, continuous code review, security scanning, and performance optimization with truth-score verification."
+    },
+    {
+      "id": "skill:pdf",
+      "kind": "skill",
+      "name": "pdf",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive PDF manipulation toolkit for extracting text and tables, creating new PDFs, merging/splitting documents, and handling forms. When Claude needs to fill in a PDF form or programmatically process, generate, or analyze PDF documents at scale."
+    },
+    {
+      "id": "skill:performance-analysis",
+      "kind": "skill",
+      "name": "performance-analysis",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive performance analysis, bottleneck detection, and optimization recommendations for Claude Flow swarms"
+    },
+    {
+      "id": "skill:planning-with-files",
+      "kind": "skill",
+      "name": "planning-with-files",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "plan",
+        "task",
+        "breakdown",
+        "implement",
+        "complex task",
+        "multi-step"
+      ],
+      "description": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep",
+        "WebFetch",
+        "WebSearch"
+      ]
+    },
+    {
+      "id": "skill:pptx",
+      "kind": "skill",
+      "name": "pptx",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Presentation creation, editing, and analysis. When Claude needs to work with presentations (.pptx files) for: (1) Creating new presentations, (2) Modifying or editing content, (3) Working with layouts, (4) Adding comments or speaker notes, or any other presentation tasks"
+    },
+    {
+      "id": "skill:product-engine",
+      "kind": "skill",
+      "name": "product-engine",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Product creation and packaging pipeline. Creates premium digital products from FrankX component library, agentic AI systems, and design assets. Actions: create, package, publish, price, bundle. Products: UI kit, dashboard template, SaaS starter, agentic system, content engine, component library. Formats: Next.js, React, Tailwind, shadcn, Python, Notion, Obsidian. Channels: Gumroad, GitHub, frankx.ai."
+    },
+    {
+      "id": "skill:product-management-expert",
+      "kind": "skill",
+      "name": "product-management-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "product",
+        "launch",
+        "course",
+        "pricing",
+        "landing page",
+        "funnel"
+      ],
+      "description": ""
+    },
+    {
+      "id": "skill:prompt-optimizer",
+      "kind": "skill",
+      "name": "prompt-optimizer",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ">-"
+    },
+    {
+      "id": "skill:reasoningbank-agentdb",
+      "kind": "skill",
+      "name": "reasoningbank-agentdb",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Implement ReasoningBank adaptive learning with AgentDB's 150x faster vector database. Includes trajectory tracking, verdict judgment, memory distillation, and pattern recognition. Use when building self-learning agents, optimizing decision-making, or implementing experience replay systems."
+    },
+    {
+      "id": "skill:reasoningbank-intelligence",
+      "kind": "skill",
+      "name": "reasoningbank-intelligence",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Implement adaptive learning with ReasoningBank for pattern recognition, strategy optimization, and continuous improvement. Use when building self-learning agents, optimizing workflows, or implementing meta-cognitive systems."
+    },
+    {
+      "id": "skill:rules-distill",
+      "kind": "skill",
+      "name": "rules-distill",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Scan skills to extract cross-cutting principles and distill them into rules — append, revise, or create new rule files"
+    },
+    {
+      "id": "skill:safety-guard",
+      "kind": "skill",
+      "name": "safety-guard",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:santa-method",
+      "kind": "skill",
+      "name": "santa-method",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Multi-agent adversarial verification with convergence loop. Two independent review agents must both pass before output ships."
+    },
+    {
+      "id": "skill:search-first",
+      "kind": "skill",
+      "name": "search-first",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent."
+    },
+    {
+      "id": "skill:security-auditor",
+      "kind": "skill",
+      "name": "security-auditor",
+      "group": "technical",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "security",
+        "audit",
+        "vulnerability",
+        "penetration"
+      ],
+      "description": "Security auditing and vulnerability assessment patterns"
+    },
+    {
+      "id": "skill:skill-builder",
+      "kind": "skill",
+      "name": "skill-builder",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Create new Claude Code Skills with proper YAML frontmatter, progressive disclosure structure, and complete directory organization. Use when you need to build custom skills for specific workflows, generate skill templates, or understand the Claude Skills specification."
+    },
+    {
+      "id": "skill:skill-comply",
+      "kind": "skill",
+      "name": "skill-comply",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Visualize whether skills, rules, and agent definitions are actually followed — auto-generates scenarios at 3 prompt strictness levels, runs agents, classifies behavioral sequences, and reports compliance rates with full tool call timelines"
+    },
+    {
+      "id": "skill:skill-creator",
+      "kind": "skill",
+      "name": "skill-creator",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations."
+    },
+    {
+      "id": "skill:skill-stocktake",
+      "kind": "skill",
+      "name": "skill-stocktake",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation."
+    },
+    {
+      "id": "skill:slack-gif-creator",
+      "kind": "skill",
+      "name": "slack-gif-creator",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like \"make me a GIF of X doing Y for Slack.\""
+    },
+    {
+      "id": "skill:social-media-strategy",
+      "kind": "skill",
+      "name": "social-media-strategy",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "social",
+        "linkedin",
+        "twitter",
+        "instagram",
+        "farcaster",
+        "thread",
+        "post"
+      ],
+      "description": ""
+    },
+    {
+      "id": "skill:sparc-methodology",
+      "kind": "skill",
+      "name": "sparc-methodology",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "SPARC (Specification, Pseudocode, Architecture, Refinement, Completion) comprehensive development methodology with multi-agent orchestration"
+    },
+    {
+      "id": "skill:spartan-warrior",
+      "kind": "skill",
+      "name": "spartan-warrior",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "discipline",
+        "spartan",
+        "warrior",
+        "mental toughness",
+        "resilience"
+      ],
+      "description": "Embody the unbreakable Spartan ethos of discipline, courage, and relentless excellence through laconic wisdom and warrior mentality forged in hardship"
+    },
+    {
+      "id": "skill:strategic-compact",
+      "kind": "skill",
+      "name": "strategic-compact",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction."
+    },
+    {
+      "id": "skill:stream-chain",
+      "kind": "skill",
+      "name": "stream-chain",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Stream-JSON chaining for multi-agent pipelines, data transformation, and sequential workflows"
+    },
+    {
+      "id": "skill:suno-ai-mastery",
+      "kind": "skill",
+      "name": "suno-ai-mastery",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "music",
+        "suno",
+        "track",
+        "song",
+        "lyrics",
+        "melody",
+        "beat",
+        "frequency",
+        "hz",
+        "audio"
+      ],
+      "description": "Expert prompt engineering and music generation with Suno AI v4.5+ for professional-quality songs across all genres with advanced composition techniques"
+    },
+    {
+      "id": "skill:suno-prompt-architect",
+      "kind": "skill",
+      "name": "suno-prompt-architect",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:swarm-advanced",
+      "kind": "skill",
+      "name": "swarm-advanced",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Advanced swarm orchestration patterns for research, development, testing, and complex distributed workflows"
+    },
+    {
+      "id": "skill:swarm-orchestration",
+      "kind": "skill",
+      "name": "swarm-orchestration",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Orchestrate multi-agent swarms with agentic-flow for parallel task execution, dynamic topology, and intelligent coordination. Use when scaling beyond single agents, implementing complex workflows, or building distributed AI systems."
+    },
+    {
+      "id": "skill:template-monetization",
+      "kind": "skill",
+      "name": "template-monetization",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Blueprint-to-template monetization system for deployment, affiliate, and revenue workflows."
+    },
+    {
+      "id": "skill:theme-factory",
+      "kind": "skill",
+      "name": "theme-factory",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly."
+    },
+    {
+      "id": "skill:ui-ux-design-expert",
+      "kind": "skill",
+      "name": "ui-ux-design-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "design",
+        "UX",
+        "UI",
+        "interface",
+        "component",
+        "layout",
+        "responsive",
+        "accessibility"
+      ],
+      "description": "Expert guidance on UI/UX design, design systems, accessibility (WCAG 2.2), user research, and creating inclusive, user-centered interfaces with 2025 best practices"
+    },
+    {
+      "id": "skill:ui-ux-pro-max",
+      "kind": "skill",
+      "name": "ui-ux-pro-max",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": ""
+    },
+    {
+      "id": "skill:verification-loop",
+      "kind": "skill",
+      "name": "verification-loop",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "A comprehensive verification system for Claude Code sessions."
+    },
+    {
+      "id": "skill:verification-quality",
+      "kind": "skill",
+      "name": "verification-quality",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive truth scoring, code quality verification, and automatic rollback system with 0.95 accuracy threshold for ensuring high-quality agent outputs and codebase reliability."
+    },
+    {
+      "id": "skill:video-production-workflow",
+      "kind": "skill",
+      "name": "video-production-workflow",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "low",
+      "keywords": [
+        "video",
+        "podcast",
+        "youtube",
+        "recording",
+        "script"
+      ],
+      "description": ""
+    },
+    {
+      "id": "skill:vis",
+      "kind": "skill",
+      "name": "vis",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Agentic visual asset management — scan, audit, and manage images across your site with AI-powered quality enforcement"
+    },
+    {
+      "id": "skill:web-artifacts-builder",
+      "kind": "skill",
+      "name": "web-artifacts-builder",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts."
+    },
+    {
+      "id": "skill:web-design-expert",
+      "kind": "skill",
+      "name": "web-design-expert",
+      "group": "skill",
+      "status": "shipped",
+      "priority": "medium",
+      "keywords": [
+        "website",
+        "web design",
+        "landing page",
+        "hero section",
+        "glassmorphic"
+      ],
+      "description": ""
+    },
+    {
+      "id": "skill:webapp-testing",
+      "kind": "skill",
+      "name": "webapp-testing",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs."
+    },
+    {
+      "id": "skill:worker-benchmarks",
+      "kind": "skill",
+      "name": "worker-benchmarks",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Run comprehensive worker system benchmarks and performance analysis"
+    },
+    {
+      "id": "skill:worker-integration",
+      "kind": "skill",
+      "name": "worker-integration",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Worker-Agent integration for intelligent task dispatch and performance tracking"
+    },
+    {
+      "id": "skill:xlsx",
+      "kind": "skill",
+      "name": "xlsx",
+      "group": "skill",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [],
+      "description": "Comprehensive spreadsheet creation, editing, and analysis with support for formulas, formatting, data analysis, and visualization. When Claude needs to work with spreadsheets (.xlsx, .xlsm, .csv, .tsv, etc) for: (1) Creating new spreadsheets with formulas and formatting, (2) Reading or analyzing data, (3) Modify existing spreadsheets while preserving formulas, (4) Data analysis and visualization in spreadsheets, or (5) Recalculating formulas"
+    },
+    {
+      "id": "skill:content-strategy",
+      "kind": "skill",
+      "name": "content-strategy",
+      "group": "creative",
+      "status": "shipped",
+      "priority": "high",
+      "keywords": [
+        "content strategy",
+        "content plan",
+        "editorial calendar",
+        "content pillar"
+      ],
+      "description": "Strategic content planning with calendar management and pillar mapping"
+    },
+    {
+      "id": "skill:suno-mastery",
+      "kind": "skill",
+      "name": "suno-mastery",
+      "group": "creative",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "suno",
+        "ai music",
+        "music generation",
+        "song creation"
+      ],
+      "description": "Suno AI music generation with advanced prompt engineering"
+    },
+    {
+      "id": "skill:oci-services",
+      "kind": "skill",
+      "name": "oci-services",
+      "group": "business",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "oci",
+        "oracle cloud",
+        "oci genai",
+        "oracle ai"
+      ],
+      "description": "Oracle Cloud Infrastructure services and architecture patterns"
+    },
+    {
+      "id": "skill:7-pillars",
+      "kind": "skill",
+      "name": "7-pillars",
+      "group": "soulbook",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "7 pillars",
+        "life pillars",
+        "soulbook pillars",
+        "transformation"
+      ],
+      "description": "The 7 Pillars life transformation framework"
+    },
+    {
+      "id": "skill:life-symphony",
+      "kind": "skill",
+      "name": "life-symphony",
+      "group": "soulbook",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "life symphony",
+        "harmony",
+        "life balance"
+      ],
+      "description": "Life Symphony orchestration and harmony framework"
+    },
+    {
+      "id": "skill:golden-path",
+      "kind": "skill",
+      "name": "golden-path",
+      "group": "soulbook",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "golden path",
+        "soul purpose",
+        "life purpose"
+      ],
+      "description": "Golden Path purpose-aligned direction discovery"
+    },
+    {
+      "id": "skill:workshop-building",
+      "kind": "skill",
+      "name": "workshop-building",
+      "group": "technical",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "workshop",
+        "tutorial",
+        "hands-on",
+        "training"
+      ],
+      "description": "Interactive workshop creation and delivery patterns"
+    },
+    {
+      "id": "skill:daily-ops",
+      "kind": "skill",
+      "name": "daily-ops",
+      "group": "creative",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "daily ops",
+        "morning routine",
+        "daily workflow"
+      ],
+      "description": "Daily operations and routine management workflows"
+    },
+    {
+      "id": "skill:publishing-factory",
+      "kind": "skill",
+      "name": "publishing-factory",
+      "group": "creative",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "publish",
+        "factory",
+        "content pipeline",
+        "seo"
+      ],
+      "description": "End-to-end content publishing pipeline with SEO and AEO"
+    },
+    {
+      "id": "skill:creator-intelligence",
+      "kind": "skill",
+      "name": "creator-intelligence",
+      "group": "technical",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "jarvis",
+        "personal ai",
+        "intelligence system",
+        "creator os"
+      ],
+      "description": "Personal Jarvis system for creator intelligence operations"
+    },
+    {
+      "id": "skill:agentic-builder-lab",
+      "kind": "skill",
+      "name": "agentic-builder-lab",
+      "group": "projects",
+      "status": "shipped",
+      "priority": null,
+      "keywords": [
+        "log a build",
+        "build session log",
+        "agentic-builder-lab",
+        "build log"
+      ],
+      "description": "Convert a single build session into MDX build-log entry, LinkedIn draft, demo brief, Mermaid diagram, and a reusable prompt for the /agentic-builder-lab and /build pages on frankx.ai."
+    },
+    {
+      "id": "command:agentic-orchestration",
+      "kind": "command",
+      "name": "/agentic-orchestration",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:council",
+      "kind": "command",
+      "name": "/council",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:starlight-intelligence",
+      "kind": "command",
+      "name": "/starlight-intelligence",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:acos",
+      "kind": "command",
+      "name": "/acos",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:claude-sdk",
+      "kind": "command",
+      "name": "/claude-sdk",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:automation-dev",
+      "kind": "command",
+      "name": "/automation-dev",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:author-team",
+      "kind": "command",
+      "name": "/author-team",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:frankx-brand",
+      "kind": "command",
+      "name": "/frankx-brand",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:office-hours",
+      "kind": "command",
+      "name": "/office-hours",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:plan-ceo-review",
+      "kind": "command",
+      "name": "/plan-ceo-review",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:plan-eng-review",
+      "kind": "command",
+      "name": "/plan-eng-review",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:plan-design-review",
+      "kind": "command",
+      "name": "/plan-design-review",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:review",
+      "kind": "command",
+      "name": "/review",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:qa",
+      "kind": "command",
+      "name": "/qa",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:qa-only",
+      "kind": "command",
+      "name": "/qa-only",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:ship",
+      "kind": "command",
+      "name": "/ship",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:land-and-deploy",
+      "kind": "command",
+      "name": "/land-and-deploy",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:canary",
+      "kind": "command",
+      "name": "/canary",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:benchmark",
+      "kind": "command",
+      "name": "/benchmark",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:browse",
+      "kind": "command",
+      "name": "/browse",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:cso",
+      "kind": "command",
+      "name": "/cso",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:investigate",
+      "kind": "command",
+      "name": "/investigate",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:retro",
+      "kind": "command",
+      "name": "/retro",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:autoplan",
+      "kind": "command",
+      "name": "/autoplan",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:design-review",
+      "kind": "command",
+      "name": "/design-review",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:design-consultation",
+      "kind": "command",
+      "name": "/design-consultation",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:codex",
+      "kind": "command",
+      "name": "/codex",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:careful",
+      "kind": "command",
+      "name": "/careful",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:freeze",
+      "kind": "command",
+      "name": "/freeze",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:guard",
+      "kind": "command",
+      "name": "/guard",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:unfreeze",
+      "kind": "command",
+      "name": "/unfreeze",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:setup-browser-cookies",
+      "kind": "command",
+      "name": "/setup-browser-cookies",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:setup-deploy",
+      "kind": "command",
+      "name": "/setup-deploy",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:document-release",
+      "kind": "command",
+      "name": "/document-release",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:gstack-upgrade",
+      "kind": "command",
+      "name": "/gstack-upgrade",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:langgraph-patterns",
+      "kind": "command",
+      "name": "/langgraph-patterns",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:mcp-architecture",
+      "kind": "command",
+      "name": "/mcp-architecture",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:mcp-status",
+      "kind": "command",
+      "name": "/mcp-status",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:nextjs-deploy",
+      "kind": "command",
+      "name": "/nextjs-deploy",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:spec",
+      "kind": "command",
+      "name": "/spec",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:starlight-architect",
+      "kind": "command",
+      "name": "/starlight-architect",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:oracle-adk",
+      "kind": "command",
+      "name": "/oracle-adk",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:planning-with-files",
+      "kind": "command",
+      "name": "/planning-with-files",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:products-creation",
+      "kind": "command",
+      "name": "/products-creation",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:security-audit",
+      "kind": "command",
+      "name": "/security-audit",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:generate-social",
+      "kind": "command",
+      "name": "/generate-social",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:create-music",
+      "kind": "command",
+      "name": "/create-music",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:ux-design",
+      "kind": "command",
+      "name": "/ux-design",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:content-strategy",
+      "kind": "command",
+      "name": "/content-strategy",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:content-calendar",
+      "kind": "command",
+      "name": "/content-calendar",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:article-creator",
+      "kind": "command",
+      "name": "/article-creator",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:factory",
+      "kind": "command",
+      "name": "/factory",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:publish",
+      "kind": "command",
+      "name": "/publish",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:suno-mastery",
+      "kind": "command",
+      "name": "/suno-mastery",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:suno-prompt-architect",
+      "kind": "command",
+      "name": "/suno-prompt-architect",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:oci-services",
+      "kind": "command",
+      "name": "/oci-services",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:soulbook",
+      "kind": "command",
+      "name": "/soulbook",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:life-symphony",
+      "kind": "command",
+      "name": "/life-symphony",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:golden-path",
+      "kind": "command",
+      "name": "/golden-path",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:workshop-building",
+      "kind": "command",
+      "name": "/workshop-building",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:daily-ops",
+      "kind": "command",
+      "name": "/daily-ops",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:frankx-daily-execution",
+      "kind": "command",
+      "name": "/frankx-daily-execution",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:creator-intelligence-system",
+      "kind": "command",
+      "name": "/creator-intelligence-system",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:agentic-creator-os",
+      "kind": "command",
+      "name": "/agentic-creator-os",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:build-log",
+      "kind": "command",
+      "name": "/build-log",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "command:agentic-builder-lab",
+      "kind": "command",
+      "name": "/agentic-builder-lab",
+      "group": "command",
+      "description": ""
+    },
+    {
+      "id": "workflow:dependency-audit",
+      "kind": "workflow",
+      "name": "dependency-audit",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Dependency health audit. Parallel: security CVEs, license compliance, outdated versions, bundle size, supply-chain risk, dead deps. Ranked action list with impact × effort.",
+      "file": ".claude/workflows/dependency-audit.js"
+    },
+    {
+      "id": "workflow:incident-postmortem",
+      "kind": "workflow",
+      "name": "incident-postmortem",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Post-incident analysis. Parallel evidence gathering (timeline + impact + context) → root cause + contributing factors → blameless postmortem markdown ready for team review.",
+      "file": ".claude/workflows/incident-postmortem.js"
+    },
+    {
+      "id": "workflow:model-arena-daily",
+      "kind": "workflow",
+      "name": "model-arena-daily",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Daily multi-tier model arena. Runs the same canonical prompt through Claude Opus / Sonnet / Haiku in parallel. Synthesizer ranks responses on depth, accuracy, specificity. Captures regression signal if a tier drops.",
+      "file": ".claude/workflows/model-arena-daily.js"
+    },
+    {
+      "id": "workflow:pr-review-multi-perspective",
+      "kind": "workflow",
+      "name": "pr-review-multi-perspective",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Multi-perspective PR review with adversarial verification. Pipeline: 6 dimensions reviewed in parallel → each finding adversarially verified by an independent agent → synthesis. Only confirmed findings surface.",
+      "file": ".claude/workflows/pr-review-multi-perspective.js"
+    },
+    {
+      "id": "workflow:release-checklist",
+      "kind": "workflow",
+      "name": "release-checklist",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Pre-release validation gate. Parallel: tests, changelog, version bumps, migration docs, rollback plan + composes dependency-audit. Optional pr-review-multi-perspective sub-call. Pass/fail verdict on whether to ship.",
+      "file": ".claude/workflows/release-checklist.js"
+    },
+    {
+      "id": "workflow:repo-onboarding",
+      "kind": "workflow",
+      "name": "repo-onboarding",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Cold-start understanding of a repo. Parallel: architecture, data flow, dependencies, conventions, recent activity, gotchas. Synthesize into operating brief with first-task recommendations.",
+      "file": ".claude/workflows/repo-onboarding.js"
+    },
+    {
+      "id": "workflow:research-pulse-daily",
+      "kind": "workflow",
+      "name": "research-pulse-daily",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Daily lightweight research pulse — 3 parallel domain scans, synthesize to a 200-word brief. The cheap daily counterpart to research-fanout (which is heavy/weekly). Tags ship-worthy signals for the Friday newsletter queue.",
+      "file": ".claude/workflows/research-pulse-daily.js"
+    },
+    {
+      "id": "workflow:tech-debt-triage",
+      "kind": "workflow",
+      "name": "tech-debt-triage",
+      "group": "workflow",
+      "tierLabel": "L99",
+      "status": "shipped",
+      "description": "Code-smell scan + priority ranking. Parallel: complexity, duplication, outdated patterns, test gaps, doc gaps. Output: ranked findings in 3 buckets + concrete fix proposals for top items.",
+      "file": ".claude/workflows/tech-debt-triage.js"
+    },
+    {
+      "id": "iam:content-writer",
+      "kind": "iam-profile",
+      "name": "content-writer",
+      "group": "iam",
+      "description": "Blog articles, documentation, content creation",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Grep",
+        "Glob",
+        "WebSearch",
+        "WebFetch"
+      ],
+      "deniedTools": [
+        "Bash"
+      ]
+    },
+    {
+      "id": "iam:frontend-engineer",
+      "kind": "iam-profile",
+      "name": "frontend-engineer",
+      "group": "iam",
+      "description": "UI components, styling, layouts",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Grep",
+        "Glob",
+        "Bash",
+        "WebSearch"
+      ],
+      "deniedTools": []
+    },
+    {
+      "id": "iam:backend-engineer",
+      "kind": "iam-profile",
+      "name": "backend-engineer",
+      "group": "iam",
+      "description": "APIs, database, server-side logic",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Grep",
+        "Glob",
+        "Bash"
+      ],
+      "deniedTools": []
+    },
+    {
+      "id": "iam:devops-engineer",
+      "kind": "iam-profile",
+      "name": "devops-engineer",
+      "group": "iam",
+      "description": "Deployment, CI/CD, build configuration",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Bash",
+        "Grep",
+        "Glob"
+      ],
+      "deniedTools": []
+    },
+    {
+      "id": "iam:security-auditor",
+      "kind": "iam-profile",
+      "name": "security-auditor",
+      "group": "iam",
+      "description": "Security review, dependency audit — read-only",
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash",
+        "WebSearch"
+      ],
+      "deniedTools": [
+        "Edit",
+        "Write"
+      ]
+    },
+    {
+      "id": "iam:system-architect",
+      "kind": "iam-profile",
+      "name": "system-architect",
+      "group": "iam",
+      "description": "ACOS internals, hooks, configuration — requires gate approval",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Write",
+        "Bash",
+        "Grep",
+        "Glob"
+      ],
+      "deniedTools": []
+    }
+  ],
+  "edges": [
+    {
+      "source": "skill:agentic-orchestration",
+      "target": "skill:creator-intelligence",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:agentic-orchestration",
+      "target": "command:agentic-orchestration",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:agentic-orchestration",
+      "target": "command:council",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:agentic-orchestration",
+      "target": "command:starlight-intelligence",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:cacos",
+      "target": "command:acos",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:claude-sdk",
+      "target": "command:claude-sdk",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:claude-sdk",
+      "target": "command:automation-dev",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:excellence-book-writing",
+      "target": "command:author-team",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:frankx-brand",
+      "target": "command:frankx-brand",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:office-hours",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:plan-ceo-review",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:plan-eng-review",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:plan-design-review",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:review",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:qa",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:qa-only",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:ship",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:land-and-deploy",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:canary",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:benchmark",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:browse",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:cso",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:investigate",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:retro",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:autoplan",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:design-review",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:design-consultation",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:codex",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:careful",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:freeze",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:guard",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:unfreeze",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:setup-browser-cookies",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:setup-deploy",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:document-release",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:gstack",
+      "target": "command:gstack-upgrade",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:langgraph-patterns",
+      "target": "command:langgraph-patterns",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:mcp-architecture",
+      "target": "command:mcp-architecture",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:mcp-architecture",
+      "target": "command:mcp-status",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:mcp-architecture",
+      "target": "command:automation-dev",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:nextjs-react-expert",
+      "target": "command:nextjs-deploy",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:nextjs-react-expert",
+      "target": "command:spec",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:opus-extended-thinking",
+      "target": "command:starlight-architect",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:opus-extended-thinking",
+      "target": "command:council",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:oracle-adk",
+      "target": "skill:oci-services",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:oracle-adk",
+      "target": "command:oracle-adk",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:planning-with-files",
+      "target": "command:planning-with-files",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:planning-with-files",
+      "target": "command:spec",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:product-management-expert",
+      "target": "command:products-creation",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:security-auditor",
+      "target": "command:security-audit",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:social-media-strategy",
+      "target": "command:generate-social",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:suno-ai-mastery",
+      "target": "command:create-music",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:ui-ux-design-expert",
+      "target": "command:ux-design",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:web-design-expert",
+      "target": "command:ux-design",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:content-strategy",
+      "target": "skill:frankx-brand",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:content-strategy",
+      "target": "command:content-strategy",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:content-strategy",
+      "target": "command:content-calendar",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:content-strategy",
+      "target": "command:article-creator",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:content-strategy",
+      "target": "command:factory",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:content-strategy",
+      "target": "command:publish",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:suno-mastery",
+      "target": "command:suno-mastery",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:suno-mastery",
+      "target": "command:suno-prompt-architect",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:oci-services",
+      "target": "command:oci-services",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:7-pillars",
+      "target": "command:soulbook",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:life-symphony",
+      "target": "skill:7-pillars",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:life-symphony",
+      "target": "command:life-symphony",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:golden-path",
+      "target": "skill:7-pillars",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:golden-path",
+      "target": "command:golden-path",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:workshop-building",
+      "target": "skill:content-strategy",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:workshop-building",
+      "target": "command:workshop-building",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:daily-ops",
+      "target": "skill:content-strategy",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:daily-ops",
+      "target": "command:daily-ops",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:daily-ops",
+      "target": "command:frankx-daily-execution",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:publishing-factory",
+      "target": "skill:content-strategy",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:publishing-factory",
+      "target": "skill:frankx-brand",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:publishing-factory",
+      "target": "command:factory",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:publishing-factory",
+      "target": "command:publish",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:creator-intelligence",
+      "target": "skill:content-strategy",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:creator-intelligence",
+      "target": "skill:daily-ops",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:creator-intelligence",
+      "target": "command:creator-intelligence-system",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:creator-intelligence",
+      "target": "command:agentic-creator-os",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:agentic-builder-lab",
+      "target": "skill:frankx-brand",
+      "rel": "uses-skill"
+    },
+    {
+      "source": "skill:agentic-builder-lab",
+      "target": "command:build-log",
+      "rel": "triggers"
+    },
+    {
+      "source": "skill:agentic-builder-lab",
+      "target": "command:agentic-builder-lab",
+      "rel": "triggers"
+    },
+    {
+      "source": "workflow:release-checklist",
+      "target": "workflow:dependency-audit",
+      "rel": "composes"
+    },
+    {
+      "source": "workflow:release-checklist",
+      "target": "workflow:pr-review-multi-perspective",
+      "rel": "composes"
+    },
+    {
+      "source": "workflow:research-fanout",
+      "target": "workflow:research-pulse-daily",
+      "rel": "composes"
+    }
+  ]
+}

--- a/scripts/sync-observatory-catalog.mjs
+++ b/scripts/sync-observatory-catalog.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * sync-observatory-catalog.mjs
+ *
+ * Keeps public/observatory/catalog.json (the data behind /observatory) fresh.
+ *
+ * The catalog is GENERATED in the ACOS repo (agentic-creator-os), which is not
+ * available at Vercel build time — so a snapshot is committed here. This script:
+ *   - if ACOS_REPO_PATH points at a local ACOS checkout, regenerates the catalog
+ *     there and copies it in (use when agents/skills change);
+ *   - otherwise verifies the committed snapshot exists (no-op, build-safe).
+ *
+ * Usage:
+ *   ACOS_REPO_PATH=/path/to/agentic-creator-os node scripts/sync-observatory-catalog.mjs
+ *   node scripts/sync-observatory-catalog.mjs            # verify-only
+ */
+
+import { existsSync, copyFileSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+
+const DEST = join(process.cwd(), 'public/observatory/catalog.json')
+const ACOS = process.env.ACOS_REPO_PATH
+
+function verify() {
+  if (!existsSync(DEST)) {
+    console.error(`✗ ${DEST} missing and no ACOS_REPO_PATH to regenerate from.`)
+    process.exit(1)
+  }
+  const c = JSON.parse(readFileSync(DEST, 'utf8'))
+  if (!Array.isArray(c.nodes) || c.nodes.length === 0) {
+    console.error('✗ committed catalog is empty or malformed.')
+    process.exit(1)
+  }
+  console.log(`✓ catalog snapshot OK — ${c.nodes.length} nodes (${JSON.stringify(c.counts)})`)
+}
+
+if (ACOS && existsSync(ACOS)) {
+  const gen = join(ACOS, 'scripts/build-catalog.mjs')
+  const src = join(ACOS, 'tools/observatory/public/catalog.json')
+  if (existsSync(gen)) {
+    console.log(`↻ regenerating catalog from ${ACOS} …`)
+    execFileSync('node', [gen], { stdio: 'inherit' })
+    copyFileSync(src, DEST)
+    console.log(`✓ copied fresh catalog → ${DEST}`)
+  } else {
+    console.warn(`! ACOS_REPO_PATH set but generator not found at ${gen}; verifying snapshot.`)
+  }
+}
+
+verify()

--- a/scripts/sync-observatory-catalog.mjs
+++ b/scripts/sync-observatory-catalog.mjs
@@ -40,7 +40,12 @@ if (ACOS && existsSync(ACOS)) {
   const src = join(ACOS, 'tools/observatory/public/catalog.json')
   if (existsSync(gen)) {
     console.log(`↻ regenerating catalog from ${ACOS} …`)
-    execFileSync('node', [gen], { stdio: 'inherit' })
+    // Run from the ACOS root so the generator's relative paths resolve correctly.
+    execFileSync('node', [gen], { stdio: 'inherit', cwd: ACOS })
+    if (!existsSync(src)) {
+      console.error(`✗ generator did not produce ${src}`)
+      process.exit(1)
+    }
     copyFileSync(src, DEST)
     console.log(`✓ copied fresh catalog → ${DEST}`)
   } else {


### PR DESCRIPTION
## Agent Observatory — public showcase at `/observatory`

An interactive, world-class map of the Agentic Creator OS fleet — **142 agents, 108 skills, 66 commands, 8 workflows**, and the IAM capability matrix. Pairs with the tooling PR `frankxai/agentic-creator-os#19`.

### Design
- **Exact Anthropic brand tokens** (Dark `#141413`, Light `#faf9f5`, accents Orange `#d97757` / Blue `#6a9bcc` / Green `#788c5d`), Poppins cluster labels — FrankX-owned surface, no Anthropic marks shipped.
- **Constellation layout**: nodes laid out as radial concentric-ring clusters with labels, packed into a row (**Galaxy**) or wrapped shelf grid (**Pillars**); radial depth gradient on the canvas. Reuses the already-installed `@xyflow/react`.
- Refined nodes (kind glyph, tier ring, gap indicator, hover lift, reduced-motion aware), detail drawer, MiniMap.

### Views & interaction
Galaxy · Pillars · Workflows · **IAM Matrix** (profiles × tools grid + profile cards). Kind filters, search, click-to-inspect detail drawer.

### Responsive & a11y
Below `md`, the touch-unfriendly graph is swapped for a searchable, grouped **card directory**; detail drawer is full-width on mobile. Reduced-motion respected; `aria-label`s on controls.

### Live
A **Go Live** toggle (`useLiveActivity` SSE hook) connects to a local Observatory server (`localhost:4317`); agent nodes pulse as they run in Claude Code. On the https site the local connection is blocked by mixed-content rules → stays static (expected).

### Data freshness
`scripts/sync-observatory-catalog.mjs` regenerates the committed `public/observatory/catalog.json` snapshot from a local ACOS checkout (`ACOS_REPO_PATH`) or verifies it (build-safe). The catalog is generated in ACOS (not available at Vercel build time), hence the committed snapshot.

### Verification
`tsc --noEmit` + ESLint clean on all observatory files. Desktop (Galaxy/Pillars/Workflows/IAM) + mobile directory + detail drawer + Go Live confirmed via headless screenshots, zero page errors. **Vercel preview deploys green** (the structurally-identical prior commit already reached Ready).

### Files
`app/observatory/` · `components/observatory/{AgentGraph,ObservatoryNode,ClusterLabel,IamMatrix,ObservatoryDirectory,ObservatoryShell}.tsx` · `lib/observatory/{types,theme,layout,useLiveActivity,useMediaQuery}.ts` · `public/observatory/catalog.json` · `scripts/sync-observatory-catalog.mjs`

https://claude.ai/code/session_01HnCGUAqVXJqPght2Ktf33a