### PR TITLE
Add Microsoft MAI models to arena + launch article

### DIFF
--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -126,6 +126,23 @@ const frontierModels = [
     },
     notes: 'Most cost-effective reasoning model. Open-source under MIT license.',
   },
+  {
+    name: 'MAI-Thinking-1',
+    org: 'Microsoft AI',
+    released: 'Jun 2026',
+    context: '256K',
+    output: '—',
+    pricing: { input: 0, output: 0 },
+    achievement: 'Vendor-claimed: 97% AIME 2025, 53% SWE-Bench Pro, human-pref over Sonnet 4.6',
+    benchmarks: { aime2025: 97, sweBenchPro: 53 },
+    tags: ['reasoning', 'preview', 'in-house', 'MoE'],
+    color: '#0078d4',
+    highlight: false,
+    links: {
+      docs: 'https://microsoft.ai',
+    },
+    notes: 'Microsoft’s first in-house frontier family (7 MAI models inc. Image-2.5, Code-1-Flash) on MAIA 200 silicon. 35B-active MoE. Numbers vendor-claimed at launch — pending independent reproduction.',
+  },
 ]
 
 const benchmarkComparison = [
@@ -179,15 +196,18 @@ export default function Models2026Page() {
         <section className="pt-16 pb-16 md:pt-24 md:pb-20 px-6">
           <div className="max-w-6xl mx-auto">
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
-              <p className="text-[#a855f7] font-mono text-sm mb-4 tracking-wider uppercase">Updated February 2026</p>
+              <p className="text-[#a855f7] font-mono text-sm mb-4 tracking-wider uppercase">Updated June 2026</p>
               <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">Frontier AI Models Intelligence Hub</h1>
               <p className="text-white/60 text-lg md:text-xl max-w-3xl mb-8 leading-relaxed">
                 Benchmarks, pricing, context windows, and capabilities for every frontier model worth tracking.
                 Data validated against official sources and independent benchmarks.
               </p>
               <div className="flex flex-wrap gap-3">
+                <Link href="/blog/microsoft-mai-frontier-models-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#0078d4]/10 border border-[#0078d4]/20 hover:border-[#0078d4]/40 text-[#4cc2ff] text-sm transition-colors">
+                  <Zap className="w-4 h-4" /> New: Microsoft&apos;s 7 MAI Models
+                </Link>
                 <Link href="/blog/claude-opus-4-6-analysis-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#a855f7]/10 border border-[#a855f7]/20 hover:border-[#a855f7]/40 text-[#a855f7] text-sm transition-colors">
-                  <Crown className="w-4 h-4" /> New: Claude Opus 4.6 Deep Analysis
+                  <Crown className="w-4 h-4" /> Claude Opus 4.6 Deep Analysis
                 </Link>
                 <Link href="/research/agent-benchmarks" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 border border-white/10 hover:border-white/20 text-white/60 text-sm transition-colors">
                   <TrendingUp className="w-4 h-4" /> Benchmark Methodology
@@ -200,7 +220,7 @@ export default function Models2026Page() {
         {/* Frontier Models - Enhanced Cards */}
         <section className="py-16 px-6 border-t border-white/5">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold mb-2">Frontier Models (February 2026)</h2>
+            <h2 className="text-2xl font-bold mb-2">Frontier Models (June 2026)</h2>
             <p className="text-white/40 text-sm mb-8">Sorted by reasoning capability. Pricing per 1M tokens.</p>
             <div className="grid md:grid-cols-2 gap-4">
               {frontierModels.map((m, i) => (
@@ -245,7 +265,7 @@ export default function Models2026Page() {
                     <div className="p-2 rounded-lg bg-white/[0.03]">
                       <p className="text-[10px] text-white/30 uppercase tracking-wider mb-0.5">Price In/Out</p>
                       <p className="text-sm font-mono font-medium text-white/80">
-                        {m.pricing.input === 0 ? 'Open' : `$${m.pricing.input}/$${m.pricing.output}`}
+                        {m.pricing.input === 0 ? (m.tags.includes('preview') ? 'Preview' : 'Open') : `$${m.pricing.input}/$${m.pricing.output}`}
                       </p>
                     </div>
                   </div>

--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -265,7 +265,7 @@ export default function Models2026Page() {
                     <div className="p-2 rounded-lg bg-white/[0.03]">
                       <p className="text-[10px] text-white/30 uppercase tracking-wider mb-0.5">Price In/Out</p>
                       <p className="text-sm font-mono font-medium text-white/80">
-                        {m.pricing.input === 0 ? (m.tags.includes('preview') ? 'Preview' : 'Open') : `$${m.pricing.input}/$${m.pricing.output}`}
+                        {m.pricing.input === 0 ? (m.tags?.includes('preview') ? 'Preview' : 'Open') : `$${m.pricing.input}/$${m.pricing.output}`}
                       </p>
                     </div>
                   </div>

--- a/content/blog/microsoft-mai-frontier-models-2026.mdx
+++ b/content/blog/microsoft-mai-frontier-models-2026.mdx
@@ -1,0 +1,137 @@
+---
+title: "Microsoft's 7 MAI Models: The In-House Frontier Bet"
+description: "Microsoft AI launched 7 self-built MAI models — Thinking-1, Image-2.5, Code-1-Flash and more — on its own MAIA silicon. What the vendor claims, what's verifiable, and what it means for builders."
+date: "2026-06-03"
+lastUpdated: "2026-06-03"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - microsoft
+  - mai
+  - frontier-models
+  - ai-2026
+  - benchmarks
+keywords:
+  - microsoft mai models
+  - mai-thinking-1
+  - mai-image-2.5
+  - mai-code-1-flash
+  - microsoft frontier tuning
+  - maia 200 chip
+  - microsoft superintelligence
+  - mustafa suleyman mai
+  - microsoft ai models 2026
+image: "/images/blog/microsoft-mai-models-2026-hero.svg"
+featured: false
+schema: ["Article", "FAQPage"]
+readingGoal: "You will understand exactly what Microsoft shipped with its 7 MAI models, which claims are verifiable today, and how to slot them into a model-routing strategy."
+tldr: "Microsoft AI announced seven in-house MAI models on June 2, 2026 — its first fully self-built frontier family, trained on Microsoft's own MAIA silicon. Headliners: MAI-Thinking-1 (35B-active MoE, 256K context, vendor-claimed 97% AIME 2025 and human-rater preference over Sonnet 4.6), MAI-Image-2.5 (claimed #2 on image leaderboards, ahead of Nano Banana 2 on editing), and MAI-Code-1-Flash (51% SWE-Bench Pro at just 5B params). Every number is vendor-claimed from a launch post — treat them as marketing until independent benchmarks land. The real story isn't any single score; it's Microsoft owning the full stack from chip to model to Frontier Tuning."
+---
+
+# Microsoft's 7 MAI Models: The In-House Frontier Bet
+
+**TL;DR**: On June 2, 2026, Mustafa Suleyman (CEO, Microsoft AI) announced **seven new MAI models** — Microsoft's first fully self-built frontier family, trained and served on Microsoft's own **MAIA** silicon. The lineup: **MAI-Image-2.5** and **MAI-Image-2.5 Flash**, **MAI-Transcribe-1.5**, **MAI-Thinking-1**, **MAI-Voice-2** and **MAI-Voice-2 Flash**, and **MAI-Code-1-Flash**. The flagship reasoning model, MAI-Thinking-1, is a 35B-active-parameter mixture-of-experts with a 256K context window. Microsoft claims human raters on Surge prefer it over Claude Sonnet 4.6 in blind comparisons, that it scores 97% on AIME 2025, and 53% on SWE-Bench Pro. Every figure here is **vendor-claimed from a launch announcement** — not independently reproduced. The strategic signal matters more than any single benchmark: Microsoft now owns the full stack, chip to model to customization layer.
+
+---
+
+## What did Microsoft actually announce?
+
+Seven models, launched together, spanning text, image, voice, transcription, and code. Here's the lineup as described in the announcement:
+
+| Model | Type | What Microsoft claims |
+|-------|------|-----------------------|
+| **MAI-Thinking-1** | Text reasoning foundation | 35B-active MoE, 256K context; preferred over Sonnet 4.6 by human raters (blind); 97% AIME 2025; 53% SWE-Bench Pro |
+| **MAI-Image-2.5** | Image generation/editing | #2 on image leaderboards; surpasses Nano Banana 2 on editing |
+| **MAI-Image-2.5 Flash** | Fast image gen | Flash-tier latency/cost variant of Image-2.5 |
+| **MAI-Voice-2** | Speech synthesis | Next-gen voice model |
+| **MAI-Voice-2 Flash** | Fast speech | Flash-tier voice variant |
+| **MAI-Transcribe-1.5** | Speech-to-text | Transcription model |
+| **MAI-Code-1-Flash** | Coding | 5B params; 51% SWE-Bench Pro; tuned for VS Code + GitHub Copilot CLI |
+
+The framing from Suleyman: a new era of AI "designed to keep you in control and on the frontier," explicitly tied to Microsoft's stated pursuit of *humanist superintelligence*.
+
+---
+
+## Why does this matter more than the benchmark numbers?
+
+For years, Microsoft's frontier AI story ran through OpenAI. This launch is the clearest evidence yet that Microsoft AI is building a parallel, fully in-house stack — and not just the models. Three layers are now Microsoft-owned:
+
+1. **Silicon.** MAI-Thinking-1 was co-designed with Microsoft's **MAIA 200** chip. Microsoft claims a ~30% better performance-per-dollar and a 1.4x performance-per-watt gain running MAI models on MAIA 200 end-to-end, benchmarked head-to-head against NVIDIA's GB200. If even directionally true, owning the chip is what makes the economics of the Flash-tier models (Image, Voice, Code) viable at scale.
+
+2. **Models.** Seven of them, across every major modality, shipped on one day. That cadence only works when you control your own training infrastructure.
+
+3. **Customization — "Frontier Tuning."** This is the part most builders skipped over. Microsoft is letting customers tune MAI models into custom, company-specific agents — "your model, your data, your agents, your moat," in Suleyman's words. The cited proof point: a McKinsey-tuned model that delivered the highest win rate on McKinsey's tasks, claimed to outperform GPT-5.5 on quality while running ~10x cheaper. Microsoft also announced a collaboration with **Mayo Clinic** to jointly train a healthcare frontier model.
+
+The pattern is the same one Anthropic, Google, and OpenAI are racing toward: vertical integration from chip to deployed agent. Microsoft just made its move public and concrete.
+
+---
+
+## How good is MAI-Thinking-1, really?
+
+Here's where I separate the claim from the evidence, because the editorial standard here is that every number gets a source — and these numbers have exactly one: Microsoft's own launch.
+
+**The claims:**
+- 35B active parameters, MoE architecture, 256K context window.
+- Independent human raters on Surge prefer it over **Claude Sonnet 4.6** for overall quality in blind side-by-side comparisons.
+- 97% on **AIME 2025** (competition math).
+- 53% on **SWE-Bench Pro**, which Microsoft positions "alongside Opus 4.6" on one of the hardest coding benchmarks.
+
+**How I read it:** A 35B-active MoE landing near the top of frontier coding and math benchmarks would be genuinely impressive — that's a small active footprint for that class of result, and it's consistent with the MAIA-200 efficiency story. But two cautions. First, "human raters prefer it over Sonnet 4.6" is a preference signal on a specific eval set, not a capability ceiling — preference studies are notoriously sensitive to prompt mix and judging rubric. Second, none of this is reproduced yet. We've seen vendor launch numbers compress hard once [LMArena](https://lmarena.ai/), [ARC Prize](https://arcprize.org/), and [Artificial Analysis](https://artificialanalysis.ai/) get their hands on a model. Until then, MAI-Thinking-1 sits in my "promising, unverified" bucket — the same bucket I put vendor-launch Gemini numbers in.
+
+---
+
+## What about the image and code models?
+
+**MAI-Image-2.5** is the one with the most checkable claim: Microsoft says it and its Flash variant sit at **#2 on image leaderboards**, surpassing Google's **Nano Banana 2** on image editing specifically. Image leaderboards (the LMArena image arena, in particular) update fast and are crowd-judged, so this is the claim most likely to be confirmed or debunked within weeks. If it holds, the Flash variant is the interesting one — competitive editing quality at Flash-tier cost is exactly what high-volume creative pipelines need.
+
+**MAI-Code-1-Flash** is the efficiency play. 51% on SWE-Bench Pro at **5B parameters** puts it in Haiku-class size territory but, per Microsoft, cheaper — and it's explicitly tuned for **VS Code** and the **GitHub Copilot CLI**, which is the obvious distribution channel. A small, cheap, IDE-native coding model is a different product than a frontier reasoning model: it's the one you run on every keystroke, not the one you call for architecture. That's a smart lane to own given Microsoft already controls the editor.
+
+---
+
+## What's verifiable today vs. what to wait on
+
+| Claim | Status |
+|-------|--------|
+| 7 models exist, across these modalities | **Verifiable** (announced) |
+| Tuned for VS Code / Copilot CLI | **Verifiable** (Microsoft's own surfaces) |
+| Mayo Clinic + McKinsey collaborations | **Stated** (vendor, not yet detailed) |
+| MAI-Thinking-1 beats Sonnet 4.6 (human pref) | **Vendor-claimed** — single eval, unreproduced |
+| 97% AIME 2025 / 53% SWE-Bench Pro | **Vendor-claimed** — await independent runs |
+| MAI-Image-2.5 > Nano Banana 2 on editing | **Vendor-claimed** — leaderboards will confirm fast |
+| MAIA 200: 30% perf/$, 1.4x perf/watt vs GB200 | **Vendor-claimed** — no third-party silicon data |
+
+If you're making procurement or architecture decisions, treat the bottom five rows as marketing until the independent benchmarks land.
+
+---
+
+## What should builders and creators do now?
+
+- **Don't rip out your stack.** Nothing here displaces a working Claude/GPT/Gemini routing setup today. These are new options, not proven replacements.
+- **Watch the image arena first.** MAI-Image-2.5's leaderboard claim is the fastest to verify. If it holds, the Flash variant is worth piloting for bulk creative work.
+- **If you live in VS Code, pilot MAI-Code-1-Flash** when it's available — it's free to evaluate the efficiency claim on your own repo, and SWE-Bench Pro numbers don't tell you how it feels on *your* code.
+- **Frontier Tuning is the enterprise story.** If you're building company-specific agents, a tunable model on Microsoft's silicon-and-cloud bundle changes the cost math. That's the part to evaluate seriously, separate from any single benchmark.
+- **Re-check in 30 days.** This is a launch-day read. I'll update this post once independent benchmarks exist.
+
+For the broader competitive picture, see the [frontier model landscape for 2026](/blog/frontier-model-landscape-2026-claude-gpt-gemini-deepseek), the [Claude Opus 4.6 deep analysis](/blog/claude-opus-4-6-analysis-2026), and the live [Frontier Models Intelligence Hub](/ai-ops/models-2026). For routing and pricing across every provider, the [LLM Hub](/llm-hub) tracks them side by side.
+
+---
+
+## FAQ
+
+**What are Microsoft's MAI models?**
+MAI (Microsoft AI) models are Microsoft's in-house frontier model family. The June 2026 launch introduced seven: MAI-Thinking-1 (text reasoning), MAI-Image-2.5 and Image-2.5 Flash (image), MAI-Voice-2 and Voice-2 Flash (speech), MAI-Transcribe-1.5 (speech-to-text), and MAI-Code-1-Flash (coding).
+
+**Is MAI-Thinking-1 better than Claude or GPT?**
+Microsoft claims human raters prefer it over Claude Sonnet 4.6 in blind comparisons, with 97% on AIME 2025 and 53% on SWE-Bench Pro. These are vendor-claimed numbers from the launch, not independently reproduced. Wait for third-party benchmarks (LMArena, ARC Prize, Artificial Analysis) before treating it as a Claude or GPT replacement.
+
+**What is MAIA 200?**
+MAIA 200 is Microsoft's in-house AI accelerator chip. MAI-Thinking-1 was co-designed for it; Microsoft claims ~30% better performance-per-dollar and 1.4x performance-per-watt versus NVIDIA's GB200 when running MAI models end-to-end. No independent silicon benchmarks exist yet.
+
+**What is Microsoft Frontier Tuning?**
+Frontier Tuning lets customers fine-tune MAI models into custom, company-specific agents on their own data. Microsoft cites a McKinsey-tuned model that beat GPT-5.5 on quality at roughly 10x lower cost, and a Mayo Clinic collaboration to train a healthcare frontier model.
+
+**How is MAI-Code-1-Flash different from a frontier coding model?**
+It's a small (5B-parameter), inference-efficient coding model tuned for VS Code and the GitHub Copilot CLI — designed for high-frequency, low-latency in-editor use rather than complex multi-file architecture. Microsoft claims 51% on SWE-Bench Pro, strong for its size.
+
+**Where can I track these models against competitors?**
+The [FrankX Frontier Models Intelligence Hub](/ai-ops/models-2026) and [LLM Hub](/llm-hub) track frontier models side by side on benchmarks, context windows, and pricing as independent data becomes available.

--- a/data/model-registry.json
+++ b/data/model-registry.json
@@ -1,7 +1,7 @@
 {
   "_description": "FrankX Frontier Model Registry - Single source of truth for all AI model data",
   "_version": "1.0.0",
-  "_updated": "2026-02-06",
+  "_updated": "2026-06-03",
   "_maintainer": "FrankX Intelligence Pipeline (/new-model command)",
 
   "models": {
@@ -198,6 +198,72 @@
       "context_window": 1000000,
       "modalities": ["text", "vision"],
       "sources": []
+    },
+    "mai-thinking-1": {
+      "name": "MAI-Thinking-1",
+      "id": "mai-thinking-1",
+      "organization": "microsoft",
+      "family": "mai",
+      "released": "2026-06-02",
+      "status": "preview",
+      "architecture": "moe",
+      "parameters": "35B active",
+      "context_window": 256000,
+      "modalities": ["text", "code"],
+      "benchmarks": {
+        "aime_2025": 97,
+        "swe_bench_pro": 53,
+        "human_pref_vs_sonnet_4_6": "preferred (blind, Surge raters)"
+      },
+      "key_capabilities": [
+        "Text reasoning foundation model",
+        "35B-active mixture-of-experts",
+        "256K context window",
+        "Co-designed for Microsoft MAIA 200 silicon",
+        "Microsoft Frontier Tuning (custom company-specific agents)"
+      ],
+      "frankx_notes": "Vendor-claimed at launch (June 2, 2026) and not yet independently reproduced. Microsoft claims human-rater preference over Claude Sonnet 4.6 and SWE-Bench Pro alongside Opus 4.6. Treat benchmarks as marketing until LMArena/ARC/Artificial Analysis confirm.",
+      "sources": ["https://www.linkedin.com/in/mustafa-suleyman"]
+    },
+    "mai-image-2-5": {
+      "name": "MAI-Image-2.5",
+      "id": "mai-image-2-5",
+      "organization": "microsoft",
+      "family": "mai",
+      "released": "2026-06-02",
+      "status": "preview",
+      "modalities": ["image"],
+      "benchmarks": {
+        "image_leaderboard_rank": 2,
+        "image_editing": "claimed > Nano Banana 2"
+      },
+      "key_capabilities": [
+        "Image generation and editing",
+        "Flash variant for low-latency / lower-cost generation",
+        "Claimed #2 on image leaderboards at launch"
+      ],
+      "frankx_notes": "Vendor-claimed. The leaderboard claim is the fastest to verify via the LMArena image arena. Ships with a Flash variant for high-volume creative pipelines.",
+      "sources": ["https://www.linkedin.com/in/mustafa-suleyman"]
+    },
+    "mai-code-1-flash": {
+      "name": "MAI-Code-1-Flash",
+      "id": "mai-code-1-flash",
+      "organization": "microsoft",
+      "family": "mai",
+      "released": "2026-06-02",
+      "status": "preview",
+      "parameters": "5B",
+      "modalities": ["text", "code"],
+      "benchmarks": {
+        "swe_bench_pro": 51
+      },
+      "key_capabilities": [
+        "Inference-efficient coding model (~5B params, Haiku-class size)",
+        "Tuned for VS Code and GitHub Copilot CLI",
+        "In-editor, high-frequency / low-latency use"
+      ],
+      "frankx_notes": "Vendor-claimed 51% SWE-Bench Pro at 5B params. The efficiency/IDE-native lane, not a frontier reasoning model. Pilot it on your own repo once available.",
+      "sources": ["https://www.linkedin.com/in/mustafa-suleyman"]
     }
   },
 
@@ -226,6 +292,11 @@
       "name": "Meta AI",
       "url": "https://ai.meta.com",
       "models": ["llama-4-maverick"]
+    },
+    "microsoft": {
+      "name": "Microsoft AI",
+      "url": "https://microsoft.ai",
+      "models": ["mai-thinking-1", "mai-image-2-5", "mai-code-1-flash"]
     }
   },
 
@@ -236,5 +307,5 @@
     "haiku": "claude-haiku-4-5"
   },
 
-  "last_updated": "2026-02-06"
+  "last_updated": "2026-06-03"
 }

--- a/lib/llm-hub/editorial.ts
+++ b/lib/llm-hub/editorial.ts
@@ -52,6 +52,28 @@ export const MODEL_EDITORIAL: Record<string, ModelEditorial> = {
     bestFor: ['High-throughput video gen', 'Cost-sensitive creative pipelines'],
     creatorUse: 'Bulk short-form video generation where speed and cost beat cinematic fidelity.',
   },
+  'mai-thinking-1': {
+    tagline: 'Microsoft’s in-house reasoning flagship — frontier ambitions on MAIA silicon.',
+    bestFor: [
+      'Watching Microsoft’s full-stack frontier play (chip + model + tuning)',
+      'Math/reasoning workloads (vendor-claimed 97% AIME 2025)',
+      'Frontier Tuning into custom company-specific agents',
+    ],
+    watchOut: 'Vendor-claimed at launch — human-rater preference over Sonnet 4.6 and SWE-Bench Pro figures are unreproduced. Await LMArena/ARC/Artificial Analysis before trusting in production.',
+    creatorUse: 'One to track, not yet to standardize on. Re-evaluate once independent benchmarks land.',
+  },
+  'mai-image-2-5': {
+    tagline: 'Microsoft’s image model — claimed #2 leaderboard, ahead of Nano Banana 2 on editing.',
+    bestFor: ['Image generation and editing pipelines', 'High-volume creative work via the Flash variant'],
+    watchOut: 'Leaderboard claim is vendor-stated; the LMArena image arena will confirm or debunk it fast.',
+    creatorUse: 'The Flash variant is the interesting one for bulk image-editing loops once it’s live.',
+  },
+  'mai-code-1-flash': {
+    tagline: 'Tiny (5B), IDE-native coding model — the per-keystroke lane, not the architect.',
+    bestFor: ['In-editor completion in VS Code / GitHub Copilot CLI', 'High-frequency, low-latency coding assists'],
+    watchOut: 'Vendor-claimed 51% SWE-Bench Pro. Benchmark size ≠ how it feels on your repo — pilot before adopting.',
+    creatorUse: 'Cheap, fast in-editor help; route real architecture work to a frontier model.',
+  },
   'claude-opus-4-6': {
     tagline: 'The reasoning + long-context flagship. THE model for high-stakes synthesis.',
     bestFor: [

--- a/public/images/blog/microsoft-mai-models-2026-hero.svg
+++ b/public/images/blog/microsoft-mai-models-2026-hero.svg
@@ -1,0 +1,82 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0078D4" stop-opacity="0.30" />
+      <stop offset="0.5" stop-color="#50E6FF" stop-opacity="0.16" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.22" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#0078D4" stop-opacity="0.45" />
+      <stop offset="1" stop-color="#0078D4" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accentA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#50E6FF" /><stop offset="1" stop-color="#0078D4" />
+    </linearGradient>
+    <linearGradient id="accentB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#A78BFA" /><stop offset="1" stop-color="#6D28D9" />
+    </linearGradient>
+    <linearGradient id="accentC" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FDBA74" /><stop offset="1" stop-color="#F97316" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <!-- Title block -->
+  <rect x="190" y="160" width="150" height="34" rx="17" fill="#0078D4" fill-opacity="0.18" stroke="#0078D4" stroke-opacity="0.5" />
+  <text x="265" y="183" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="17" font-weight="600" letter-spacing="2" fill="#7FD3FF" text-anchor="middle">MICROSOFT AI</text>
+  <text x="190" y="270" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="74" font-weight="800" fill="#FFFFFF">7 New MAI Models</text>
+  <text x="190" y="328" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="30" font-weight="400" fill="#9FB3D1">Microsoft&#8217;s first fully in-house frontier family &#8212; on MAIA silicon</text>
+
+  <!-- Model tiles: row 1 -->
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <!-- Thinking-1 (hero tile) -->
+    <rect x="190" y="400" width="300" height="160" rx="22" fill="url(#tile)" stroke="#2A6FB0" stroke-opacity="0.7" />
+    <circle cx="232" cy="442" r="14" fill="url(#accentB)" />
+    <text x="262" y="448" font-size="22" font-weight="700" fill="#FFFFFF">MAI-Thinking-1</text>
+    <text x="214" y="492" font-size="16" fill="#8FA6C4">35B-active MoE &#183; 256K ctx</text>
+    <text x="214" y="522" font-size="15" fill="#6F86A6">Text reasoning foundation</text>
+
+    <rect x="510" y="400" width="300" height="160" rx="22" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <circle cx="552" cy="442" r="14" fill="url(#accentA)" />
+    <text x="582" y="448" font-size="22" font-weight="700" fill="#FFFFFF">MAI-Image-2.5</text>
+    <text x="534" y="492" font-size="16" fill="#8FA6C4">+ Flash variant</text>
+    <text x="534" y="522" font-size="15" fill="#6F86A6">Image gen &amp; editing</text>
+
+    <rect x="830" y="400" width="300" height="160" rx="22" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <circle cx="872" cy="442" r="14" fill="url(#accentC)" />
+    <text x="902" y="448" font-size="22" font-weight="700" fill="#FFFFFF">MAI-Code-1-Flash</text>
+    <text x="854" y="492" font-size="16" fill="#8FA6C4">5B params &#183; VS Code</text>
+    <text x="854" y="522" font-size="15" fill="#6F86A6">Inference-efficient coding</text>
+
+    <rect x="1150" y="400" width="240" height="160" rx="22" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <circle cx="1192" cy="442" r="14" fill="url(#accentA)" />
+    <text x="1222" y="448" font-size="22" font-weight="700" fill="#FFFFFF">MAI-Voice-2</text>
+    <text x="1174" y="492" font-size="16" fill="#8FA6C4">+ Flash variant</text>
+    <text x="1174" y="522" font-size="15" fill="#6F86A6">Speech</text>
+
+    <!-- Row 2 -->
+    <rect x="190" y="592" width="460" height="118" rx="22" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <circle cx="232" cy="634" r="14" fill="url(#accentB)" />
+    <text x="262" y="640" font-size="22" font-weight="700" fill="#FFFFFF">MAI-Transcribe-1.5</text>
+    <text x="214" y="682" font-size="15" fill="#6F86A6">Speech-to-text transcription</text>
+
+    <rect x="670" y="592" width="720" height="118" rx="22" fill="#0A1326" stroke="#2A6FB0" stroke-opacity="0.45" />
+    <text x="700" y="636" font-size="19" font-weight="600" fill="#7FD3FF">Microsoft Frontier Tuning</text>
+    <text x="700" y="676" font-size="16" fill="#8FA6C4">Custom, company-specific agents &#183; Mayo Clinic &#183; MAIA 200</text>
+  </g>
+
+  <text x="190" y="772" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="15" fill="#5C6F8E">FrankX &#183; Intelligence Dispatch &#183; Metrics vendor-claimed, pending independent reproduction</text>
+</svg>


### PR DESCRIPTION
## What

Coverage for Microsoft AI's June 2, 2026 announcement of **7 in-house MAI models** (from the LinkedIn screenshots provided), spanning a new blog article and additions to the model arena.

### Article
- `content/blog/microsoft-mai-frontier-models-2026.mdx` — Intelligence Dispatch on the 7 MAI models (Thinking-1, Image-2.5/Flash, Voice-2/Flash, Transcribe-1.5, Code-1-Flash), Frontier Tuning, MAIA 200 silicon, Mayo Clinic/McKinsey.
  - **Every metric is framed as vendor-claimed / pending independent reproduction**, with an explicit "verifiable vs. wait on" table — per `EDITORIAL_STANDARD.md`.
  - TL;DR in first 100 words, question-based H2s, 6-question FAQ, `schema: ["Article","FAQPage"]`, 4 internal links.
- `public/images/blog/microsoft-mai-models-2026-hero.svg` — original on-brand hero in the repo's existing SVG style.

### Model arena
- `data/model-registry.json` — new **Microsoft AI** organization + `mai-thinking-1`, `mai-image-2-5`, `mai-code-1-flash` entries (`status: preview`, vendor-claimed benchmarks, `frankx_notes` hedging). `_updated`/`last_updated` bumped to 2026-06-03.
- `lib/llm-hub/editorial.ts` — `/llm-hub` editorial verdicts for the 3 headline models.
- `app/ai-ops/models-2026/page.tsx` — new MAI-Thinking-1 card, June 2026 date refresh, MAI article CTA, and a `Preview` price label so non-priced preview models no longer render as "Open".

## Imagery note
"Pulling images from the web" isn't possible here: this environment's network allowlist firewalls every Microsoft image CDN (`cdn-dynmedia-1.microsoft.com`, `news.microsoft.com`, the Akamai host all return `host_not_allowed`), and only a font glyph is reachable on `www.microsoft.com`. Microsoft's event imagery is also copyrighted. So the committed hero is original SVG art, and no third-party screenshots are included.

## Verification
- `tsc --noEmit` — **0 errors**
- `eslint` on touched files — **clean**
- `node -e "require('./data/model-registry.json')"` — valid JSON, all org→model refs resolve (11 models / 6 orgs)
- `prebuild-cache` + `build-route-index` succeed; new blog slug present in the route index
- Article frontmatter parses (gray-matter); hero SVG resolves on disk

> Full `npm run build` can't complete in this environment for unrelated reasons (the `sync-ais` prebuild needs an external repo that isn't cloned here, and `next/font` can't reach Google Fonts through the allowlist). Neither is related to these changes.

## Note on claims
All MAI numbers originate from a single launch post. The article and registry label them as vendor-claimed and flag that independent benchmarks (LMArena / ARC Prize / Artificial Analysis) don't yet exist.

https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three Microsoft MAI models to the platform: MAI-Thinking-1, MAI-Image-2-5, and MAI-Code-1-Flash
  * Updated pricing display to distinguish preview models

* **Documentation**
  * Published blog post introducing Microsoft's 7 MAI Models and frontier model analysis
  * Updated Frontier Models section metadata to June 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->