### PR TITLE
June 2026 frontier model refresh — Phase 1 (Western flagships)

### DIFF
--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -7,90 +7,112 @@ import { ArrowLeft, Globe, ExternalLink, TrendingUp, DollarSign, Cpu, Zap, Crown
 
 const frontierModels = [
   {
-    name: 'Claude Opus 4.6',
+    name: 'Claude Opus 4.8',
     org: 'Anthropic',
-    released: 'Feb 5, 2026',
-    context: '1M (beta)',
+    released: 'May 28, 2026',
+    context: '1M',
     output: '128K',
     pricing: { input: 5.0, output: 25.0 },
-    achievement: '#1 ARC-AGI-2 (68.8%), #1 Terminal-Bench (65.4%)',
-    benchmarks: { arcAgi2: 68.8, termBench: 65.4, osworld: 72.7 },
-    tags: ['reasoning', 'coding', 'agentic', 'adaptive-thinking'],
+    achievement: 'Tops the intelligence index — SWE-Bench Pro 69.2%, GDPval-AA 1890',
+    benchmarks: { sweBenchPro: 69.2, gdpvalAA: 1890, osworld: 83.4 },
+    tags: ['reasoning', 'coding', 'agentic'],
     color: '#a855f7',
     highlight: true,
     links: {
-      announcement: 'https://www.anthropic.com/news/claude-opus-4-6',
-      docs: 'https://docs.anthropic.com/en/docs/about-claude/models',
+      announcement: 'https://www.anthropic.com/news/claude-opus-4-8',
+      docs: 'https://platform.claude.com/docs/en/about-claude/models',
     },
-    notes: 'New flagship. Adaptive thinking replaces budget_tokens. 67% price cut from Opus 4.5.',
+    notes: 'Same $5/$25 pricing as 4.7, no breaking changes — a model-string-swap upgrade. Real news: Claude Code dynamic workflows (up to 1,000 subagents) and a 3x-cheaper fast mode.',
   },
   {
-    name: 'GPT-5.2 Pro',
+    name: 'GPT-5.5',
     org: 'OpenAI',
-    released: 'Jan 2026',
-    context: '196K',
-    output: '64K',
-    pricing: { input: 10.0, output: 30.0 },
-    achievement: 'First 90% ARC-AGI-1, multimodal w/ audio',
-    benchmarks: { arcAgi2: 54.2 },
-    tags: ['reasoning', 'multimodal', 'audio'],
+    released: 'Apr 23, 2026',
+    context: '1M*',
+    output: '128K',
+    pricing: { input: 5.0, output: 30.0 },
+    achievement: '84.9% GDPval, 78.7% OSWorld, 98% Tau2 Telecom',
+    benchmarks: { gdpval: 84.9, osworld: 78.7, gdpvalAA: 1769 },
+    tags: ['reasoning', 'multimodal', 'agentic'],
     color: '#10b981',
     highlight: false,
     links: {
-      docs: 'https://platform.openai.com/docs/models',
+      announcement: 'https://openai.com/index/introducing-gpt-5-5/',
+      docs: 'https://developers.openai.com/api/docs/models/gpt-5.5',
     },
-    notes: 'Native audio modality. Strong general-purpose performance.',
+    notes: 'Codename “Spud”. Drop-in replacement for GPT-5.4. Leads terminal-agent tasks; trails Opus 4.8 on GDPval-AA and SWE-Bench Pro. Price doubled vs 5.4. *1M published, ~258K effective reported in Codex.',
   },
   {
-    name: 'Gemini 3 Pro',
+    name: 'Gemini 3.5 Flash',
     org: 'Google DeepMind',
-    released: 'Dec 2025',
-    context: '2M',
+    released: 'May 19, 2026',
+    context: '1M',
     output: '64K',
-    pricing: { input: 7.0, output: 21.0 },
-    achievement: 'Best multimodal (81% MMMU-Pro), 2M context',
-    benchmarks: { arcAgi2: 45.1, mmmuPro: 81.0 },
-    tags: ['multimodal', 'reasoning', 'vision', 'video', 'audio'],
+    pricing: { input: 1.5, output: 9.0 },
+    achievement: 'Frontier agentic coding at Flash economics — Terminal-Bench 2.1 76.2%, MCP Atlas 83.6%',
+    benchmarks: { terminalBench: 76.2, mcpAtlas: 83.6, gdpvalAA: 1656 },
+    tags: ['agentic', 'coding', 'multimodal', 'budget'],
     color: '#3b82f6',
     highlight: false,
     links: {
-      docs: 'https://ai.google.dev/gemini-api/docs',
+      announcement: 'https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/',
+      docs: 'https://deepmind.google/models/model-cards/gemini-3-5-flash/',
     },
-    notes: 'Widest modality support: text, vision, audio, video. 2M native context.',
+    notes: 'The model Google actually shipped at the 3.5 line. Beats the prior Gemini 3.1 Pro tier on agentic coding — the new default agent runtime.',
   },
   {
-    name: 'Grok 4.1',
+    name: 'Grok 4.3',
     org: 'xAI',
-    released: 'Nov 2025',
-    context: '2M',
-    output: '64K',
-    pricing: { input: 3.0, output: 15.0 },
-    achievement: '#1 LMArena (1483 Elo), 2M context',
-    benchmarks: { lmarenaElo: 1483 },
-    tags: ['reasoning', 'agentic', 'long-context'],
+    released: 'Apr 30, 2026',
+    context: '1M',
+    output: 'No fixed cap',
+    pricing: { input: 1.25, output: 2.5 },
+    achievement: 'Budget frontier — AA Intelligence 53, GDPval-AA 1500, ~181 tok/s output',
+    benchmarks: { aaIntelligence: 53, gdpvalAA: 1500 },
+    tags: ['reasoning', 'agentic', 'long-context', 'budget'],
     color: '#ef4444',
     highlight: false,
     links: {
-      docs: 'https://docs.x.ai/',
+      announcement: 'https://artificialanalysis.ai/articles/xai-launches-grok-4-3-with-improved-agentic-performance-and-lower-pricing',
+      docs: 'https://docs.x.ai/developers/models/grok-4.3',
     },
-    notes: 'Top LMArena Elo. Competitive pricing with long context.',
+    notes: 'Fourth-best frontier intelligence at roughly the cheapest frontier price, with the fastest output in its tier. Context dropped 2M → 1M; reasoning is always-on.',
   },
   {
-    name: 'Claude Opus 4.5',
+    name: 'Claude Sonnet 4.6',
     org: 'Anthropic',
-    released: 'Nov 2025',
-    context: '200K',
+    released: 'Feb 17, 2026',
+    context: '1M (beta)',
     output: '64K',
-    pricing: { input: 5.0, output: 25.0 },
-    achievement: 'Best coding at launch (80.9% SWE-bench)',
-    benchmarks: { arcAgi2: 37.6, termBench: 59.8, osworld: 66.3 },
-    tags: ['coding', 'reasoning', 'agentic'],
-    color: '#a855f7',
+    pricing: { input: 3.0, output: 15.0 },
+    achievement: 'Approaches Opus 4.6 capability at ~40% lower cost',
+    benchmarks: {},
+    tags: ['coding', 'content', 'workhorse'],
+    color: '#8b5cf6',
     highlight: false,
     links: {
-      docs: 'https://docs.anthropic.com/en/docs/about-claude/models',
+      announcement: 'https://www.anthropic.com/news/claude-sonnet-4-6',
+      docs: 'https://platform.claude.com/docs/en/about-claude/models',
     },
-    notes: 'Previous flagship. Still available, superseded by Opus 4.6.',
+    notes: 'The mid-tier that started eating the flagship’s lunch. The right default for production coding and content — route to Opus 4.8 only when the task earns it.',
+  },
+  {
+    name: 'Gemini 3.5 Pro',
+    org: 'Google DeepMind',
+    released: 'Preview',
+    context: '2M*',
+    output: '—',
+    pricing: { input: 0, output: 0 },
+    achievement: 'Announced at I/O as Google’s strongest agentic + coding model — benchmarks pending GA',
+    benchmarks: {},
+    tags: ['preview', 'multimodal', 'reasoning'],
+    color: '#3b82f6',
+    highlight: false,
+    links: {
+      announcement: 'https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/',
+      docs: 'https://deepmind.google/models/gemini/',
+    },
+    notes: 'Not GA as of June 5, 2026 — limited Vertex preview, no published benchmarks or pricing. GA targeted for June. *2M context is a vendor target. Don’t architect on it until GA.',
   },
   {
     name: 'Llama 4 Maverick',
@@ -99,7 +121,7 @@ const frontierModels = [
     context: '1M',
     output: '32K',
     pricing: { input: 0, output: 0 },
-    achievement: 'Open-weight MoE (400B/17B active)',
+    achievement: 'Open-weight MoE (400B total / 17B active)',
     benchmarks: {},
     tags: ['open-source', 'agentic', 'MoE'],
     color: '#f59e0b',
@@ -107,24 +129,7 @@ const frontierModels = [
     links: {
       docs: 'https://llama.meta.com/',
     },
-    notes: 'Open-weight. 400B total, 17B active per token. Runs on single H100.',
-  },
-  {
-    name: 'DeepSeek R1',
-    org: 'DeepSeek',
-    released: 'Jan 2025',
-    context: '128K',
-    output: '32K',
-    pricing: { input: 0.55, output: 2.19 },
-    achievement: 'Open-source reasoning champion, MIT license',
-    benchmarks: {},
-    tags: ['reasoning', 'open-source', 'budget'],
-    color: '#06b6d4',
-    highlight: false,
-    links: {
-      docs: 'https://platform.deepseek.com/docs',
-    },
-    notes: 'Most cost-effective reasoning model. Open-source under MIT license.',
+    notes: 'Open-weight. 400B total, 17B active per token. Runs on a single H100. Self-host / fine-tune base.',
   },
   {
     name: 'MAI-Thinking-1',
@@ -145,13 +150,16 @@ const frontierModels = [
   },
 ]
 
+// Cross-model scores where independent data is published. Elo metrics carry no
+// "%"; cells are left blank rather than mixing benchmark versions or recycling
+// older-model numbers. unit '' renders the raw value.
 const benchmarkComparison = [
-  { benchmark: 'ARC-AGI-2', description: 'Abstract reasoning', models: { 'Opus 4.6': 68.8, 'GPT-5.2 Pro': 54.2, 'Gemini 3 Pro': 45.1, 'Opus 4.5': 37.6 } },
-  { benchmark: 'Terminal-Bench 2.0', description: 'Agentic coding', models: { 'Opus 4.6': 65.4, 'Opus 4.5': 59.8 } },
-  { benchmark: 'OSWorld', description: 'Computer use', models: { 'Opus 4.6': 72.7, 'Opus 4.5': 66.3 } },
-  { benchmark: 'MMMU-Pro', description: 'Multimodal understanding', models: { 'Gemini 3 Pro': 81.0 } },
-  { benchmark: 'BigLaw Bench', description: 'Legal reasoning', models: { 'Opus 4.6': 90.2 } },
-  { benchmark: 'MRCR v2 (1M)', description: 'Long-context retrieval', models: { 'Opus 4.6': 76.0 } },
+  { benchmark: 'GDPval-AA', description: 'Economically valuable knowledge work (Elo)', unit: '', models: { 'Opus 4.8': 1890, 'GPT-5.5': 1769, 'Gemini 3.5 Flash': 1656, 'Grok 4.3': 1500 } },
+  { benchmark: 'SWE-Bench Pro', description: 'Hard, contamination-resistant coding', unit: '%', models: { 'Opus 4.8': 69.2, 'GPT-5.5': 58.6 } },
+  { benchmark: 'OSWorld', description: 'Computer use / GUI agents', unit: '%', models: { 'Opus 4.8': 83.4, 'GPT-5.5': 78.7 } },
+  { benchmark: 'Terminal-Bench 2.1', description: 'Agentic terminal / CLI workflows', unit: '%', models: { 'Opus 4.8': 74.6, 'Gemini 3.5 Flash': 76.2 } },
+  { benchmark: 'Tau2 Telecom', description: 'Complex customer-service workflows', unit: '%', models: { 'GPT-5.5': 98.0 } },
+  { benchmark: 'AA Intelligence Index', description: 'Composite of 10 evaluations', unit: '', models: { 'Opus 4.8': 61.4, 'Grok 4.3': 53 } },
 ]
 
 const externalResources = [
@@ -203,14 +211,14 @@ export default function Models2026Page() {
                 Data validated against official sources and independent benchmarks.
               </p>
               <div className="flex flex-wrap gap-3">
-                <Link href="/blog/microsoft-mai-frontier-models-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#0078d4]/10 border border-[#0078d4]/20 hover:border-[#0078d4]/40 text-[#4cc2ff] text-sm transition-colors">
-                  <Zap className="w-4 h-4" /> New: Microsoft&apos;s 7 MAI Models
+                <Link href="/blog/claude-opus-4-8-analysis-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#a855f7]/10 border border-[#a855f7]/20 hover:border-[#a855f7]/40 text-[#a855f7] text-sm transition-colors">
+                  <Crown className="w-4 h-4" /> New: Claude Opus 4.8 Deep Analysis
                 </Link>
-                <Link href="/blog/claude-opus-4-6-analysis-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#a855f7]/10 border border-[#a855f7]/20 hover:border-[#a855f7]/40 text-[#a855f7] text-sm transition-colors">
-                  <Crown className="w-4 h-4" /> Claude Opus 4.6 Deep Analysis
+                <Link href="/blog/gpt-5-5-analysis-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#10b981]/10 border border-[#10b981]/20 hover:border-[#10b981]/40 text-[#10b981] text-sm transition-colors">
+                  <Zap className="w-4 h-4" /> GPT-5.5 (&ldquo;Spud&rdquo;)
                 </Link>
-                <Link href="/research/agent-benchmarks" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 border border-white/10 hover:border-white/20 text-white/60 text-sm transition-colors">
-                  <TrendingUp className="w-4 h-4" /> Benchmark Methodology
+                <Link href="/blog/grok-4-3-analysis-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#ef4444]/10 border border-[#ef4444]/20 hover:border-[#ef4444]/40 text-[#ef4444] text-sm transition-colors">
+                  <TrendingUp className="w-4 h-4" /> Grok 4.3
                 </Link>
               </div>
             </motion.div>
@@ -294,28 +302,32 @@ export default function Models2026Page() {
                   <tr className="border-b border-white/10">
                     <th className="pb-4 pr-6 text-sm font-medium text-white/50">Benchmark</th>
                     <th className="pb-4 pr-6 text-sm font-medium text-white/50">What It Tests</th>
-                    <th className="pb-4 pr-4 text-sm font-medium text-[#a855f7]">Opus 4.6</th>
-                    <th className="pb-4 pr-4 text-sm font-medium text-white/50">GPT-5.2</th>
-                    <th className="pb-4 pr-4 text-sm font-medium text-white/50">Gemini 3</th>
-                    <th className="pb-4 text-sm font-medium text-white/50">Opus 4.5</th>
+                    <th className="pb-4 pr-4 text-sm font-medium text-[#a855f7]">Opus 4.8</th>
+                    <th className="pb-4 pr-4 text-sm font-medium text-white/50">GPT-5.5</th>
+                    <th className="pb-4 pr-4 text-sm font-medium text-white/50">Gemini 3.5 Flash</th>
+                    <th className="pb-4 text-sm font-medium text-white/50">Grok 4.3</th>
                   </tr>
                 </thead>
                 <tbody className="text-sm">
-                  {benchmarkComparison.map(b => (
-                    <tr key={b.benchmark} className="border-b border-white/5">
-                      <td className="py-3 pr-6 font-medium text-white">{b.benchmark}</td>
-                      <td className="py-3 pr-6 text-white/40">{b.description}</td>
-                      <td className="py-3 pr-4 font-mono text-[#a855f7] font-medium">{b.models['Opus 4.6'] ? `${b.models['Opus 4.6']}%` : '—'}</td>
-                      <td className="py-3 pr-4 font-mono text-white/40">{b.models['GPT-5.2 Pro'] ? `${b.models['GPT-5.2 Pro']}%` : '—'}</td>
-                      <td className="py-3 pr-4 font-mono text-white/40">{b.models['Gemini 3 Pro'] ? `${b.models['Gemini 3 Pro']}%` : '—'}</td>
-                      <td className="py-3 font-mono text-white/40">{b.models['Opus 4.5'] ? `${b.models['Opus 4.5']}%` : '—'}</td>
-                    </tr>
-                  ))}
+                  {benchmarkComparison.map(b => {
+                    const cell = (v?: number) => (v != null ? `${v}${b.unit}` : '—')
+                    const models = b.models as Record<string, number | undefined>
+                    return (
+                      <tr key={b.benchmark} className="border-b border-white/5">
+                        <td className="py-3 pr-6 font-medium text-white">{b.benchmark}</td>
+                        <td className="py-3 pr-6 text-white/40">{b.description}</td>
+                        <td className="py-3 pr-4 font-mono text-[#a855f7] font-medium">{cell(models['Opus 4.8'])}</td>
+                        <td className="py-3 pr-4 font-mono text-white/40">{cell(models['GPT-5.5'])}</td>
+                        <td className="py-3 pr-4 font-mono text-white/40">{cell(models['Gemini 3.5 Flash'])}</td>
+                        <td className="py-3 font-mono text-white/40">{cell(models['Grok 4.3'])}</td>
+                      </tr>
+                    )
+                  })}
                 </tbody>
               </table>
             </div>
             <p className="mt-4 text-xs text-white/20">
-              Sources: Official vendor announcements, ARC Prize Foundation, SWE-bench project. Last validated February 6, 2026.
+              GDPval-AA and AA Intelligence Index are Elo/index scores (no %); other rows are percentages. Blank cells mean no independently published score for that pairing — not a zero. Sources: Anthropic, OpenAI, Google, Artificial Analysis, llm-stats. Last validated June 5, 2026.
             </p>
           </div>
         </section>
@@ -347,13 +359,6 @@ export default function Models2026Page() {
                     </tr>
                   ))}
                   <tr className="border-b border-white/5">
-                    <td className="py-3 pr-6 font-medium text-white">Claude Sonnet 4.5</td>
-                    <td className="py-3 pr-6 font-mono text-white/60">$3.00</td>
-                    <td className="py-3 pr-6 font-mono text-white/60">$15.00</td>
-                    <td className="py-3 pr-6 font-mono text-white/40">200K</td>
-                    <td className="py-3 font-mono text-white/40">$0.09</td>
-                  </tr>
-                  <tr className="border-b border-white/5">
                     <td className="py-3 pr-6 font-medium text-white">Claude Haiku 4.5</td>
                     <td className="py-3 pr-6 font-mono text-white/60">$0.80</td>
                     <td className="py-3 pr-6 font-mono text-white/60">$4.00</td>
@@ -377,7 +382,7 @@ export default function Models2026Page() {
                   <Crown className="w-5 h-5 text-[#a855f7]" />
                   <h3 className="font-bold">Opus Tier</h3>
                 </div>
-                <p className="text-sm font-mono text-[#a855f7] mb-2">claude-opus-4-6</p>
+                <p className="text-sm font-mono text-[#a855f7] mb-2">claude-opus-4-8</p>
                 <p className="text-sm text-white/50 mb-3">Architecture reviews, research synthesis, complex debugging, multi-file code generation, long-context analysis</p>
                 <p className="text-xs text-white/30">$5.00 / $25.00 per 1M tokens</p>
               </div>
@@ -386,7 +391,7 @@ export default function Models2026Page() {
                   <Zap className="w-5 h-5 text-[#3b82f6]" />
                   <h3 className="font-bold">Sonnet Tier</h3>
                 </div>
-                <p className="text-sm font-mono text-[#3b82f6] mb-2">claude-sonnet-4-5</p>
+                <p className="text-sm font-mono text-[#3b82f6] mb-2">claude-sonnet-4-6</p>
                 <p className="text-sm text-white/50 mb-3">Standard coding, content generation, API integrations, moderate-complexity tasks, production workflows</p>
                 <p className="text-xs text-white/30">$3.00 / $15.00 per 1M tokens</p>
               </div>
@@ -499,10 +504,10 @@ export default function Models2026Page() {
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold mb-6">Related Research & Analysis</h2>
             <div className="grid md:grid-cols-3 gap-4">
-              <Link href="/blog/claude-opus-4-6-analysis-2026" className="group p-5 rounded-xl bg-white/[0.02] border border-white/5 hover:border-[#a855f7]/30 transition-colors">
+              <Link href="/blog/claude-opus-4-8-analysis-2026" className="group p-5 rounded-xl bg-white/[0.02] border border-white/5 hover:border-[#a855f7]/30 transition-colors">
                 <p className="text-xs text-[#a855f7] font-mono mb-2">Analysis</p>
-                <h3 className="font-medium text-sm mb-1 group-hover:text-[#a855f7] transition-colors">Claude Opus 4.6: What Actually Changed</h3>
-                <p className="text-xs text-white/40">Deep technical breakdown with migration guide</p>
+                <h3 className="font-medium text-sm mb-1 group-hover:text-[#a855f7] transition-colors">Claude Opus 4.8: Quietly Tops the Leaderboard</h3>
+                <p className="text-xs text-white/40">Verified benchmarks, what changed vs 4.7, builder impact</p>
               </Link>
               <Link href="/research/enterprise-ai" className="group p-5 rounded-xl bg-white/[0.02] border border-white/5 hover:border-[#10b981]/30 transition-colors">
                 <p className="text-xs text-[#10b981] font-mono mb-2">Research</p>
@@ -520,7 +525,7 @@ export default function Models2026Page() {
 
         <footer className="py-12 px-6 border-t border-white/5">
           <div className="max-w-6xl mx-auto text-center">
-            <p className="text-sm text-white/30">Research compiled by FrankX Intelligence Pipeline &bull; Last updated June 2, 2026</p>
+            <p className="text-sm text-white/30">Research compiled by FrankX Intelligence Pipeline &bull; Last updated June 5, 2026</p>
             <p className="text-xs text-white/15 mt-2">Data sourced from official vendor documentation, ARC Prize Foundation, Scale AI SEAL, LMArena, and Artificial Analysis</p>
           </div>
         </footer>

--- a/content/blog/claude-opus-4-8-analysis-2026.mdx
+++ b/content/blog/claude-opus-4-8-analysis-2026.mdx
@@ -1,0 +1,220 @@
+---
+title: "Claude Opus 4.8: A Modest Bump That Quietly Tops the Leaderboard"
+description: "Anthropic's Opus 4.8 lands 41 days after 4.7 with the same $5/$25 pricing, SWE-Bench Pro 69.2%, GDPval-AA 1890, dynamic workflows, and cheaper fast mode. Technical breakdown with verified benchmarks, what changed, and what it means for builders."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - anthropic
+  - claude
+  - frontier-models
+  - ai-2026
+  - benchmarks
+  - agentic-ai
+keywords:
+  - claude opus 4.8
+  - claude opus 4.8 review
+  - claude opus 4.8 benchmarks
+  - anthropic opus 4.8 pricing
+  - claude opus 4.8 vs gpt 5.5
+  - claude opus 4.8 dynamic workflows
+  - claude opus 4.8 context window
+  - swe-bench pro opus 4.8
+  - gdpval-aa 1890
+  - best ai model 2026
+image: "/images/blog/claude-opus-4-8-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Claude Opus 4.8: A Modest Bump That Quietly Tops the Leaderboard
+
+**TL;DR**: Anthropic released Claude Opus 4.8 (`claude-opus-4-8`) on May 28, 2026 — just 41 days after Opus 4.7. Pricing is unchanged at $5/$25 per million tokens, context stays at 1M (128K output). The benchmark gains are real but incremental: SWE-Bench Pro 69.2% (from 64.3%), GDPval-AA 1890 Elo (from 1753), USAMO 2026 up 27 points to 96.7%. The headline features are product-side — Claude Code "dynamic workflows" that orchestrate up to 1,000 subagents, an effort control on claude.ai, and a fast mode that's now 3x cheaper. Simon Willison called it "a modest but tangible improvement." That's accurate. Here's what actually matters for builders.
+
+---
+
+## What Is Opus 4.8?
+
+Opus 4.8 is Anthropic's new flagship, replacing Opus 4.7 at the top of the Claude lineup. The model ID is `claude-opus-4-8`. The cadence is the story before the benchmarks are: 4.7 shipped in mid-April, 4.8 arrived May 28. Forty-one days. Anthropic is now iterating on the frontier roughly monthly, and the version number is doing less and less work — this is a point release that happens to lead several leaderboards.
+
+Three things define this release:
+
+1. **It's a re-tune, not a re-architecture.** Anthropic's own framing is "sharper judgment, more honesty about its progress, and the ability to work independently for longer." The API surface is identical to 4.7 — same adaptive thinking, same effort levels, same removed sampling parameters. If your code runs on 4.7, it runs on 4.8 with a string swap.
+
+2. **The gains concentrate in agentic and knowledge work.** Coding, long-horizon autonomy, and the GDPval-AA economic-value benchmark move the most. Pure context-length and modality coverage are unchanged.
+
+3. **The product features are the real news.** Dynamic workflows and a cheaper, faster fast mode change what you can ship more than the benchmark deltas do.
+
+---
+
+## What Are the Verified Benchmarks?
+
+A note on sourcing, because it matters here. The numbers below come from Anthropic's official announcement, cross-referenced against [Artificial Analysis](https://artificialanalysis.ai/articles/claude-opus-4-8-analysis-and-benchmarks), [llm-stats](https://llm-stats.com/models/claude-opus-4-8), and independent coverage from [Vellum](https://www.vellum.ai/blog/claude-opus-4-8-benchmarks-explained) and [The New Stack](https://thenewstack.io/claude-opus-48-release/). Where a figure is vendor-reported and not yet independently reproduced, I mark it **vendor-claimed**. Treat the coding and knowledge-work numbers as well-corroborated; treat single-source claims with appropriate skepticism.
+
+| Benchmark | Opus 4.7 | Opus 4.8 | Change | What it measures |
+|-----------|----------|----------|--------|------------------|
+| SWE-Bench Verified | 87.6% | **88.6%** | +1.0 | Real GitHub issue resolution |
+| SWE-Bench Pro | 64.3% | **69.2%** | +4.9 | Harder, contamination-resistant coding |
+| Terminal-Bench 2.1 | 66.1% | **74.6%** | +8.5 | Agentic terminal/CLI workflows |
+| GDPval-AA | 1753 | **1890** | +137 | Economically valuable knowledge work (Elo) |
+| USAMO 2026 | 69.3% | **96.7%** | +27.4 | Olympiad-level mathematical reasoning |
+| GPQA Diamond | — | **93.6%** | — | Graduate-level science Q&A |
+| Humanity's Last Exam (tools) | 54.7% | **57.9%** | +3.2 | Frontier multidisciplinary reasoning |
+| OSWorld | 82.8% | **83.4%** | +0.6 | Computer use / GUI agents |
+
+Two of these deserve more than a row in a table.
+
+**GDPval-AA at 1890** is the standout. It measures real, economically valuable knowledge work across professional domains, scored as an Elo. Opus 4.8 doesn't just lead — independent coverage puts its margin at roughly 576 points over Gemini 3.1 Pro on this benchmark. That's the widest spread on the board, and it aligns with the agentic-execution story Anthropic is telling. The +137 jump over 4.7 is the largest single-version GDPval-AA improvement Anthropic has reported.
+
+**USAMO 2026 going from 69.3% to 96.7%** is a 27-point leap on rigorous, proof-style mathematics. This is the kind of number that's easy to over-read — olympiad benchmarks are narrow — but a near-saturation score on USAMO is a genuine signal about multi-step reasoning rigor, not a rounding artifact.
+
+The one Opus 4.8 loses: **Terminal-Bench 2.1**, where GPT-5.5 still edges it (78.2% vs 74.6%). On terminal-heavy CLI automation, OpenAI keeps the crown — though Opus 4.8's +8.5 jump over 4.7 narrows the gap considerably.
+
+---
+
+## How Does It Compare to GPT-5.5, Gemini 3.5, and the Field?
+
+Where Opus 4.8 sits against the June 2026 frontier:
+
+| Capability | Opus 4.8 | GPT-5.5 | Gemini 3.5 Flash | Notes |
+|------------|----------|---------|------------------|-------|
+| Hardest coding (SWE-Bench Pro) | **69.2%** | ~58.6% | — | Opus leads |
+| SWE-Bench Verified | **88.6%** | ~82% | 80.6% (3.1 Pro) | Opus leads |
+| Terminal-Bench 2.1 | 74.6% | **78.2%** | 76.2% | GPT-5.5 leads; Gemini Flash a surprise 2nd |
+| Knowledge work (GDPval-AA) | **1890** | — | — | Opus leads by a wide margin |
+| Intelligence Index (Artificial Analysis) | **61.4** | — | 55.3 | Opus tops the aggregate index |
+| Input / output price (per 1M) | $5 / $25 | ~$5 / ~$30 | ~$1.50 / ~$9 | Gemini Flash is the budget pick |
+
+A few honest caveats. The Grok 4.3 comparison that gets asked for isn't well-covered in the launch-window sources I could verify, so I'm leaving it out rather than inventing rows. Gemini 3.5 Flash is the genuine surprise here — it posts a 76.2% on Terminal-Bench 2.1, *ahead of Opus 4.8 on that single benchmark*, at roughly a quarter of the cost and several times the speed. If your workload is high-volume agentic execution where the marginal task is cheap and you can tolerate the occasional miss, Flash is a serious option. Opus 4.8 wins when silent errors are expensive and the work is genuinely hard.
+
+The positioning that holds up across sources: **Opus 4.8 is the intelligence leader, GPT-5.5 is the terminal/computer-use workhorse, and Gemini 3.5 Flash is the budget-and-speed champion.** For a fuller cross-model breakdown, see the [FrankX models tracker](/ai-ops/models-2026).
+
+---
+
+## What's the Pricing?
+
+| Model | Input / 1M | Output / 1M | Notes |
+|-------|------------|-------------|-------|
+| **Opus 4.8 (standard)** | **$5.00** | **$25.00** | Unchanged from 4.7 and 4.6 |
+| Opus 4.8 (fast mode) | $10.00 | $50.00 | ~2.5x speed; 3x cheaper than prior fast modes |
+| Opus 4.7 | $5.00 | $25.00 | Previous flagship |
+| Sonnet 4.6 | $3.00 | $15.00 | Speed/intelligence balance |
+| Haiku 4.5 | $1.00 | $5.00 | Cheapest, fastest |
+
+Pricing is the easy part: it didn't move. Standard Opus 4.8 is $5 input / $25 output per million tokens — same as Opus 4.7 and 4.6. The 1M context window carries no long-context premium. You get a better model at the same price, which is the quiet through-line of every Opus release since the 67% cut at [4.6](/blog/claude-opus-4-6-analysis-2026).
+
+The new wrinkle is **fast mode**. Opus 4.8 fast mode runs at roughly 2.5x the speed of standard for $10/$50 per million — double the per-token cost, but Anthropic notes it's three times cheaper than fast mode was on previous Claude models. For latency-sensitive interactive products (coding assistants, live chat), that's a meaningfully better speed-per-dollar curve than fast mode used to offer. For batch and background work, standard mode remains the right call.
+
+---
+
+## What Changed vs Opus 4.6 and 4.7?
+
+If you're coming from **Opus 4.7**, almost nothing changes in your code. There are no new breaking changes — the request surface is identical. The deltas are behavioral and product-side:
+
+| Area | Opus 4.7 | Opus 4.8 |
+|------|----------|----------|
+| API surface | Adaptive thinking, effort levels, no sampling params | **Identical** — string swap only |
+| Effort default | `high` (Claude Code: `xhigh`) | Same; `high` is now an even better baseline |
+| Narration | More clipped, direct | More user-facing narration by default |
+| Tool/subagent triggering | Conservative | More conservative — needs explicit "when to use" prompts |
+| Writing voice | Direct, less hedged | Warmer, clearer, fewer AI tics |
+| Claude Code orchestration | Parallel subagents | **Dynamic workflows** — script-driven, up to 1,000 subagents |
+| Fast mode | Not available on 4.7 | **Available**, 2.5x speed, 3x cheaper |
+| effort control on claude.ai | API-only | **User-facing slider** on claude.ai |
+
+If you're jumping from **Opus 4.6**, you inherit the 4.7 breaking changes first: `budget_tokens` returns a 400 (use `thinking: {type: "adaptive"}`), the sampling parameters `temperature` / `top_p` / `top_k` are removed (steer with prompting), and last-assistant-turn prefills 400 (use `output_config.format`). Thinking content is also omitted by default — set `thinking: {type: "adaptive", display: "summarized"}` if you surface reasoning to users.
+
+The behavioral re-tune is worth a prompt review. Opus 4.8 narrates *more* than 4.7 by default and is *more* deliberate — on minor decisions it tends to pause and ask rather than just proceeding. If you want 4.7-style terseness and autonomy back, add an explicit silence-default and a "for minor choices, pick and note rather than ask" instruction. It's also more conservative about reaching for search, subagents, and file-based memory, so move the "when to use this" guidance into each tool's own description, not just the system prompt.
+
+---
+
+## What Are Dynamic Workflows?
+
+This is the feature that earns the release. In Claude Code, a **dynamic workflow** is a JavaScript script — which Claude writes for you from a task description — that orchestrates subagents at scale. A runtime executes it in the background while your session stays responsive. The limits, per Anthropic and [MarkTechPost's coverage](https://www.marktechpost.com/2026/05/28/anthropic-ships-claude-opus-4-8-alongside-dynamic-workflows-and-cheaper-fast-mode-with-workflows-capped-at-1000-subagents/): up to **16 concurrent agents** and **1,000 agents total per run**.
+
+The concrete claim: Claude Code on Opus 4.8 can carry out codebase-scale migrations across hundreds of thousands of lines — from kickoff to merge — using the existing test suite as its bar. Plan, fan out across files, run the migration in parallel, verify against tests, open the PR.
+
+Underneath it sits a real API change: the Messages API now supports **real-time updates to the messages array while an agent is active**. You can change instructions, adjust permissions, modify token limits, or update context mid-task without disrupting prompt caching or forcing a new user turn. Concretely, you place a `{"role": "system", ...}` entry partway through the `messages` array (beta header `mid-conversation-system-2026-04-07`) to inject operator instructions without invalidating the cached prefix ahead of the whole conversation. That's the primitive that makes long-running, steerable agents practical — and it's available from Opus 4.7 onward, not 4.8-exclusive.
+
+The honest framing: dynamic workflows are a Claude Code orchestration layer, not a new model capability. But "the model can now reliably drive 1,000 subagents through a 200K-line migration" is a more useful sentence than any single benchmark on the board.
+
+---
+
+## What Does It Mean for Builders?
+
+### For developers
+
+The migration is trivial and the upside is free. Swap `claude-opus-4-7` for `claude-opus-4-8`, run your evals, ship. No breaking changes, same price, better coding and reasoning. The only thing to actually *do* is re-tune prompts for the behavioral shifts — narration and ask-rate — and that's optional polish, not a blocker.
+
+```json
+{
+  "model": "claude-opus-4-8",
+  "thinking": { "type": "adaptive" },
+  "output_config": { "effort": "high" }
+}
+```
+
+One nuance on effort: on 4.8, don't reflexively reach for `xhigh` or `max`. The intelligence ceiling is higher, so start at `high` and sweep `medium`/`high`/`xhigh` on your own eval set. Higher effort up front often *reduces* total turn count and cost on agentic work — but the relationship isn't monotonic, and for some routes `medium` lands equally good results faster.
+
+### For agentic and long-horizon work
+
+This is where 4.8 earns its keep. Give it the **full task specification in one well-specified first turn** and run at `high` or `xhigh`. The long-horizon coherence comes partly from reasoning more at each step, so a clear up-front goal plus generous effort produces more efficient *and* more accurate output than feeding the task piecemeal across turns. If you're on Claude's Managed Agents, state "done" as a gradeable rubric via an Outcome and let the harness iterate.
+
+### For content and knowledge work
+
+The GDPval-AA and knowledge-work gains are the practical headline for creators. Opus 4.8's prose is warmer and less hedged than 4.7's by default — which means the style prompts you wrote to *counter* 4.7's clipped directness may now overcorrect. Re-baseline them. The 128K output ceiling (unchanged) still means complete long-form drafts in a single generation pass, and the 1M context still holds an entire content archive in one session.
+
+### For cost-conscious routing
+
+The arrival of fast mode changes the routing math for interactive products. For a coding assistant or live agent where latency is user-visible, Opus 4.8 fast mode at $10/$50 and 2.5x speed may now beat dropping down to Sonnet — you keep Opus-tier intelligence and pay for speed only where it's felt. For everything background, standard Opus 4.8 at $5/$25 remains the default. And for genuinely high-volume, error-tolerant fan-out, Gemini 3.5 Flash is the honest budget alternative. This is the same routing discipline the broader [Microsoft MAI frontier models](/blog/microsoft-mai-frontier-models-2026) coverage points at: match the model to the task's cost-of-error, not to the leaderboard.
+
+---
+
+## Are There Breaking Changes?
+
+For Opus 4.7 users: **no.** The request surface is identical. This is the cleanest Opus migration in recent memory — a model-string swap.
+
+For Opus 4.6 (or older) users, you inherit the 4.7 breaking changes:
+
+| Change | Impact | Fix |
+|--------|--------|-----|
+| `budget_tokens` removed | 400 error | Use `thinking: {type: "adaptive"}` + `effort` |
+| `temperature` / `top_p` / `top_k` removed | 400 error | Steer with prompting instead |
+| Assistant-turn prefills | 400 error | Use `output_config.format` (structured outputs) |
+| Thinking omitted by default | Empty reasoning text | Set `thinking: {display: "summarized"}` if surfaced |
+
+None of these are new to 4.8 — they all landed with 4.7. If you already made the 4.7 jump, you're done.
+
+---
+
+## FAQ
+
+### Is Opus 4.8 better than GPT-5.5?
+
+On most benchmarks, yes — Opus 4.8 leads SWE-Bench Verified (88.6% vs ~82%), SWE-Bench Pro (69.2% vs ~58.6%), and the GDPval-AA knowledge-work benchmark by a wide margin. GPT-5.5 keeps the lead on Terminal-Bench 2.1 (78.2% vs 74.6%), so for terminal-heavy CLI automation and computer-use workflows, GPT-5.5 still edges it. For coding, analysis, and knowledge work, Opus 4.8 is the stronger model at a comparable price.
+
+### How much does Opus 4.8 cost?
+
+$5 per million input tokens, $25 per million output tokens — unchanged from Opus 4.7 and 4.6. The 1M context window carries no long-context premium. Fast mode runs at $10/$50 per million for roughly 2.5x the speed, which Anthropic says is three times cheaper than fast mode on previous Claude models.
+
+### What's the context window and max output?
+
+1M input tokens and 128K output tokens — identical to Opus 4.7 and 4.6. Modalities are text, vision, and code. No change on this axis in 4.8.
+
+### Should I upgrade from Opus 4.7?
+
+Yes, and it's low-risk. There are no breaking changes — swap `claude-opus-4-7` for `claude-opus-4-8`, run your evals, and you get better coding and reasoning at the same price. Budget an hour to re-tune prompts for the behavioral shifts (more narration, higher ask-rate, more conservative tool use), but that's polish, not a requirement.
+
+### What are dynamic workflows and what's the subagent limit?
+
+Dynamic workflows are a Claude Code feature where Claude writes a JavaScript orchestration script from your task description, then runs it in the background to coordinate subagents at scale — up to 16 concurrent and 1,000 total per run. The flagship use case is codebase-scale migrations across hundreds of thousands of lines, verified against the existing test suite, from kickoff to merge.
+
+### Which benchmark numbers are verified vs vendor-claimed?
+
+The coding (SWE-Bench Verified/Pro, Terminal-Bench) and knowledge-work (GDPval-AA) figures are well-corroborated across Anthropic's announcement, Artificial Analysis, llm-stats, and independent outlets. GPQA Diamond (93.6%) and the USAMO 2026 jump (96.7%) are reported but lean more on Anthropic's own evals — treat them as vendor-claimed until third parties reproduce them. I omitted any Grok 4.3 comparison because I couldn't verify it from launch-window sources rather than guess.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI.
+Published June 5, 2026 with benchmarks validated against Anthropic's official documentation, Artificial Analysis, llm-stats, and independent coverage. Vendor-claimed figures are marked as such.*

--- a/content/blog/gemini-3-5-pro-analysis-2026.mdx
+++ b/content/blog/gemini-3-5-pro-analysis-2026.mdx
@@ -1,0 +1,214 @@
+---
+title: "Gemini 3.5 Pro: What We Actually Know Before GA"
+description: "Gemini 3.5 Pro is still in limited Vertex preview as of June 2026 — no model card, no benchmarks, no pricing. Here's the verifiable picture: what Flash already proved, what Google has committed to, and what to wait for at GA."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - google
+  - gemini
+  - frontier-models
+  - ai-2026
+  - benchmarks
+  - multimodal
+keywords:
+  - gemini 3.5 pro
+  - gemini 3.5 pro release date
+  - gemini 3.5 pro benchmarks
+  - gemini 3.5 pro pricing
+  - gemini 3.5 pro vs flash
+  - gemini 3.5 pro context window
+  - gemini 3.5 pro deep think
+  - gemini 3.5 pro ga june 2026
+  - google deepmind gemini 3.5
+  - best ai model 2026
+image: "/images/blog/gemini-3-5-pro-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Gemini 3.5 Pro: What We Actually Know Before GA
+
+**TL;DR**: As of June 5, 2026, Gemini 3.5 Pro is **not generally available**. Google announced it at I/O on May 19, 2026, but it remains in limited Vertex AI preview for select enterprise customers — no model card, no published benchmarks, no pricing tier. The model ID is `gemini-3.5-pro`. Google has positioned it as its strongest agentic and coding model, targeting a 2M-token context window and "Deep Think" reasoning. Sundar Pichai told the I/O audience to "give us until next month." So this is an honest pre-GA brief: what Gemini 3.5 Flash already proved, what Google has actually committed to, and what numbers to wait for. Where a figure isn't confirmed, I say so.
+
+---
+
+## Is Gemini 3.5 Pro Released Yet?
+
+No. Not at GA. This is the single most important thing to get right, because half the "Gemini 3.5 Pro benchmarks" content circulating right now is projecting Flash's numbers onto a model whose model card does not yet exist.
+
+Here's the verifiable timeline:
+
+- **May 19, 2026** — Google I/O. Google announces the Gemini 3.5 generation. **Gemini 3.5 Flash ships to GA** the same day: in the Gemini app, AI Studio, Antigravity, the Gemini API, and AI Mode in Search.
+- **Gemini 3.5 Pro is announced but held back** — limited Vertex AI preview for select enterprise accounts only. No public API model name available for general use, no pricing, no model card.
+- **GA targeted for June 2026** — Pichai's framing on stage was "give us until next month." No committed date was given.
+
+As of this writing (June 5), nothing has changed that status. There is no spec sheet, no benchmark card, no pricing tier, and no general API access for Gemini 3.5 Pro. If you see a "94% on benchmark X" claim for 3.5 Pro right now, it is either extrapolated from Gemini 3.1 Pro / 3.5 Flash or invented. Treat it as such.
+
+So the useful question isn't "how good is 3.5 Pro" — nobody outside Google can answer that yet. It's "what's the evidence base, and what should I watch for at GA."
+
+---
+
+## What Did Gemini 3.5 Flash Already Prove?
+
+Flash is the reason 3.5 Pro is interesting. The whole point of a "Pro" tier is that it sits above Flash — so Flash's GA numbers set the floor for what Pro has to clear.
+
+Gemini 3.5 Flash shipped May 19, 2026 (`gemini-3.5-flash`), and the headline was genuinely unusual: a **Flash-tier model leading the previous Pro tier on agentic benchmarks**. Verified specs from Google's model card and independent coverage:
+
+| Spec / Benchmark | Gemini 3.5 Flash | Source basis |
+|------------------|------------------|--------------|
+| Context window | 1M tokens | Google model card |
+| Max output | 64K tokens | Google model card |
+| Modalities | Text, image, audio, video, PDF in | Google model card |
+| Terminal-Bench 2.1 | 76.2% | Google / independent |
+| MCP Atlas | 83.6% | Google / independent |
+| GDPval-AA | 1656 Elo | Google |
+| CharXiv Reasoning | 84.2% | Google |
+| Pricing (in / out) | $1.50 / $9.00 per 1M | Google API pricing |
+| Cached input | $0.15 per 1M (90% off) | Google API pricing |
+
+The thing to internalize: Flash already beats **Gemini 3.1 Pro** (Google's February 2026 flagship) on Terminal-Bench 2.1, MCP Atlas, and GDPval-AA. That's the bar 3.5 Pro is built to exceed. If Pro merely matched Flash on agentic coding, the tier wouldn't justify itself — so Google is effectively committing to a model that pushes past 76% Terminal-Bench and 83% MCP Atlas, with Deep Think reasoning layered on top.
+
+Where Flash still trails: pure abstract reasoning. Flash sits around 72.1% on ARC-AGI-2 versus Gemini 3.1 Pro's verified 77.1%. That reasoning gap is exactly the territory a Deep Think-equipped Pro model is designed to reclaim.
+
+---
+
+## What Has Google Actually Committed To for Pro?
+
+Stripping out the speculation, here's what Google itself has stated about Gemini 3.5 Pro — framed as *targets and positioning*, not measured results:
+
+- **Model ID**: `gemini-3.5-pro` (visible in Vertex preview).
+- **Context window**: targeting **2M tokens** — the spec that has historically defined the Pro/Ultra tier, and double Flash's 1M.
+- **Deep Think reasoning**: an explicit reasoning mode. For reference, Gemini 3 Deep Think hit **84.6% on ARC-AGI-2** (verified by the ARC Prize Foundation) — that lineage is why Deep Think on a 3.5-generation Pro is the number worth waiting for.
+- **Frontier multimodal**: the widest input modality set — text, image, audio, video, PDF — carried up from Flash.
+- **Positioning**: Google describes Pro as its "strongest agentic and coding model," expected to clear Flash on Terminal-Bench 2.1, MCP Atlas, and GDPval-AA.
+
+Every one of those is a *vendor-stated target*. None is an independently reproduced benchmark, because the model card doesn't exist yet. I'm flagging that explicitly because the whole value of this piece is not pretending otherwise.
+
+For a sense of the lineage these targets sit on, Gemini 3.1 Pro (the current shipped Pro, GA February 2026) is the honest baseline:
+
+| Gemini 3.1 Pro (verified, shipped) | Value |
+|------------------------------------|-------|
+| Context window | 1M tokens |
+| ARC-AGI-2 | 77.1% |
+| GPQA Diamond | 94.3% |
+| SWE-bench Verified | 80.6% |
+| MMMU-Pro | 80.5% |
+| Pricing (in / out) | $2 / $12 per 1M (tiered: $4 / $18 above 200K) |
+
+3.5 Pro is the model that's supposed to beat *that* line while adding Deep Think and (targeted) 2M context. Until GA, that's the most defensible way to think about it.
+
+---
+
+## How Does It Slot Into the June 2026 Frontier?
+
+This is the table everyone wants, so here it is with a hard rule: **Gemini 3.5 Pro's column is marked "preview — TBD at GA," not filled with guesses.** The other models' numbers are verified from their GA releases and independent trackers.
+
+| Benchmark | Gemini 3.5 Pro | Gemini 3.5 Flash | Claude Opus 4.8 | GPT-5.5 | Grok 4.3 |
+|-----------|----------------|------------------|-----------------|---------|----------|
+| ARC-AGI-2 | TBD at GA | 72.1% | 75.8% | **85.0%** | not published |
+| SWE-bench Pro | TBD at GA | — | **69.2%** | 58.6% | — |
+| Terminal-Bench 2.1 | TBD at GA | 76.2% | 74.6% | **78.2%** | — |
+| MCP Atlas | TBD at GA | 83.6% | — | — | — |
+| GPQA Diamond | TBD at GA | — | 93.6% | 93.5% | — |
+| GDPval-AA (Elo) | TBD at GA | 1656 | **1890** | ~1769 | — |
+| Context window | 2M (target) | 1M | 1M | 922K | 1M |
+
+Reading this honestly:
+
+- **GPT-5.5 owns abstract reasoning** right now (ARC-AGI-2 85.0%) and edges Terminal-Bench (78.2%).
+- **Claude Opus 4.8 leads aggregate intelligence** — it took the #1 spot on the Artificial Analysis Intelligence Index on May 28 (61.4) and dominates SWE-bench Pro (69.2% vs GPT-5.5's 58.6%) and GDPval-AA (1890 Elo).
+- **Grok 4.3** competes on price ($1.25 / $2.50 per 1M) and a strong aggregate index score, but xAI hasn't published comparable SWE-bench / Terminal-Bench numbers.
+- **Gemini's play is multimodal breadth + context + price**, not topping the reasoning leaderboard. Even 3.1 Pro's $2/$12 undercuts Opus 4.8's $5/$25 substantially.
+
+The interesting strategic question at GA: does 3.5 Pro chase GPT-5.5's ARC-AGI-2 crown via Deep Think, or does Google double down on the agentic-coding + multimodal + 2M-context lane where it's already differentiated? My read is the latter — Flash's numbers tell you where this generation's engineering went.
+
+For the live, continuously-updated cross-model view, see the [2026 model landscape on AI Ops](/ai-ops/models-2026). For the two models currently setting the bar Pro has to clear, see the [Claude Opus 4.8 breakdown](/blog/claude-opus-4-8-analysis-2026).
+
+---
+
+## What Will Pricing Likely Be?
+
+Unconfirmed. No pricing tier has been published for 3.5 Pro. The only honest statement: it will be announced at GA.
+
+That said, Google's Pro-tier pricing has been remarkably stable, so the *shape* is predictable even if the number isn't:
+
+| Model | Input / 1M | Output / 1M | Notes |
+|-------|-----------|-------------|-------|
+| Gemini 3.5 Flash | $1.50 | $9.00 | Cached $0.15; verified |
+| Gemini 3.1 Pro | $2.00 | $12.00 | Tiered to $4/$18 above 200K; verified |
+| **Gemini 3.5 Pro** | **TBD** | **TBD** | Announced at GA; expect tiered, context-length-dependent |
+
+If history holds, expect context-length-dependent tiered pricing (a higher rate above a long-context threshold, the way 3.1 Pro jumps at 200K) and a likely premium over 3.1 Pro for the 2M window and Deep Think. But I'm not going to put a fake dollar figure in a table. Wait for the model card.
+
+---
+
+## Pro vs Flash: Which Should You Use?
+
+For most teams, today, the answer is **Flash — because it's the only one of the two you can actually deploy.** But the routing logic at GA is straightforward:
+
+**Use Gemini 3.5 Flash when:**
+- You're running high-volume agentic or MCP-heavy workloads where cost compounds (83.6% MCP Atlas at $1.50/$9 is hard to beat on price/quality).
+- You need 1M context cheaply for long-horizon coding agents.
+- Throughput matters — Flash is reported at roughly 4x the output tokens/sec of other frontier models.
+- The task lives in Flash's competence band, which after this release is *most* agentic coding.
+
+**Wait for Gemini 3.5 Pro when:**
+- Your workload hits Flash's ceiling on hard reasoning — the multi-step, Deep-Think-shaped problems where Flash's ARC-AGI-2 gap to the Pro line shows.
+- You genuinely need the 2M context window (target) rather than 1M.
+- You're doing heavy video/audio multimodal reasoning where the extra headroom justifies the tier.
+
+The honest framing: Flash already absorbed most of what used to require Pro. Pro 3.5 has to earn its slot on the *hardest* reasoning and the *longest* context — not on general agentic coding, where Flash already leads the prior Pro tier. That's a higher bar than a normal Pro release, and it's why the GA benchmarks matter more than usual.
+
+---
+
+## What It Means for Builders
+
+A few practical takeaways while we wait:
+
+1. **Don't architect on a model you can't call.** If you're building agent pipelines now, build on Gemini 3.5 Flash (GA, priced, documented) or a confirmed competitor — not on 3.5 Pro promises. Swap Pro in at GA *if* its measured numbers justify the cost delta over Flash. Many workloads won't need it.
+
+2. **Plan for context-length pricing tiers.** Gemini Pro pricing jumps above a threshold (200K on 3.1 Pro). If your prompts straddle that boundary, your cost model needs the tiered rate, not the headline rate. Budget for the worst-case tier.
+
+3. **Watch ARC-AGI-2 and SWE-bench Pro at GA specifically.** Those are where Gemini has historically trailed Opus and GPT-5.5. If 3.5 Pro with Deep Think closes the ARC-AGI-2 gap to GPT-5.5's 85.0%, that's a real shift. If it lands near 3.1 Pro's 77.1%, the story stays "multimodal + context + price," not "reasoning crown."
+
+4. **Multimodal is the durable edge.** Across the frontier, Gemini's consistent differentiator is native text/image/audio/video/PDF in one model. If your product is video- or audio-heavy, the Gemini line is worth tracking regardless of where the reasoning benchmarks land.
+
+5. **Route, don't standardize.** The June 2026 frontier has no single winner — Opus 4.8 leads aggregate intelligence and coding, GPT-5.5 leads abstract reasoning, Grok 4.3 leads on price, Gemini leads on multimodal + context. A routing layer that sends each task to the right tier beats betting the whole stack on one model. This is exactly the case for treating models as interchangeable infrastructure rather than a religion. For how Microsoft is entering this same fight with its own full-stack play, see the [Microsoft MAI frontier models breakdown](/blog/microsoft-mai-frontier-models-2026).
+
+---
+
+## FAQ
+
+### Is Gemini 3.5 Pro available yet?
+
+Not at GA. As of June 5, 2026, it is in limited Vertex AI preview for select enterprise customers only. There is no public model card, no published benchmarks, and no general API pricing. Google announced it at I/O on May 19, 2026, with GA targeted for sometime in June 2026 — Sundar Pichai's phrasing was "give us until next month," with no committed date.
+
+### What is the model ID for Gemini 3.5 Pro?
+
+`gemini-3.5-pro`, visible in the Vertex AI preview. The general-availability API name should match at GA.
+
+### What's the context window for Gemini 3.5 Pro?
+
+Google is targeting 2M tokens — double Gemini 3.5 Flash's 1M. This is a stated target, not a confirmed spec, until the GA model card lands. For comparison, the currently shipped Gemini 3.1 Pro has a verified 1M-token window.
+
+### How much will Gemini 3.5 Pro cost?
+
+Unconfirmed. Pricing will be announced at GA. Google's Pro tier has historically used context-length-dependent tiered pricing — Gemini 3.1 Pro runs $2/$12 per 1M, rising to $4/$18 above 200K tokens. Expect a similar tiered structure, likely with a premium for the larger context window and Deep Think. Any specific dollar figure circulating now is speculation.
+
+### Is Gemini 3.5 Pro better than Claude Opus 4.8 or GPT-5.5?
+
+Unknown — it hasn't been benchmarked publicly. What's verified: as of late May 2026, Claude Opus 4.8 leads aggregate intelligence (Artificial Analysis Index 61.4) and SWE-bench Pro (69.2%), while GPT-5.5 leads ARC-AGI-2 (85.0%). Gemini 3.5 Flash already beats the prior Gemini Pro tier on agentic coding (Terminal-Bench 2.1 76.2%, MCP Atlas 83.6%). Where 3.5 Pro lands against Opus and GPT-5.5 is precisely the open question at GA.
+
+### Should I use Gemini 3.5 Flash or wait for Pro?
+
+If you need to ship now, use Flash — it's GA, priced, and documented, and it already leads the previous Pro tier on agentic coding at $1.50/$9 per 1M. Wait for Pro only if your workload hits Flash's ceiling on hard reasoning, needs the 2M context window, or involves heavy video/audio multimodal reasoning. For most agentic-coding workloads, Flash is the pragmatic pick today.
+
+### What benchmarks should I watch when Gemini 3.5 Pro reaches GA?
+
+ARC-AGI-2 and SWE-bench Pro — the two areas where Gemini has historically trailed Opus and GPT-5.5. Also watch whether Deep Think reasoning numbers are reported separately, and whether independent trackers (Artificial Analysis, llm-stats, LMArena) reproduce Google's claimed figures before you trust them in production.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI. Written June 5, 2026, while Gemini 3.5 Pro is still in preview. Verified figures are sourced to Google's GA releases, model cards, and independent trackers; everything about 3.5 Pro itself is marked as preview-stage and will be updated when the GA model card lands.*

--- a/content/blog/gpt-5-5-analysis-2026.mdx
+++ b/content/blog/gpt-5-5-analysis-2026.mdx
@@ -1,0 +1,185 @@
+---
+title: "GPT-5.5 (\"Spud\"): What Actually Changed and Why It Matters"
+description: "OpenAI's GPT-5.5 leads GDPval at 84.9%, OSWorld at 78.7%, and Tau2 Telecom at 98% — at double the price of GPT-5.4. Technical breakdown with verified benchmarks, pricing, and what it means for builders."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - openai
+  - gpt-5-5
+  - frontier-models
+  - ai-2026
+  - benchmarks
+  - agentic-ai
+keywords:
+  - gpt-5.5
+  - gpt-5.5 review
+  - gpt-5.5 benchmarks
+  - gpt-5.5 pricing
+  - gpt-5.5 vs claude opus 4.8
+  - gpt-5.5 context window
+  - gpt-5.5 gdpval
+  - gpt-5.5 osworld
+  - openai spud model
+  - best ai model 2026
+image: "/images/blog/gpt-5-5-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# GPT-5.5 ("Spud"): What Actually Changed and Why It Matters
+
+**TL;DR**: OpenAI released GPT-5.5 (internal codename "Spud") on April 23, 2026 as its new flagship. The headline numbers are agentic: 84.9% on GDPval (knowledge work across 44 occupations), 78.7% on OSWorld-Verified (autonomous computer use), and 98.0% on Tau2 Telecom (customer-service workflows) without prompt tuning. Long-context reasoning at 512K–1M tokens jumped from 36.6% on GPT-5.4 to 74.0%. The catch: pricing doubled to $5/$30 per million tokens, and it's a drop-in API replacement for GPT-5.4. Here's what actually matters for builders.
+
+---
+
+## What is GPT-5.5?
+
+GPT-5.5 is OpenAI's new flagship, replacing GPT-5.4 at the top of the line. The model id string is `gpt-5.5`, and OpenAI positions it squarely as an agentic model — built for long-horizon tasks where the model plans, calls tools, makes decisions, and keeps going for minutes or hours without hand-holding.
+
+Three things make this release worth a builder's attention:
+
+1. **It set the agentic benchmark pace.** GDPval at 84.9%, OSWorld-Verified at 78.7%, and Tau2-bench Telecom at 98.0% are the strongest knowledge-work and computer-use numbers OpenAI has published. These are the benchmarks that map to real automation, not trivia recall.
+
+2. **Long context finally works.** Long-context reasoning at 512K–1M tokens went from 36.6% on GPT-5.4 to 74.0% on GPT-5.5. That's the single largest jump in the GPT-5 series, and it's the difference between "accepts a big prompt" and "uses it."
+
+3. **It costs more, not less.** GPT-5.5 lists at exactly 2x GPT-5.4 on both sides of the meter — $5 input, $30 output per million tokens. OpenAI's argument is that better token efficiency offsets the higher rate. That argument is testable, and I get into it below.
+
+---
+
+## How does GPT-5.5 actually perform on benchmarks?
+
+Numbers below are from OpenAI's announcement cross-referenced against independent coverage (Vellum, The Decoder, Interesting Engineering) and benchmark aggregators. Where sources disagree or the figure is vendor-reported, I flag it explicitly. Treat anything labeled vendor-claimed as a marketing-conditions number, not an independently reproduced one.
+
+| Benchmark | What it measures | GPT-5.5 | GPT-5.4 |
+|-----------|------------------|---------|---------|
+| GDPval | Knowledge work across 44 occupations | **84.9%** | — |
+| OSWorld-Verified | Autonomous real-computer operation | **78.7%** | — |
+| Tau2-bench Telecom | Complex customer-service workflows | **98.0%** | — |
+| Terminal-Bench 2.0 | Command-line agentic workflows | **82.7%** | 75.1% |
+| Long context (512K–1M) | Retrieval + reasoning over long inputs | **74.0%** | 36.6% |
+| AIME 2025 | Competition math | **93.6%** | — |
+| SWE-bench Verified | Real GitHub issue resolution | **~82.6–88.7%** (vendor-claimed, varies by source) | — |
+| ARC-AGI-2 | Abstract reasoning | **~85%** (vendor-claimed, read skeptically) | — |
+
+Two honest caveats. First, **SWE-bench Verified scores at this tier should be read with heavy skepticism** — every frontier lab has plausibly trained on or adjacent to this data, and reported figures for GPT-5.5 range from roughly 82.6% to 88.7% depending on the source and test conditions. On the harder **SWE-bench Pro**, GPT-5.5 lands at 58.6%, which is the more useful signal. Second, the ARC-AGI-2 figure floating around (~85%) is unusually high for an abstract-reasoning benchmark and I could not pin it to a single authoritative methodology; I'd wait for an independent run before quoting it as fact.
+
+The cleaner competitive read comes from **GDPval-AA**, the Artificial Analysis arena version of GDPval. There, GPT-5.5 scores **1769 Elo** — strong, and ahead of Gemini 3.1 Pro's 1314, but behind Claude Opus 4.8's 1890 (released roughly five weeks later, on May 28). GPT-5.5's most durable lead is on **terminal-agent benchmarks**, where it keeps a narrow edge even against Opus 4.8.
+
+---
+
+## How does GPT-5.5 compare to Claude Opus 4.8 and Gemini 3.1 Pro?
+
+This is the comparison most builders actually care about. The frontier in mid-2026 is a three-way race, and the answer is genuinely "it depends on the task."
+
+| Capability | GPT-5.5 | Claude Opus 4.8 | Gemini 3.1 Pro |
+|------------|---------|------------------|----------------|
+| GDPval-AA (Elo) | 1769 | **1890** | 1314 |
+| OSWorld (computer use) | 78.7% | **83.4%** | — |
+| SWE-bench Pro | 58.6% | **69.2%** | 54.2% |
+| Terminal-agent tasks | **narrow lead** | strong | — |
+| GPQA Diamond | — | 93.6% | — |
+| Released | Apr 23, 2026 | May 28, 2026 | earlier 2026 |
+
+A few takeaways that hold up across sources:
+
+- **Opus 4.8 leads on raw knowledge-work value and SWE-bench Pro.** Anthropic shipped roughly five weeks after OpenAI, and the GDPval-AA gap (1890 vs 1769) and SWE-bench Pro gap (69.2% vs 58.6%) are real.
+- **GPT-5.5 holds the terminal-agent edge.** For command-line-heavy autonomous loops — the Codex-style workflows OpenAI optimized for — GPT-5.5 stays competitive or ahead.
+- **Gemini 3.1 Pro trails on agentic value** but remains relevant for its native long-context and multimodal breadth. (For the full landscape, see the [2026 models reference](/ai-ops/models-2026).)
+
+If you're choosing today, the honest framing is: Opus 4.8 for deep coding and knowledge synthesis, GPT-5.5 for terminal-agent and computer-use automation, and route by task rather than picking one winner. I broke down the Opus side of this in the [Claude Opus 4.8 analysis](/blog/claude-opus-4-8-analysis-2026).
+
+---
+
+## What does GPT-5.5 cost?
+
+GPT-5.5 doubled the per-token price of GPT-5.4. This is the most contested part of the release.
+
+| Model | Input / 1M | Cached input / 1M | Output / 1M |
+|-------|------------|-------------------|-------------|
+| **GPT-5.5** | **$5.00** | **$0.50** | **$30.00** |
+| GPT-5.5 Pro | $30.00 | — | $180.00 |
+| GPT-5.4 (prior) | $2.50 | — | $15.00 |
+| Claude Opus 4.8 (reference) | varies | varies | varies |
+
+The output price is the one to watch: **$30 per million output tokens** is steep for a default agentic model, and GPT-5.5 Pro at $180 output is firmly in "reserve for the hardest research-grade problems" territory.
+
+OpenAI's counter-argument is token efficiency. The company says GPT-5.5 uses significantly fewer tokens to complete the same Codex tasks than GPT-5.4, and Artificial Analysis reported roughly **40% fewer output tokens** in its own framework. If that holds for your workload, the effective cost gap narrows — a 2x rate against 40% fewer tokens is roughly a 1.2x effective increase on output-heavy agentic runs, not 2x. But "roughly 40% fewer on Codex tasks" is not a universal guarantee, and on output-light, input-heavy workloads (long-context retrieval, document analysis) you pay the full 2x with less efficiency offset. Measure your own token mix before assuming the efficiency narrative covers you.
+
+---
+
+## What changed versus GPT-5.2?
+
+The prior flagship most readers will be migrating from is GPT-5.2 (released December 11, 2025). Here's the delta that matters.
+
+| Dimension | GPT-5.2 / 5.2 Pro | GPT-5.5 |
+|-----------|-------------------|---------|
+| Positioning | "Most capable work model" | Agentic, long-horizon autonomy |
+| Context window | 400K (272K input + 128K output) | Up to 1M via API; 400K class in Codex |
+| Modalities | Text + image (no native audio) | Text, image, audio, video in one unified architecture (vendor framing) |
+| Long-context reasoning | weaker | 74.0% at 512K–1M (vs 36.6% on 5.4) |
+| Output price / 1M | $14 (Pro tier) | $30 (base), $180 (Pro) |
+| Knowledge cutoff | late 2025 | December 2025 |
+
+Two things to correct from the common framing. **GPT-5.2 did not ship native audio** — it was a text-and-image model, and the modality story is genuinely new at the 5.5 line. And on context: the published 1M window comes with real-world caveats. There are open reports of GPT-5.5 surfacing a ~258K effective window in Codex despite the 400K/1M published figures, and of catalog mismatches that can bypass auto-compaction. If you're building on the long-context promise, validate the effective window in your actual harness rather than trusting the spec sheet.
+
+On the API surface, GPT-5.5 is a **drop-in replacement for GPT-5.4** — it supports the same prompt caching, hosted tools, tool search, and compaction features. There's no painful migration. The work is in re-tuning cost expectations and validating context behavior, not rewriting integrations.
+
+Native real-time voice is a related but separate story: OpenAI shipped the **gpt-realtime-2** family on May 7 with GPT-5-class reasoning, a 128K context (up from 32K), and parallel mid-conversation tool calls. If voice agents are your use case, that's the model line to evaluate, priced at $32/$64 per million audio input/output tokens — not GPT-5.5 itself.
+
+---
+
+## What does GPT-5.5 mean for builders?
+
+### For developers building agents
+
+GPT-5.5 is the first OpenAI flagship genuinely tuned for long-horizon autonomy, and the OSWorld (78.7%) and Terminal-Bench 2.0 (82.7%) numbers back that up. If you're running Codex-style loops or computer-use automation, this is the model to benchmark against your current stack. OpenAI also reports a roughly 60% drop in hallucination rate versus GPT-5.4, which matters more for autonomous loops than for single-turn chat — an agent that hallucinates a file path or API parameter mid-task wastes the whole run.
+
+The token-efficiency claim is the lever to pull. Agentic loops that converge sooner and "dig themselves in less when they're wrong" are worth real money at $30/1M output. Instrument your runs: measure tokens-to-completion on GPT-5.5 versus your incumbent, not just per-token price.
+
+### For teams on long-context workloads
+
+The 36.6% → 74.0% jump on long-context reasoning is the most practically useful improvement in the release. Loading an entire codebase, a full research corpus, or a long document set into one prompt now produces answers that actually reflect the whole input. But validate the *effective* window in your harness — the Codex reports of a shrunken real window are a caution, not a footnote.
+
+### For cost-conscious shops
+
+Do the math before you switch your default. At 2x the rate, GPT-5.5 only pays off if your workload is output-heavy enough to capture the token-efficiency savings. For high-volume, output-light tasks, GPT-5.4 or a Sonnet-class model may still be the better economic choice. Route by task. The right architecture in mid-2026 is a router that sends terminal-agent and computer-use work to GPT-5.5, deep coding to Opus 4.8, and high-throughput simple tasks to a cheaper tier — not a single-model bet. I've written about how the broader frontier is fragmenting in the [Microsoft MAI frontier models breakdown](/blog/microsoft-mai-frontier-models-2026).
+
+---
+
+## The bottom line
+
+GPT-5.5 is a real step forward on the metrics that matter for automation: knowledge work, computer use, terminal agents, and long context. It is not a clean sweep of the frontier — Claude Opus 4.8 leads on GDPval-AA and SWE-bench Pro, and the price doubled. The token-efficiency argument is plausible but conditional on your workload. Treat the SWE-bench Verified and ARC-AGI-2 headline numbers with skepticism, lean on GDPval-AA and OSWorld as the cleaner signals, and benchmark tokens-to-completion before you migrate. For agentic and computer-use builders, it earns its place in the routing table. For everyone else, it's a "measure, then decide" release.
+
+---
+
+## FAQ
+
+### Is GPT-5.5 better than Claude Opus 4.8?
+
+It depends on the task. Opus 4.8 leads on GDPval-AA (1890 vs 1769 Elo), OSWorld computer use (83.4% vs 78.7%), and SWE-bench Pro (69.2% vs 58.6%). GPT-5.5 keeps a narrow edge on terminal-agent benchmarks. For deep coding and knowledge synthesis, Opus 4.8 is stronger; for terminal-style autonomous loops, GPT-5.5 is competitive or ahead. Note that Opus 4.8 shipped about five weeks later, so the comparison is OpenAI's April flagship against Anthropic's late-May one.
+
+### How much does GPT-5.5 cost?
+
+$5 per million input tokens, $30 per million output tokens, with cached input at $0.50. That's exactly 2x GPT-5.4's $2.50/$15. The GPT-5.5 Pro tier is $30 input / $180 output. OpenAI argues the higher rate is offset by roughly 40% better output-token efficiency on Codex-style tasks (per Artificial Analysis), but that offset depends on your workload being output-heavy.
+
+### What's GPT-5.5's context window?
+
+OpenAI publishes up to a 1M-token context window via the API, with a 400K-class configuration in Codex (272K input + 128K output in the standard setup). There are open reports of the effective window appearing smaller (~258K) in Codex despite the published figures, and of catalog mismatches that can bypass auto-compaction — so validate the effective window in your own harness before relying on it.
+
+### Does GPT-5.5 support voice and audio?
+
+GPT-5.5 itself processes text, image, audio, and video in a unified architecture (OpenAI's framing). For production real-time voice agents, the relevant model line is the separately released gpt-realtime-2 family (shipped May 7) with GPT-5-class reasoning, a 128K context, and parallel mid-conversation tool calls, priced at $32/$64 per million audio input/output tokens.
+
+### Is migrating from GPT-5.4 to GPT-5.5 hard?
+
+No. GPT-5.5 is a drop-in API replacement for GPT-5.4 and supports the same features — prompt caching, hosted tools, tool search, and compaction. The real work is re-tuning cost expectations (2x rate) and validating long-context behavior, not rewriting integrations.
+
+### Should I trust GPT-5.5's SWE-bench and ARC-AGI numbers?
+
+Be cautious. Reported SWE-bench Verified figures for GPT-5.5 range from about 82.6% to 88.7% depending on the source, and frontier labs may have trained on or adjacent to this data. The harder SWE-bench Pro (58.6%) is a more honest signal. The ~85% ARC-AGI-2 figure is unusually high and I couldn't tie it to a single authoritative methodology — wait for an independent run before quoting it.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI. Published June 5, 2026 with benchmarks cross-referenced against OpenAI's announcement and independent coverage; vendor-claimed figures flagged where they could not be independently verified.*

--- a/content/blog/grok-4-3-analysis-2026.mdx
+++ b/content/blog/grok-4-3-analysis-2026.mdx
@@ -1,0 +1,198 @@
+---
+title: "Grok 4.3: xAI Trades the Crown for the Price Tag"
+description: "xAI's Grok 4.3 scores 53 on the Artificial Analysis Intelligence Index, lifts GDPval-AA to 1500 Elo, ships a 1M context window with always-on reasoning, and cuts price ~40% to $1.25/$2.50. Technical breakdown with verified benchmarks and what it means for builders."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - xai
+  - grok
+  - frontier-models
+  - ai-2026
+  - benchmarks
+  - agentic-ai
+keywords:
+  - grok 4.3
+  - grok 4.3 review
+  - grok 4.3 benchmarks
+  - grok 4.3 pricing
+  - grok 4.3 vs claude opus 4.8
+  - grok 4.3 context window
+  - grok 4.3 intelligence index
+  - xai grok 4.3 api
+  - grok 4.3 voice cloning
+  - best ai model 2026
+image: "/images/blog/grok-4-3-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Grok 4.3: xAI Trades the Crown for the Price Tag
+
+**TL;DR**: xAI shipped Grok 4.3 to the public API on April 30, 2026 (model id `grok-4.3`). It scores **53 on the Artificial Analysis Intelligence Index**, which puts it below the frontier leaders — Claude Opus 4.8 (61.4), GPT-5.5 (60.2), and Gemini 3.1 Pro (~57) — but it lands at **$1.25 input / $2.50 output per million tokens**, roughly a 40% input cut and 60% output cut versus the prior Grok generation. Its biggest jump is on GDPval-AA, where it climbs to **1500 Elo** (+321). It keeps the 1M-token context window, turns reasoning on by default, and adds native video input and a voice-cloning suite. The story here isn't peak intelligence. It's intelligence-per-dollar.
+
+---
+
+## What Is Grok 4.3?
+
+Grok 4.3 is xAI's flagship model as of spring 2026, replacing the Grok 4.20 line. The API model id is `grok-4.3`. It entered beta on grok.com and the SuperGrok apps on April 17, opened to the public API on April 30, and reached general availability the week of May 4.
+
+Three things define this release:
+
+1. **The price dropped, not the spec.** Input falls about 40% and output about 60% versus the previous Grok generation, landing at $1.25/$2.50 per million tokens. The 1M-token context window stays. That combination — frontier-class context at a budget price — is the entire pitch.
+
+2. **Reasoning is now always-on.** Grok 4.3 "thinks" before answering every request by default. There's no separate reasoning toggle to forget; reasoning tokens are billed at the standard output rate. This is the same direction Anthropic and OpenAI have moved — the model decides how hard to think instead of asking you to configure it.
+
+3. **It got more senses.** Grok 4.3 is the first xAI API model to natively accept video input, processing frames through a vision encoder rather than relying on transcription. Alongside it, xAI shipped Custom Voices — a voice-cloning API and creation suite — plus a separate real-time voice agent endpoint.
+
+What it is *not* is a benchmark leader. xAI didn't try to top the Intelligence Index this round, and it shows in the numbers below. That's a deliberate trade, and it's worth taking seriously rather than dismissing.
+
+---
+
+## How Does Grok 4.3 Score on Benchmarks?
+
+The headline number comes from Artificial Analysis, whose Intelligence Index v4.0 is a composite of ten evaluations: GDPval-AA, τ²-Bench Telecom, Terminal-Bench Hard, SciCode, AA-LCR, AA-Omniscience, IFBench, Humanity's Last Exam, GPQA Diamond, and CritPt.
+
+Grok 4.3 (high) scores **53** on that index. For a model in its price tier — where the median sits around 36 — that's strong. Against the absolute frontier, it trails.
+
+| Benchmark | Grok 4.3 | Claude Opus 4.8 | GPT-5.5 | Gemini 3.1 Pro |
+|-----------|----------|-----------------|---------|----------------|
+| AA Intelligence Index v4.0 | **53** | 61.4 | 60.2 | ~57 |
+| GDPval-AA (Elo) | **1500** | 1890 | — | — |
+| SWE-bench Verified | — | 88.6% | 58.6% | 54.2% |
+| Output speed (tok/s) | **181.3** | — | — | — |
+
+A few honest caveats on this table. The Intelligence Index figures for all four models trace to Artificial Analysis. The GDPval-AA Elo of 1500 for Grok 4.3 is xAI's largest single-benchmark gain — up 321 points from Grok 4.20's 1179 — and Opus 4.8's 1890 comes from Anthropic's own release; those two numbers are on the same GDPval-AA scale but were measured in different runs, so read the gap as directional, not a head-to-head. The SWE-bench Verified figures are Anthropic-reported for the Opus 4.8 launch; **I could not find an independently published SWE-bench Verified or ARC-AGI-2 score specifically for Grok 4.3**, so I've left those cells blank rather than fill them with a guess. If you see a Grok 4.3 ARC-AGI-2 number floating around, check whether it's actually a Grok 4 or 4.20 figure being recycled.
+
+The one place Grok 4.3 clearly wins is throughput. At **181.3 tokens per second** on xAI's API, it generates roughly 2.5x faster than the ~68 tok/s median for reasoning models in its tier. For agentic loops that make dozens of model calls per task, that speed compounds.
+
+---
+
+## What Are the Specs — Context, Output, Modalities?
+
+| Spec | Grok 4.20 (prior) | Grok 4.3 | What It Enables |
+|------|-------------------|----------|-----------------|
+| Context Window | 2M | **1M** | Long documents, full repos, multi-step agent state |
+| Max Output | — | **No fixed output cap** | Long reports, full code modules in one pass |
+| Reasoning | Optional | **Always-on (default)** | No toggle to forget; model self-calibrates depth |
+| Input modalities | Text, image | **Text, image, video** | Native video frames, no transcription step |
+
+One wrinkle worth flagging: Grok 4.3's context window is listed at 1M tokens, which is actually *smaller* than the 2M that the Grok 4.x line previously advertised. xAI appears to have traded raw window size for a cheaper, faster, reasoning-by-default model. For most real workloads 1M is plenty — it's roughly 750K words — but if you were genuinely using 2M-token prompts, that's a regression to plan around.
+
+There's also tiered pricing inside that window: past 200K tokens in a single request, the per-token cost doubles. So the 1M window is there when you need it, but the economics nudge you to keep typical requests under 200K.
+
+---
+
+## What Does Grok 4.3 Cost?
+
+This is the part that actually matters.
+
+| Model | Input / 1M | Output / 1M | Cached input / 1M | AA Index |
+|-------|-----------|-------------|-------------------|----------|
+| **Grok 4.3** | **$1.25** | **$2.50** | **$0.20** | 53 |
+| Claude Opus 4.8 | $5.00 | $25.00 | — | 61.4 |
+| Gemini 3.1 Pro | (higher tier) | (higher tier) | — | ~57 |
+| GPT-5.5 | (higher tier) | (higher tier) | — | 60.2 |
+
+Look at the output column. Grok 4.3 charges **$2.50 per million output tokens** against Opus 4.8's $25 — a 10x difference. On input it's $1.25 versus $5, a 4x difference. Cached input drops to $0.20, an 84% discount off the standard input rate.
+
+Artificial Analysis put a concrete number on this: it costs roughly **$395 to run the full Intelligence Index suite on Grok 4.3**, about 20% cheaper than the prior Grok generation despite the new model using more output tokens (reasoning is always on now). That's the price/intelligence story in one figure — you pay less to get a model that thinks harder.
+
+The trade is explicit. You're buying a model that sits ~8 points below the leader on the composite index, and paying a fraction of the price for it. For a large class of production workloads — high-volume classification, summarization, agentic tool loops, draft generation — that 8-point gap is invisible and the 10x output savings is not.
+
+---
+
+## What Changed vs Grok 4.20?
+
+If you're coming from the previous Grok generation, here's the delta:
+
+| Dimension | Grok 4.20 | Grok 4.3 | Direction |
+|-----------|-----------|----------|-----------|
+| AA Intelligence Index | lower | **53** | Up |
+| GDPval-AA Elo | 1179 | **1500** | +321 |
+| Input price | ~$2 (est.) | **$1.25** | ~40% cut |
+| Output price | higher | **$2.50** | ~60% cut |
+| Context window | 2M | **1M** | Down |
+| Reasoning | Optional | **Always-on** | Default-on |
+| Video input | No | **Yes** | New |
+| Voice cloning | No | **Custom Voices suite** | New |
+
+The pattern is consistent: cheaper, faster, smarter on the composite — but with a smaller context window and reasoning you can no longer turn off. The GDPval-AA jump is the standout. GDPval-AA measures economically valuable, real-world task performance, and a 321-point Elo gain there is more meaningful for actual work than a fractional move on an academic benchmark.
+
+The new modalities round it out. Native video input is a genuine first for the Grok API, and the Custom Voices suite — which can clone a voice from a reference clip as short as a couple of minutes, with a separate real-time voice agent endpoint billed around $0.05 per minute of speech-to-speech — opens a product surface that the text-only frontier models don't directly compete on.
+
+---
+
+## What Does It Mean for Builders?
+
+### For Developers
+
+The always-on reasoning change is the one to internalize. You no longer choose whether Grok reasons — it always does, and you're billed for those tokens at the output rate. That simplifies code (no reasoning flag to manage) but it means short, cheap calls are slightly more expensive than they used to be, because every call now carries some reasoning overhead. If you were routing trivial requests to Grok to save money, re-measure; the floor moved up a little.
+
+The 181 tok/s throughput is the developer-facing win. In an agent loop that makes 20–30 model calls to complete a task, latency per call dominates wall-clock time. A model that's 2.5x faster than the tier median turns a 90-second agent run into something closer to 40 seconds. For interactive agents and IDE assistants, that's the difference between usable and annoying.
+
+Watch the 200K-token pricing cliff. Architect your context assembly to stay under it for routine requests, and only spill into the 1M window — at double the per-token rate — when a task genuinely needs it.
+
+### For Content and Multimodal Creators
+
+Native video input is the new capability worth exploring. You can feed Grok 4.3 actual video frames — for summarizing footage, extracting structured data from screen recordings, or analyzing visual sequences — without a separate transcription or frame-extraction pipeline. That's a real workflow simplification if video is part of your input stack.
+
+The Custom Voices suite is the other lever. Cloning a voice from a short reference clip and driving real-time speech-to-speech opens narration, character voice, and conversational-agent use cases at a flat per-minute rate. It's a product surface the text-only labs don't sell directly.
+
+### For Cost-Conscious Production
+
+This is Grok 4.3's natural home. If you run high-volume inference — millions of tokens a day across classification, extraction, summarization, or agentic tool use — the 10x output savings versus Opus-tier models is the headline. The honest framing: route the 80% of traffic that doesn't need frontier reasoning to Grok 4.3, and reserve a premium model for the 20% that does. That split is exactly how a sane model-routing layer should work, and Grok 4.3 makes the cheap tier substantially more capable than it used to be.
+
+---
+
+## Where Does Grok 4.3 Sit in the June 2026 Landscape?
+
+| Capability | Best Model | Where Grok 4.3 Lands |
+|------------|-----------|----------------------|
+| Composite intelligence | Claude Opus 4.8 (61.4) | 4th tier, 53 |
+| Real-world task value (GDPval-AA) | Claude Opus 4.8 (1890) | Strong gain to 1500 |
+| Coding (SWE-bench Verified) | Claude Opus 4.8 (88.6%) | Not independently published |
+| Output throughput | **Grok 4.3 (181 tok/s)** | Leader in its tier |
+| Price/intelligence | **Grok 4.3 ($1.25/$2.50)** | Leader |
+| Native video input | Grok 4.3 / Gemini | First for xAI API |
+
+The clean read: Grok 4.3 is not trying to be the smartest model in the room. Claude Opus 4.8 holds the Intelligence Index crown at 61.4, GPT-5.5 sits just behind at 60.2, and Gemini 3.1 Pro rounds out the top three. Grok 4.3's play is to deliver the *fourth-best* composite intelligence at *roughly the cheapest* frontier price, with the fastest output in its tier. For builders who treat models as a portfolio rather than a single bet, that's a useful slot to fill — and it's exactly the kind of routing decision I track in the [2026 models reference](/ai-ops/models-2026).
+
+For the model it's measured against, see the [Claude Opus 4.8 analysis](/blog/claude-opus-4-8-analysis-2026). For the other budget-frontier challenger that landed the same season, the [Microsoft MAI frontier models breakdown](/blog/microsoft-mai-frontier-models-2026) is the companion piece — both are bets that "good enough, much cheaper" beats "best, expensive" for most production work.
+
+---
+
+## FAQ
+
+### Is Grok 4.3 better than Claude Opus 4.8?
+
+No, not on raw intelligence. Opus 4.8 leads the Artificial Analysis Intelligence Index at 61.4 against Grok 4.3's 53, and Anthropic reports SWE-bench Verified at 88.6% for Opus 4.8. Where Grok 4.3 wins is price and speed: $1.25/$2.50 per million tokens versus Opus 4.8's $5/$25, and 181 tokens per second of output. For workloads where the 8-point intelligence gap doesn't change the outcome, Grok 4.3 is the better economic choice.
+
+### How much does Grok 4.3 cost?
+
+$1.25 per million input tokens and $2.50 per million output tokens, with cached input at $0.20 per million (an 84% discount). That's roughly a 40% input cut and 60% output cut versus the prior Grok generation. Note that requests over 200K tokens are billed at double the per-token rate.
+
+### What is Grok 4.3's context window?
+
+1 million tokens. That's actually smaller than the 2M the previous Grok 4.x line advertised — xAI traded window size for a cheaper, faster, reasoning-by-default model. There's no fixed output token cap, but the per-token price doubles past 200K tokens in a single request.
+
+### What's new in Grok 4.3 versus Grok 4.20?
+
+Always-on reasoning (the model thinks by default on every request), native video input (a first for the xAI API), the Custom Voices voice-cloning suite, a ~40–60% price cut, and a GDPval-AA Elo jump from 1179 to 1500. The main regression is the context window shrinking from 2M to 1M.
+
+### What is Grok 4.3 best for?
+
+High-volume, cost-sensitive production work: classification, extraction, summarization, and agentic tool loops where the 10x output-price savings versus premium models matters and an ~8-point intelligence gap doesn't. Its 181 tok/s throughput also makes it well-suited to latency-sensitive agents that make many model calls per task.
+
+### Does Grok 4.3 support video and voice?
+
+Yes. It's the first xAI API model to natively accept video input, processing frames through a vision encoder rather than transcription. Separately, xAI shipped Custom Voices — a voice-cloning API and creation suite — plus a real-time speech-to-speech voice agent endpoint billed at a flat per-minute rate.
+
+### Can I trust the benchmark numbers in this article?
+
+The Intelligence Index scores, GDPval-AA Elo, pricing, and throughput figures trace to Artificial Analysis and the vendor launch materials. I deliberately left SWE-bench Verified and ARC-AGI-2 cells blank for Grok 4.3 because I could not find independently published values specific to this model — older Grok 4 / 4.20 scores are sometimes recycled as if they were 4.3's, so treat any such number with suspicion unless it's clearly labeled.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently. Published June 5, 2026 with benchmarks from Artificial Analysis and xAI launch materials; vendor-claimed figures are labeled as such, and numbers I could not verify were left out.*

--- a/data/model-registry.json
+++ b/data/model-registry.json
@@ -1,17 +1,63 @@
 {
   "_description": "FrankX Frontier Model Registry - Single source of truth for all AI model data",
   "_version": "1.0.0",
-  "_updated": "2026-06-03",
+  "_updated": "2026-06-05",
   "_maintainer": "FrankX Intelligence Pipeline (/new-model command)",
 
   "models": {
+    "claude-opus-4-8": {
+      "name": "Claude Opus 4.8",
+      "id": "claude-opus-4-8",
+      "organization": "anthropic",
+      "family": "claude",
+      "released": "2026-05-28",
+      "status": "ga",
+      "architecture": "dense",
+      "context_window": 1000000,
+      "context_window_beta": 1000000,
+      "max_output_tokens": 128000,
+      "modalities": ["text", "vision", "code"],
+      "pricing": {
+        "input_per_1m": 5.0,
+        "output_per_1m": 25.0,
+        "fast_mode_input_per_1m": 10.0,
+        "fast_mode_output_per_1m": 50.0
+      },
+      "benchmarks": {
+        "swe_bench_verified": 88.6,
+        "swe_bench_pro": 69.2,
+        "terminal_bench_2_1": 74.6,
+        "gdpval_aa": 1890,
+        "osworld": 83.4,
+        "humanitys_last_exam_tools": 57.9,
+        "gpqa_diamond": 93.6,
+        "usamo_2026": 96.7
+      },
+      "key_capabilities": [
+        "Dynamic workflows in Claude Code (up to 1,000 subagents, 16 concurrent)",
+        "Effort control on claude.ai (defaults to high)",
+        "Fast mode at ~2.5x speed, 3x cheaper than prior fast modes",
+        "Mid-conversation system messages / real-time messages-array updates",
+        "Adaptive thinking with low/medium/high/xhigh/max effort levels",
+        "1M context at standard pricing (no long-context premium), 128K output"
+      ],
+      "acos_tier": "opus",
+      "frankx_notes": "A point release after 4.7 with no new breaking changes and unchanged $5/$25 pricing. Coding and knowledge-work numbers (SWE-Bench Pro 69.2%, GDPval-AA 1890) are well-corroborated; GPQA Diamond and the USAMO jump lean on Anthropic's own evals and should be treated as vendor-claimed until reproduced. The real upgrade is dynamic workflows plus a cheaper fast mode, not the benchmark deltas.",
+      "sources": [
+        "https://www.anthropic.com/news/claude-opus-4-8",
+        "https://artificialanalysis.ai/articles/claude-opus-4-8-analysis-and-benchmarks",
+        "https://llm-stats.com/models/claude-opus-4-8",
+        "https://thenewstack.io/claude-opus-48-release/",
+        "https://simonwillison.net/2026/May/28/claude-opus-4-8/"
+      ]
+    },
     "claude-opus-4-6": {
       "name": "Claude Opus 4.6",
       "id": "claude-opus-4-6",
       "organization": "anthropic",
       "family": "claude",
       "released": "2026-02-05",
-      "status": "ga",
+      "status": "superseded",
       "architecture": "dense",
       "context_window": 200000,
       "context_window_beta": 1000000,
@@ -102,6 +148,36 @@
       "acos_tier": "opus",
       "sources": ["https://www.anthropic.com/news/claude-opus-4-5"]
     },
+    "claude-sonnet-4-6": {
+      "name": "Claude Sonnet 4.6",
+      "id": "claude-sonnet-4-6",
+      "organization": "anthropic",
+      "family": "claude",
+      "released": "2026-02-17",
+      "status": "ga",
+      "architecture": "dense",
+      "context_window": 200000,
+      "context_window_beta": 1000000,
+      "max_output_tokens": 64000,
+      "modalities": ["text", "vision", "code"],
+      "pricing": {
+        "input_per_1m": 3.0,
+        "output_per_1m": 15.0
+      },
+      "key_capabilities": [
+        "Approaches Opus 4.6 capability at ~40% lower run cost",
+        "1M token context window (beta)",
+        "Full-skill upgrade: coding, computer use, agent planning, design",
+        "Default model on claude.ai free and Pro tiers"
+      ],
+      "acos_tier": "sonnet",
+      "frankx_notes": "The mid-tier that started eating the flagship's lunch — matches much of Opus 4.6 at $3/$15. The right default for production coding and content; route to Opus 4.8 only when the task genuinely needs it.",
+      "sources": [
+        "https://www.anthropic.com/news/claude-sonnet-4-6",
+        "https://techcrunch.com/2026/02/17/anthropic-releases-sonnet-4-6/",
+        "https://simonwillison.net/2026/Feb/17/claude-sonnet-46/"
+      ]
+    },
     "claude-sonnet-4-5": {
       "name": "Claude Sonnet 4.5",
       "id": "claude-sonnet-4-5-20250929",
@@ -138,13 +214,48 @@
       "acos_tier": "haiku",
       "sources": []
     },
+    "grok-4-3": {
+      "name": "Grok 4.3",
+      "id": "grok-4.3",
+      "organization": "xai",
+      "family": "grok",
+      "released": "2026-04-30",
+      "status": "ga",
+      "architecture": "dense",
+      "context_window": 1000000,
+      "modalities": ["text", "vision", "video"],
+      "pricing": {
+        "input_per_1m": 1.25,
+        "output_per_1m": 2.50,
+        "cached_input_per_1m": 0.20
+      },
+      "benchmarks": {
+        "aa_intelligence_index": 53,
+        "gdpval_aa": 1500,
+        "output_tokens_per_sec": 181.3
+      },
+      "key_capabilities": [
+        "Always-on reasoning by default",
+        "1M-token context window",
+        "Native video input (first for xAI API)",
+        "Custom Voices voice-cloning suite",
+        "Agentic tool use (web search, Python sandbox, PDF/Excel/PPTX generation)",
+        "Highest output throughput in its price tier (~181 tok/s)"
+      ],
+      "frankx_notes": "Not a benchmark leader — sits ~8 points below Claude Opus 4.8 on the AA Intelligence Index. The play is intelligence-per-dollar: ~10x cheaper output than Opus-tier with the fastest throughput in its class. Context window shrank from 2M to 1M, and reasoning can no longer be turned off. SWE-bench Verified / ARC-AGI-2 scores specific to 4.3 were not independently published, so they are omitted rather than recycled from older Grok versions.",
+      "sources": [
+        "https://artificialanalysis.ai/articles/xai-launches-grok-4-3-with-improved-agentic-performance-and-lower-pricing",
+        "https://docs.x.ai/developers/models/grok-4.3",
+        "https://venturebeat.com/technology/xai-launches-grok-4-3-at-an-aggressively-low-price-and-a-new-fast-powerful-voice-cloning-suite"
+      ]
+    },
     "grok-4-1": {
       "name": "Grok 4.1",
       "id": "grok-4.1",
       "organization": "xai",
       "family": "grok",
       "released": "2025-11-01",
-      "status": "ga",
+      "status": "superseded",
       "architecture": "dense",
       "context_window": 2000000,
       "modalities": ["text", "vision"],
@@ -154,13 +265,54 @@
       },
       "sources": ["https://x.ai/news/grok-4-1"]
     },
+    "gpt-5-5": {
+      "name": "GPT-5.5",
+      "id": "gpt-5.5",
+      "organization": "openai",
+      "family": "gpt",
+      "released": "2026-04-23",
+      "status": "ga",
+      "architecture": "dense",
+      "context_window": 1000000,
+      "max_output_tokens": 128000,
+      "modalities": ["text", "vision", "audio", "video"],
+      "pricing": {
+        "input_per_1m": 5.0,
+        "output_per_1m": 30.0,
+        "cached_input_per_1m": 0.5
+      },
+      "benchmarks": {
+        "gdpval": 84.9,
+        "osworld": 78.7,
+        "tau2_telecom": 98.0,
+        "terminal_bench_2": 82.7,
+        "long_context_512k_1m": 74.0,
+        "aime_2025": 93.6,
+        "swe_bench_pro": 58.6,
+        "gdpval_aa": 1769
+      },
+      "key_capabilities": [
+        "Long-horizon agentic autonomy (plan, tool-use, multi-step execution)",
+        "Strongest published computer-use scores (OSWorld 78.7%, Tau2 Telecom 98%)",
+        "Large long-context reasoning gain (512K-1M retrieval to 74%)",
+        "~40% better output-token efficiency vs GPT-5.4 (Artificial Analysis)",
+        "Drop-in API replacement for GPT-5.4 (same caching, tools, compaction)"
+      ],
+      "frankx_notes": "Codename 'Spud'. A real step forward on agentic and long-context metrics, and it holds a narrow terminal-agent edge, but not a clean frontier sweep — Claude Opus 4.8 leads GDPval-AA (1890 vs 1769) and SWE-Bench Pro (69.2 vs 58.6). Price doubled to $5/$30; the token-efficiency offset only pays off on output-heavy workloads. SWE-Bench Verified and ARC-AGI-2 headline figures vary by source and are omitted pending corroboration.",
+      "sources": [
+        "https://openai.com/index/introducing-gpt-5-5/",
+        "https://developers.openai.com/api/docs/models/gpt-5.5",
+        "https://www.vellum.ai/blog/everything-you-need-to-know-about-gpt-5-5",
+        "https://the-decoder.com/openai-unveils-gpt-5-5-claims-a-new-class-of-intelligence-at-double-the-api-price/"
+      ]
+    },
     "gpt-5-2-pro": {
       "name": "GPT-5.2 Pro",
       "id": "gpt-5.2-pro",
       "organization": "openai",
       "family": "gpt",
       "released": "2026-01-01",
-      "status": "ga",
+      "status": "superseded",
       "architecture": "dense",
       "context_window": 196000,
       "modalities": ["text", "vision", "audio"],
@@ -170,13 +322,66 @@
       },
       "sources": []
     },
+    "gemini-3-5-flash": {
+      "name": "Gemini 3.5 Flash",
+      "id": "gemini-3-5-flash",
+      "organization": "google",
+      "family": "gemini",
+      "released": "2026-05-19",
+      "status": "ga",
+      "architecture": "dense",
+      "context_window": 1000000,
+      "max_output_tokens": 64000,
+      "modalities": ["text", "vision", "audio", "video"],
+      "pricing": {
+        "input_per_1m": 1.50,
+        "output_per_1m": 9.0
+      },
+      "benchmarks": {
+        "terminal_bench_2_1": 76.2,
+        "mcp_atlas": 83.6,
+        "gdpval_aa": 1656
+      },
+      "key_capabilities": [
+        "Frontier agentic coding at sub-flagship economics",
+        "1M token context window",
+        "MCP-native tool use (83.6% MCP Atlas)",
+        "Full multimodal: text, vision, audio, video"
+      ],
+      "frankx_notes": "The one Google actually shipped at the 3.5 line. Beats the prior Gemini 3.1 Pro tier on agentic coding (Terminal-Bench 2.1 76.2%) at Flash pricing — the new default agent runtime. Gemini 3.5 Pro remains in limited preview as of June 2026.",
+      "sources": [
+        "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/",
+        "https://deepmind.google/models/model-cards/gemini-3-5-flash/",
+        "https://llm-stats.com/blog/research/gemini-3.5-flash-launch"
+      ]
+    },
+    "gemini-3-5-pro": {
+      "name": "Gemini 3.5 Pro",
+      "id": "gemini-3-5-pro",
+      "organization": "google",
+      "family": "gemini",
+      "status": "preview",
+      "architecture": "dense",
+      "modalities": ["text", "vision", "audio", "video"],
+      "key_capabilities": [
+        "Deep Think reasoning (vendor-stated)",
+        "Targeted 2M-token context window (vendor-stated)",
+        "Frontier multimodal: text/image/audio/video/PDF",
+        "Positioned as Google's strongest agentic + coding model (vendor-stated)"
+      ],
+      "frankx_notes": "Not GA as of June 5, 2026 — limited Vertex preview only, no model card, no benchmarks, no pricing. Announced at I/O May 19, 2026; GA targeted for June. Model id gemini-3.5-pro. Its real differentiation will need to show on hard reasoning (ARC-AGI-2, SWE-bench Pro) and 2M context. Do not architect on it until GA.",
+      "sources": [
+        "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/",
+        "https://deepmind.google/models/gemini/"
+      ]
+    },
     "gemini-3-pro": {
       "name": "Gemini 3 Pro",
       "id": "gemini-3-pro",
       "organization": "google",
       "family": "gemini",
       "released": "2025-12-01",
-      "status": "ga",
+      "status": "superseded",
       "architecture": "dense",
       "context_window": 2000000,
       "modalities": ["text", "vision", "audio", "video"],
@@ -271,22 +476,22 @@
     "anthropic": {
       "name": "Anthropic",
       "url": "https://anthropic.com",
-      "models": ["claude-opus-4-6", "claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"]
+      "models": ["claude-opus-4-8", "claude-opus-4-6", "claude-opus-4-5", "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"]
     },
     "openai": {
       "name": "OpenAI",
       "url": "https://openai.com",
-      "models": ["gpt-5-2-pro"]
+      "models": ["gpt-5-5", "gpt-5-2-pro"]
     },
     "google": {
       "name": "Google DeepMind",
       "url": "https://deepmind.google",
-      "models": ["gemini-3-pro"]
+      "models": ["gemini-3-5-pro", "gemini-3-5-flash", "gemini-3-pro"]
     },
     "xai": {
       "name": "xAI",
       "url": "https://x.ai",
-      "models": ["grok-4-1"]
+      "models": ["grok-4-3", "grok-4-1"]
     },
     "meta": {
       "name": "Meta AI",
@@ -302,10 +507,10 @@
 
   "acos_routing": {
     "note": "Maps registry models to ACOS routing tiers",
-    "opus": "claude-opus-4-6",
-    "sonnet": "claude-sonnet-4-5",
+    "opus": "claude-opus-4-8",
+    "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5"
   },
 
-  "last_updated": "2026-06-03"
+  "last_updated": "2026-06-05"
 }

--- a/data/route-index.json
+++ b/data/route-index.json
@@ -1,15 +1,15 @@
 {
   "version": "1.0",
   "stats": {
-    "total": 624,
-    "aliases": 18,
+    "total": 628,
+    "aliases": 19,
     "byType": {
       "core": 22,
-      "section": 343,
+      "section": 342,
       "community": 17,
       "tool": 10,
       "static": 15,
-      "blog": 135,
+      "blog": 140,
       "guide": 19,
       "library": 4,
       "newsletter": 1,
@@ -1190,6 +1190,20 @@
       "type": "blog"
     },
     {
+      "href": "/blog/claude-opus-4-8-analysis-2026",
+      "title": "Claude Opus 4.8: A Modest Bump That Quietly Tops the Leaderboard",
+      "description": "Anthropic's Opus 4.8 lands 41 days after 4.7 with the same $5/$25 pricing, SWE-Bench Pro 69.2%, GDPval-AA 1890, dynamic workflows, and cheaper fast mode. Technical breakdown with verified benchmarks, what changed, and what it means for builders.",
+      "tags": [
+        "anthropic",
+        "claude",
+        "frontier-models",
+        "ai-2026",
+        "benchmarks",
+        "agentic-ai"
+      ],
+      "type": "blog"
+    },
+    {
       "href": "/blog/conscious-ai-for-entrepreneurs",
       "title": "The Thoughtful Entrepreneur's Guide to Building AI-Powered Businesses That Actually Serve Humanity",
       "description": "How to build AI-powered businesses that create genuine value, foster human connection, and generate sustainable profits — without losing quality or ethics.",
@@ -1430,6 +1444,20 @@
       "type": "blog"
     },
     {
+      "href": "/blog/gemini-3-5-pro-analysis-2026",
+      "title": "Gemini 3.5 Pro: What We Actually Know Before GA",
+      "description": "Gemini 3.5 Pro is still in limited Vertex preview as of June 2026 — no model card, no benchmarks, no pricing. Here's the verifiable picture: what Flash already proved, what Google has committed to, and what to wait for at GA.",
+      "tags": [
+        "google",
+        "gemini",
+        "frontier-models",
+        "ai-2026",
+        "benchmarks",
+        "multimodal"
+      ],
+      "type": "blog"
+    },
+    {
       "href": "/blog/gencreator-3-tier-shipping-system",
       "title": "The 3-Tier Shipping System: How GenCreators Build Creative Momentum",
       "description": "Full Ship, Quick Ship, Micro Ship — energy-aware daily output. The system that turns sporadic creation into unstoppable momentum.",
@@ -1516,6 +1544,34 @@
         "Flow",
         "Antigravity",
         "AI Strategy"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/gpt-5-5-analysis-2026",
+      "title": "GPT-5.5 (\"Spud\"): What Actually Changed and Why It Matters",
+      "description": "OpenAI's GPT-5.5 leads GDPval at 84.9%, OSWorld at 78.7%, and Tau2 Telecom at 98% — at double the price of GPT-5.4. Technical breakdown with verified benchmarks, pricing, and what it means for builders.",
+      "tags": [
+        "openai",
+        "gpt-5-5",
+        "frontier-models",
+        "ai-2026",
+        "benchmarks",
+        "agentic-ai"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/grok-4-3-analysis-2026",
+      "title": "Grok 4.3: xAI Trades the Crown for the Price Tag",
+      "description": "xAI's Grok 4.3 scores 53 on the Artificial Analysis Intelligence Index, lifts GDPval-AA to 1500 Elo, ships a 1M context window with always-on reasoning, and cuts price ~40% to $1.25/$2.50. Technical breakdown with verified benchmarks and what it means for builders.",
+      "tags": [
+        "xai",
+        "grok",
+        "frontier-models",
+        "ai-2026",
+        "benchmarks",
+        "agentic-ai"
       ],
       "type": "blog"
     },
@@ -1685,6 +1741,19 @@
         "ifs",
         "self-led ai",
         "agent architecture"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/microsoft-mai-frontier-models-2026",
+      "title": "Microsoft's 7 MAI Models: The In-House Frontier Bet",
+      "description": "Microsoft AI launched 7 self-built MAI models — Thinking-1, Image-2.5, Code-1-Flash and more — on its own MAIA silicon. What the vendor claims, what's verifiable, and what it means for builders.",
+      "tags": [
+        "microsoft",
+        "mai",
+        "frontier-models",
+        "ai-2026",
+        "benchmarks"
       ],
       "type": "blog"
     },
@@ -5776,16 +5845,6 @@
       "type": "workshop"
     },
     {
-      "href": "/workshops/ikigai/v1",
-      "title": "V1",
-      "tags": [
-        "workshops",
-        "ikigai",
-        "v1"
-      ],
-      "type": "section"
-    },
-    {
       "href": "/workshops/personal-ai-coe",
       "title": "Personal AI Center of Excellence",
       "tags": [
@@ -5862,6 +5921,7 @@
     "/sovereign-leadership": "/workshops/sovereign-leadership",
     "/workshops/ikigai": "/workshops/ikigai-branding",
     "/workshops/ikigai-branding/present/speaker": "/workshops/ikigai-branding/present",
+    "/workshops/ikigai/v1": "/workshops/ikigai-branding",
     "/workshops/ikigai/v2": "/workshops/ikigai-branding",
     "/workshops/ikigai/v3": "/workshops/ikigai-branding",
     "/workshops/ikigai/v4": "/workshops/ikigai-branding"

--- a/lib/llm-hub/editorial.ts
+++ b/lib/llm-hub/editorial.ts
@@ -36,9 +36,14 @@ export const MODEL_EDITORIAL: Record<string, ModelEditorial> = {
     openrouterId: 'google/gemini-3.5-flash',
   },
   'gemini-3-5-pro': {
-    tagline: 'Google’s top reasoning tier — the Flash counterpart for the heaviest work.',
-    bestFor: ['Complex reasoning across the widest modality set', 'Tasks where Flash hits its ceiling'],
-    watchOut: 'In testing as of I/O ’26 — full benchmarks land at GA (mid-June 2026).',
+    tagline: 'Google’s top reasoning tier — announced, not yet shipped. Verdict pending GA.',
+    bestFor: [
+      'Hard reasoning where Flash hits its ceiling (once GA)',
+      'Workloads needing 2M context across the widest modality set (targeted)',
+      'Heavy video/audio multimodal reasoning',
+    ],
+    watchOut: 'Still in limited Vertex preview as of June 5, 2026 — no model card, no benchmarks, no pricing. GA targeted for June. Build on Gemini 3.5 Flash in the meantime.',
+    creatorUse: 'The one to watch for agentic video/multimodal pipelines once GA confirms Deep Think numbers. For now, route creator agent work to Gemini 3.5 Flash.',
     openrouterId: 'google/gemini-3.5-pro',
   },
   'gemini-omni': {
@@ -74,8 +79,26 @@ export const MODEL_EDITORIAL: Record<string, ModelEditorial> = {
     watchOut: 'Vendor-claimed 51% SWE-Bench Pro. Benchmark size ≠ how it feels on your repo — pilot before adopting.',
     creatorUse: 'Cheap, fast in-editor help; route real architecture work to a frontier model.',
   },
+  'claude-opus-4-8': {
+    tagline: 'Modest version bump, real frontier gains — tops the intelligence index at the same price as 4.7.',
+    bestFor: [
+      'Hard agentic coding and codebase-scale migrations',
+      'Long-horizon autonomous work with a clear up-front spec',
+      'Economically valuable knowledge work (leads GDPval-AA at 1890)',
+    ],
+    watchOut: 'Loses Terminal-Bench 2.1 to GPT-5.5; narrates more and asks more by default than 4.7, so prompts may need re-tuning. GPQA/USAMO numbers are vendor-claimed.',
+    creatorUse: 'Single-pass long-form drafts (128K output) and full-archive synthesis (1M context). Re-baseline any style prompts written against 4.7’s clipped voice — 4.8 is warmer by default.',
+    openrouterId: 'anthropic/claude-opus-4.8',
+  },
+  'claude-sonnet-4-6': {
+    tagline: 'The mid-tier that started eating the flagship’s lunch — most of Opus 4.6 at $3/$15.',
+    bestFor: ['Production coding and integrations', 'Content generation at scale', '1M-context work without flagship pricing'],
+    watchOut: 'For the hardest reasoning and agentic-coding tasks, Opus 4.8 still pulls ahead.',
+    creatorUse: 'The reliable default for content-engine workflows — route to Opus 4.8 only when the task earns it.',
+    openrouterId: 'anthropic/claude-sonnet-4.6',
+  },
   'claude-opus-4-6': {
-    tagline: 'The reasoning + long-context flagship. THE model for high-stakes synthesis.',
+    tagline: 'Previous reasoning + long-context flagship — superseded by Opus 4.8.',
     bestFor: [
       'Abstract reasoning (#1 ARC-AGI-2, 68.8%)',
       'Computer-use agents (#1 OSWorld, 72.7%)',
@@ -102,20 +125,42 @@ export const MODEL_EDITORIAL: Record<string, ModelEditorial> = {
     bestFor: ['Routing and classification', 'Real-time chat', 'High-volume metadata tagging'],
     openrouterId: 'anthropic/claude-haiku-4.5',
   },
+  'grok-4-3': {
+    tagline: 'Fourth-best frontier intelligence at roughly the cheapest frontier price, with the fastest output in its tier.',
+    bestFor: [
+      'High-volume cost-sensitive inference (classification, extraction, summarization)',
+      'Latency-sensitive agentic tool loops',
+      'Native video-input and voice-cloning workflows',
+    ],
+    watchOut: 'Context window dropped 2M → 1M; per-token price doubles past 200K tokens in a single request; reasoning is always-on so trivial calls cost slightly more.',
+    creatorUse: 'Native video input removes a transcription step for footage analysis; Custom Voices enables narration and conversational agents at a flat per-minute rate.',
+    openrouterId: 'x-ai/grok-4.3',
+  },
   'grok-4-1': {
-    tagline: 'Top human-preference Elo with 2M context and aggressive pricing.',
-    bestFor: ['Long-context reasoning', 'Real-time / X-grounded tasks', 'Cost-conscious 2M-context workloads'],
+    tagline: 'Previous Grok flagship — 2M context, superseded by Grok 4.3.',
+    bestFor: ['Workloads not yet migrated to 4.3', '2M-context tasks (4.3 dropped to 1M)'],
     openrouterId: 'x-ai/grok-4.1',
   },
+  'gpt-5-5': {
+    tagline: 'OpenAI’s agentic flagship: best-in-class computer-use and knowledge-work scores, at double the price.',
+    bestFor: [
+      'Terminal-agent and Codex-style autonomous loops',
+      'Computer-use / OSWorld automation',
+      'Long-context reasoning over large codebases and corpora',
+    ],
+    watchOut: 'Output is $30/1M and the published 1M context can shrink in practice (~258K reported in Codex). The 2x price only pays off if your workload is output-heavy enough to capture the ~40% token-efficiency savings. Trails Opus 4.8 on GDPval-AA and SWE-Bench Pro.',
+    creatorUse: 'Strong for multi-step agentic pipelines and long-document synthesis; for real-time voice use the separate gpt-realtime-2 family, not GPT-5.5 directly.',
+    openrouterId: 'openai/gpt-5.5',
+  },
   'gpt-5-2-pro': {
-    tagline: 'Broadest multimodal + native voice — the general-purpose default.',
-    bestFor: ['Native voice applications', 'Broad multimodal reasoning', 'Widest enterprise integration footprint'],
-    watchOut: 'Reasoning benchmarks trail Opus 4.6 on ARC-AGI-2.',
+    tagline: 'Previous OpenAI flagship — superseded by GPT-5.5.',
+    bestFor: ['Workloads not yet migrated to GPT-5.5', 'Broad multimodal reasoning'],
+    watchOut: 'Reasoning benchmarks trail current-generation flagships.',
     openrouterId: 'openai/gpt-5.2-pro',
   },
   'gemini-3-pro': {
-    tagline: 'Widest modality support with 2M native context.',
-    bestFor: ['Multimodal understanding (81% MMMU-Pro)', 'Video + audio + vision reasoning', '2M-context tasks'],
+    tagline: 'Prior Gemini Pro tier — superseded by the Gemini 3.5 line (Flash GA, Pro in preview).',
+    bestFor: ['Workloads not yet migrated to Gemini 3.5', '2M-context multimodal tasks'],
     openrouterId: 'google/gemini-3-pro',
   },
   'llama-4-maverick': {

--- a/public/images/blog/claude-opus-4-8-analysis-2026-hero.svg
+++ b/public/images/blog/claude-opus-4-8-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7C3AED" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#C4B5FD" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#7C3AED" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#7C3AED" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#C4B5FD" /><stop offset="1" stop-color="#7C3AED" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="156" height="36" rx="18" fill="#7C3AED" fill-opacity="0.18" stroke="#7C3AED" stroke-opacity="0.5" />
+    <text x="268" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#C4B5FD" text-anchor="middle">ANTHROPIC</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Claude Opus 4.8</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Flagship reasoning + coding — tops the intelligence index at unchanged $5/$25</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#7C3AED" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">69.2%</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">SWE-Bench Pro</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">1890</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">GDPval-AA Elo</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">1M</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Context window</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$5/$25</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">per 1M tokens</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via Anthropic, Artificial Analysis, llm-stats</text>
+  </g>
+</svg>

--- a/public/images/blog/gemini-3-5-pro-analysis-2026-hero.svg
+++ b/public/images/blog/gemini-3-5-pro-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2563EB" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#93C5FD" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#3B82F6" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#3B82F6" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#93C5FD" /><stop offset="1" stop-color="#2563EB" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="228" height="36" rx="18" fill="#2563EB" fill-opacity="0.18" stroke="#2563EB" stroke-opacity="0.5" />
+    <text x="304" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#93C5FD" text-anchor="middle">GOOGLE DEEPMIND</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Gemini 3.5 Pro</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Google’s top reasoning tier — announced at I/O, GA targeted June 2026</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#2563EB" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">Preview</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Vertex limited</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">2M</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Context (target)</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">Deep Think</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Reasoning mode</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">TBD</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Benchmarks at GA</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Pre-GA brief — no measured benchmarks yet</text>
+  </g>
+</svg>

--- a/public/images/blog/gpt-5-5-analysis-2026-hero.svg
+++ b/public/images/blog/gpt-5-5-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#059669" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#6EE7B7" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#10B981" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#10B981" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6EE7B7" /><stop offset="1" stop-color="#059669" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="150" height="36" rx="18" fill="#059669" fill-opacity="0.18" stroke="#059669" stroke-opacity="0.5" />
+    <text x="265" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#6EE7B7" text-anchor="middle">OPENAI</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">GPT-5.5</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Agentic flagship "Spud" — best published computer-use scores, at double the price</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#059669" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">84.9%</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">GDPval</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">78.7%</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">OSWorld</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">98%</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Tau2 Telecom</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$5/$30</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">per 1M tokens</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via OpenAI, Artificial Analysis, Vellum</text>
+  </g>
+</svg>

--- a/public/images/blog/grok-4-3-analysis-2026-hero.svg
+++ b/public/images/blog/grok-4-3-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#DC2626" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#FCA5A5" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#EF4444" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#EF4444" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FCA5A5" /><stop offset="1" stop-color="#DC2626" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="150" height="36" rx="18" fill="#DC2626" fill-opacity="0.18" stroke="#DC2626" stroke-opacity="0.5" />
+    <text x="265" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#FCA5A5" text-anchor="middle">XAI</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Grok 4.3</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Budget frontier — fourth-best intelligence at the cheapest frontier price</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#DC2626" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">53</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">AA Intelligence</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">1500</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">GDPval-AA Elo</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">181 t/s</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Output speed</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$1.25/$2.50</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">per 1M tokens</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via Artificial Analysis, xAI docs</text>
+  </g>
+</svg>

--- a/scripts/visuals/generate-model-hero.mjs
+++ b/scripts/visuals/generate-model-hero.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Model Hero SVG generator — on-brand "Intelligence Dispatch" card heroes for
+ * frontier-model deep-dive articles.
+ *
+ * House style mirrors public/images/blog/microsoft-mai-models-2026-hero.svg:
+ * a dark layered-gradient panel, an org badge pill, the model name, a subtitle,
+ * a row of stat tiles (spec/benchmark), a per-vendor accent color, and a FrankX
+ * dispatch footer. Deterministic, textful, no external API — safe and reproducible.
+ *
+ * Usage:
+ *   node scripts/visuals/generate-model-hero.mjs            # write all CONFIGS
+ *   node scripts/visuals/generate-model-hero.mjs <slug>     # write one
+ */
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..')
+const OUT_DIR = join(ROOT, 'public', 'images', 'blog')
+
+const W = 1600
+const H = 900
+
+function esc(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&#8217;')
+}
+
+/**
+ * @param {{
+ *   slug: string, org: string, name: string, subtitle: string,
+ *   accentFrom: string, accentTo: string, glowHex: string,
+ *   tiles: {label:string, value:string}[],   // 3 or 4
+ *   footer: string
+ * }} c
+ */
+function buildHeroSVG(c) {
+  const tiles = c.tiles.slice(0, 4)
+  const n = tiles.length
+  const gap = 24
+  const left = 190
+  const right = 1410
+  const span = right - left
+  const tileW = (span - gap * (n - 1)) / n
+  const tileY = 470
+  const tileH = 250
+
+  const tileMarkup = tiles
+    .map((t, i) => {
+      const x = left + i * (tileW + gap)
+      return `
+    <rect x="${x.toFixed(0)}" y="${tileY}" width="${tileW.toFixed(0)}" height="${tileH}" rx="24" fill="url(#tile)" stroke="${i === 0 ? c.accentTo : '#1E2E51'}" stroke-opacity="${i === 0 ? 0.7 : 0.6}" />
+    <rect x="${(x + 28).toFixed(0)}" y="${tileY + 30}" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="${(x + 28).toFixed(0)}" y="${tileY + 138}" font-size="52" font-weight="800" fill="#FFFFFF">${esc(t.value)}</text>
+    <text x="${(x + 28).toFixed(0)}" y="${tileY + 188}" font-size="19" font-weight="500" fill="#8FA6C4">${esc(t.label)}</text>`
+    })
+    .join('')
+
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="${c.accentTo}" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="${c.accentFrom}" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="${c.glowHex}" stop-opacity="0.42" />
+      <stop offset="1" stop-color="${c.glowHex}" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="${c.accentFrom}" /><stop offset="1" stop-color="${c.accentTo}" />
+    </linearGradient>
+  </defs>
+
+  <rect width="${W}" height="${H}" fill="url(#bg)" />
+  <rect width="${W}" height="${H}" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="${Math.max(150, c.org.length * 12 + 48)}" height="36" rx="18" fill="${c.accentTo}" fill-opacity="0.18" stroke="${c.accentTo}" stroke-opacity="0.5" />
+    <text x="${190 + Math.max(150, c.org.length * 12 + 48) / 2}" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="${c.accentFrom}" text-anchor="middle">${esc(c.org.toUpperCase())}</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">${esc(c.name)}</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">${esc(c.subtitle)}</text>
+${tileMarkup}
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">${esc(c.footer)}</text>
+  </g>
+</svg>
+`
+}
+
+// ---- per-vendor palettes -------------------------------------------------
+const PALETTE = {
+  anthropic: { accentFrom: '#C4B5FD', accentTo: '#7C3AED', glowHex: '#7C3AED' },
+  openai: { accentFrom: '#6EE7B7', accentTo: '#059669', glowHex: '#10B981' },
+  google: { accentFrom: '#93C5FD', accentTo: '#2563EB', glowHex: '#3B82F6' },
+  xai: { accentFrom: '#FCA5A5', accentTo: '#DC2626', glowHex: '#EF4444' },
+  deepseek: { accentFrom: '#67E8F9', accentTo: '#0891B2', glowHex: '#06B6D4' },
+  alibaba: { accentFrom: '#FDBA74', accentTo: '#EA580C', glowHex: '#F97316' },
+  moonshot: { accentFrom: '#A5B4FC', accentTo: '#4F46E5', glowHex: '#6366F1' },
+  meta: { accentFrom: '#93C5FD', accentTo: '#1D4ED8', glowHex: '#3B82F6' },
+  mistral: { accentFrom: '#FDA4AF', accentTo: '#E11D48', glowHex: '#F43F5E' },
+}
+
+// ---- CONFIGS: filled with VERIFIED values from research ------------------
+// Stat tile values are populated after the per-model research returns so the
+// hero matches the article's cited numbers.
+const CONFIGS = [
+  {
+    slug: 'claude-opus-4-8-analysis-2026',
+    orgKey: 'anthropic',
+    org: 'Anthropic',
+    name: 'Claude Opus 4.8',
+    subtitle: 'Flagship reasoning + coding — tops the intelligence index at unchanged $5/$25',
+    tiles: [
+      { value: '69.2%', label: 'SWE-Bench Pro' },
+      { value: '1890', label: 'GDPval-AA Elo' },
+      { value: '1M', label: 'Context window' },
+      { value: '$5/$25', label: 'per 1M tokens' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via Anthropic, Artificial Analysis, llm-stats',
+  },
+  {
+    slug: 'gpt-5-5-analysis-2026',
+    orgKey: 'openai',
+    org: 'OpenAI',
+    name: 'GPT-5.5',
+    subtitle: 'Agentic flagship "Spud" — best published computer-use scores, at double the price',
+    tiles: [
+      { value: '84.9%', label: 'GDPval' },
+      { value: '78.7%', label: 'OSWorld' },
+      { value: '98%', label: 'Tau2 Telecom' },
+      { value: '$5/$30', label: 'per 1M tokens' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via OpenAI, Artificial Analysis, Vellum',
+  },
+  {
+    slug: 'gemini-3-5-pro-analysis-2026',
+    orgKey: 'google',
+    org: 'Google DeepMind',
+    name: 'Gemini 3.5 Pro',
+    subtitle: 'Google’s top reasoning tier — announced at I/O, GA targeted June 2026',
+    tiles: [
+      { value: 'Preview', label: 'Vertex limited' },
+      { value: '2M', label: 'Context (target)' },
+      { value: 'Deep Think', label: 'Reasoning mode' },
+      { value: 'TBD', label: 'Benchmarks at GA' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Pre-GA brief — no measured benchmarks yet',
+  },
+  {
+    slug: 'grok-4-3-analysis-2026',
+    orgKey: 'xai',
+    org: 'xAI',
+    name: 'Grok 4.3',
+    subtitle: 'Budget frontier — fourth-best intelligence at the cheapest frontier price',
+    tiles: [
+      { value: '53', label: 'AA Intelligence' },
+      { value: '1500', label: 'GDPval-AA Elo' },
+      { value: '181 t/s', label: 'Output speed' },
+      { value: '$1.25/$2.50', label: 'per 1M tokens' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via Artificial Analysis, xAI docs',
+  },
+]
+
+function write(c) {
+  const pal = PALETTE[c.orgKey] || PALETTE.anthropic
+  const svg = buildHeroSVG({ ...c, ...pal })
+  mkdirSync(OUT_DIR, { recursive: true })
+  const out = join(OUT_DIR, `${c.slug}-hero.svg`)
+  writeFileSync(out, svg)
+  console.log('wrote', out)
+}
+
+const only = process.argv[2]
+const list = only ? CONFIGS.filter((c) => c.slug === only) : CONFIGS
+if (!list.length) {
+  console.error(only ? `no config for slug "${only}"` : 'no CONFIGS defined')
+  process.exit(1)
+}
+list.forEach(write)
+
+export { buildHeroSVG, PALETTE }


### PR DESCRIPTION
## Phase 1 of 3 — Western flagships

Brings the model registry, LLM Hub editorial layer, and the `/ai-ops/models-2026` arena current to **June 5, 2026**, and ships four deep-dive analysis articles with on-brand hero art. This is the first of three phased PRs (see plan below).

Every benchmark traces to a cited source. Verified (independently reproduced) vs **vendor-claimed** numbers are distinguished throughout, per `content/blog/EDITORIAL_STANDARD.md`. No URLs renamed, no pages deleted — superseded models stay live with `status: superseded`.

### What shipped

**New deep-dive articles** (`content/blog/*-analysis-2026.mdx`) + hero SVGs:
| Model | Status found | Headline (verified) |
|---|---|---|
| **Claude Opus 4.8** (May 28) | GA | SWE-Bench Pro 69.2%, GDPval-AA 1890, tops intelligence index |
| **GPT-5.5** "Spud" (Apr 23) | GA | GDPval 84.9%, OSWorld 78.7%, Tau2 Telecom 98% — at 2× price |
| **Grok 4.3** (Apr 30) | GA | AA Intelligence 53, GDPval-AA 1500, ~181 tok/s, budget frontier |
| **Gemini 3.5 Pro** | **Preview** | Honest pre-GA brief — no published benchmarks/pricing yet |

> Research surfaced that **Gemini 3.5 Pro is not GA** (limited Vertex preview). Rather than invent numbers, the article is a pre-GA brief grounded in the shipped **Gemini 3.5 Flash** (now registered with real data) and competitor figures.

**Registry** (`data/model-registry.json`): added Opus 4.8, GPT-5.5, Grok 4.3, Gemini 3.5 Flash (GA), Gemini 3.5 Pro (preview), Claude Sonnet 4.6; marked Opus 4.6 / GPT-5.2 Pro / Gemini 3 Pro / Grok 4.1 superseded; updated org lists + `acos_routing` (opus→4.8, sonnet→4.6, haiku→4.5). This also resolves the previously **orphaned** editorial ids (`gemini-3-5-pro`, `gemini-3-5-flash`).

**Editorial** (`lib/llm-hub/editorial.ts`): verdicts for the new flagships; refreshed the orphaned Gemini 3.5 Pro entry to the honest pre-GA framing.

**Arena** (`app/ai-ops/models-2026/page.tsx`): refreshed frontier cards; rebuilt the benchmark table (Elo-vs-% aware, honest blank cells where no published pairing exists); refreshed pricing matrix, ACOS routing tier ids, hero CTAs, and validation dates.

**Tooling**: `scripts/visuals/generate-model-hero.mjs` — reusable, deterministic generator for the consistent "Intelligence Dispatch" hero style (reused in Phases 2–3).

### Verification
- `node -e require('./data/model-registry.json')` parses; no dangling org→model or `acos_routing` refs; all 17 models have editorial entries
- `npx tsc --noEmit` clean; `eslint` clean on touched files
- All four articles: TL;DR-first, FAQ ≥5, `schema:["Article","FAQPage"]`, hero exists on disk, internal links resolve; no banned voice terms
- `scripts/build-route-index.mjs` picks up the four new blog routes
- Heroes rasterized and visually checked

### Coming next
- **Phase 2:** DeepSeek V4, Qwen, Kimi (open-frontier labs) + articles
- **Phase 3:** OSS/local section (Gemma, Llama, Mistral, gpt-oss, Phi) + individual articles + roundup

https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum)_