### PR TITLE
fix(seo): kill global 'appendChild Invalid token' JS error (JSON-LD via plain script)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -156,10 +156,13 @@ export default function RootLayout({
         <link rel="alternate" hrefLang="en" href="https://frankx.ai" />
         <link rel="alternate" hrefLang="x-default" href="https://frankx.ai" />
         {aisSchemaGraph && (
-          <Script
+          // Plain <script>, NOT next/script: next/script client-re-injects
+          // inline content (throwing "appendChild: Invalid or unexpected token"
+          // on every page) and JSON-LD must be in the static SSR HTML for
+          // crawlers/AI agents anyway. Matches components/seo/JsonLd.tsx.
+          <script
             id="ais-schema-graph"
             type="application/ld+json"
-            strategy="beforeInteractive"
             dangerouslySetInnerHTML={{ __html: JSON.stringify(aisSchemaGraph) }}
           />
         )}


### PR DESCRIPTION
## Problem
Every page throws a JS pageerror: `Failed to execute 'appendChild' on 'Node': Invalid or unexpected token` — verified in headless Chrome on /, /ai-architecture, /connect.

## Cause
Root layout injected the global `ais-schema-graph` JSON-LD via **next/script** (`<Script beforeInteractive dangerouslySetInnerHTML>`). next/script client-re-injects inline content, which trips the appendChild token error. The team already documented (in `components/seo/JsonLd.tsx`) that JSON-LD must use a **plain `<script>`**, not next/script — this was the lone outlier.

## Fix
Plain `<script type="application/ld+json">` matching JsonLd.tsx. JSON-LD stays in static SSR HTML (good for crawlers/AI agents); the global JS error goes away.

## Verify
- [ ] CI green
- [ ] Post-deploy: headless Chrome on / shows 0 pageerrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized how structured data metadata is rendered in page templates to improve static HTML generation consistency and delivery reliability for search engines and automated systems. The implementation change maintains all existing functionality without impact to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->