### PR TITLE
June 2026 frontier model refresh — Phase 3 (open & local)

### DIFF
--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -373,7 +373,7 @@ export default function Models2026Page() {
                 >
                   <div className="flex items-start justify-between mb-3">
                     <div className="flex items-center gap-2">
-                      <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: m.color }} />
+                      <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: m.color }} aria-hidden="true" />
                       <h3 className="font-bold text-lg">{m.name}</h3>
                       {m.highlight && <span className="px-2 py-0.5 text-[10px] rounded-full bg-[#a855f7]/20 text-[#a855f7] font-medium uppercase tracking-wider">New</span>}
                     </div>
@@ -439,7 +439,7 @@ export default function Models2026Page() {
                   }`}
                 >
                   <div className="flex items-center gap-2 mb-3">
-                    <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: m.color }} />
+                    <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: m.color }} aria-hidden="true" />
                     <h3 className="font-bold">{m.name}</h3>
                   </div>
                   <p className="text-sm text-white/40 mb-1">{m.org}</p>
@@ -451,8 +451,8 @@ export default function Models2026Page() {
                     <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">License</dt><dd className="font-mono text-white/70 text-right">{m.license}</dd></div>
                     <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">Run via</dt><dd className="font-mono text-white/50 text-right">{m.runners}</dd></div>
                   </dl>
-                  <Link href={`/blog/${m.slug}`} className="mt-4 inline-flex items-center gap-1.5 text-xs text-white/50 hover:text-white transition-colors">
-                    Deep dive <ArrowUpRight className="w-3.5 h-3.5" />
+                  <Link href={`/blog/${m.slug}`} className="mt-4 inline-flex items-center gap-1.5 text-xs text-white/50 hover:text-white transition-colors" aria-label={`Deep dive into ${m.name}`}>
+                    Deep dive <ArrowUpRight className="w-3.5 h-3.5" aria-hidden="true" />
                   </Link>
                 </motion.div>
               ))}

--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -225,6 +225,76 @@ const externalResources = [
   { name: 'SEAL Leaderboards', url: 'https://scale.com/leaderboard', description: 'Scale AI expert evaluations across enterprise tasks' },
 ]
 
+// Run-it-yourself models — the open & local lane. Pricing is $0 (open weights);
+// the real costs are hardware + license terms, so this grid leads with VRAM and license.
+const openLocalModels = [
+  {
+    name: 'Gemma 4',
+    org: 'Google',
+    params: '31B dense (+ 26B MoE, 12B, edge tiers)',
+    minVram: '~18GB Q4 (31B) · ~2GB (E2B)',
+    context: '256K',
+    license: 'Apache 2.0',
+    runners: 'Ollama · LM Studio · vLLM · HF',
+    achievement: 'Frontier-tier quality on one consumer GPU; native multimodal',
+    color: '#22c55e',
+    slug: 'gemma-3-analysis-2026',
+    highlight: true,
+  },
+  {
+    name: 'gpt-oss (120b / 20b)',
+    org: 'OpenAI',
+    params: '120B/5.1B · 20B/3.6B (MoE)',
+    minVram: '~80GB (120b) · ~16GB (20b)',
+    context: '131K',
+    license: 'Apache 2.0',
+    runners: 'Ollama · vLLM · LM Studio',
+    achievement: 'Best reasoning-per-VRAM open option; MLPerf v6.0 benchmark',
+    color: '#10b981',
+    slug: 'gpt-oss-analysis-2026',
+    highlight: false,
+  },
+  {
+    name: 'Mistral Large 3',
+    org: 'Mistral AI',
+    params: '675B/41B (MoE)',
+    minVram: '8×H200 (FP8) · or $0.50/1M API',
+    context: '256K',
+    license: 'Apache 2.0',
+    runners: 'vLLM · SGLang · Red Hat AI',
+    achievement: 'EU-sovereign open frontier; #2 OSS on LMArena (~1418)',
+    color: '#fb7185',
+    slug: 'mistral-large-3-analysis-2026',
+    highlight: false,
+  },
+  {
+    name: 'Llama 4 Maverick',
+    org: 'Meta',
+    params: '400B/17B (MoE) · Scout 109B/17B',
+    minVram: '8×H100 (Maverick) · 1×H100 (Scout)',
+    context: '1M · 10M (Scout)',
+    license: 'Llama Community',
+    runners: 'vLLM · Ollama (Scout) · HF',
+    achievement: 'Native multimodal MoE; permissive license, 10M-ctx Scout',
+    color: '#f59e0b',
+    slug: 'llama-4-analysis-2026',
+    highlight: false,
+  },
+  {
+    name: 'Microsoft Phi-4',
+    org: 'Microsoft',
+    params: '3.8B – 15B tiers',
+    minVram: '~3-4GB (mini) · ~8-10GB (14B Q4)',
+    context: '16K – 128K',
+    license: 'MIT',
+    runners: 'Ollama · ONNX · LM Studio · llama.cpp',
+    achievement: 'Laptop-class STEM specialist; 14B beats GPT-4o on GPQA/MATH',
+    color: '#0078d4',
+    slug: 'phi-analysis-2026',
+    highlight: false,
+  },
+]
+
 const ociModels = [
   { name: 'Cohere Command A Reasoning', provider: 'Cohere', context: '256K', useCase: 'Complex reasoning', eu: true },
   { name: 'Cohere Command A Vision', provider: 'Cohere', context: '256K', useCase: 'Multimodal', eu: true },
@@ -345,6 +415,51 @@ export default function Models2026Page() {
                 </motion.div>
               ))}
             </div>
+          </div>
+        </section>
+
+        {/* Open & Local Models */}
+        <section className="py-16 px-6 border-t border-white/5">
+          <div className="max-w-6xl mx-auto">
+            <h2 className="text-2xl font-bold mb-2">Open &amp; Local Models</h2>
+            <p className="text-white/40 text-sm mb-8">
+              Run-it-yourself, open-weight models. Pricing is $0 per token — the real costs are hardware and license terms, so these lead with VRAM and license.
+              DeepSeek V4 and Kimi K2.6 (in the frontier grid above) are also open-weight and self-hostable.
+            </p>
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {openLocalModels.map((m, i) => (
+                <motion.div
+                  key={m.name}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: i * 0.04 }}
+                  className={`p-5 rounded-xl border transition-colors ${
+                    m.highlight ? 'bg-[#22c55e]/[0.04] border-[#22c55e]/20 hover:border-[#22c55e]/40' : 'bg-white/[0.02] border-white/5 hover:border-white/10'
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-3">
+                    <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: m.color }} />
+                    <h3 className="font-bold">{m.name}</h3>
+                  </div>
+                  <p className="text-sm text-white/40 mb-1">{m.org}</p>
+                  <p className="text-sm text-white/60 mb-4">{m.achievement}</p>
+                  <dl className="space-y-1.5 text-xs">
+                    <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">Params</dt><dd className="font-mono text-white/70 text-right">{m.params}</dd></div>
+                    <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">Min VRAM</dt><dd className="font-mono text-white/70 text-right">{m.minVram}</dd></div>
+                    <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">Context</dt><dd className="font-mono text-white/70 text-right">{m.context}</dd></div>
+                    <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">License</dt><dd className="font-mono text-white/70 text-right">{m.license}</dd></div>
+                    <div className="flex justify-between gap-3"><dt className="text-white/30 uppercase tracking-wider">Run via</dt><dd className="font-mono text-white/50 text-right">{m.runners}</dd></div>
+                  </dl>
+                  <Link href={`/blog/${m.slug}`} className="mt-4 inline-flex items-center gap-1.5 text-xs text-white/50 hover:text-white transition-colors">
+                    Deep dive <ArrowUpRight className="w-3.5 h-3.5" />
+                  </Link>
+                </motion.div>
+              ))}
+            </div>
+            <p className="mt-6 text-sm text-white/40">
+              New to self-hosting? Start with the <Link href="/blog/best-open-local-llms-2026" className="text-[#22c55e] hover:underline">open &amp; local LLM field guide</Link> — which model for which hardware, and when self-host beats an API.
+            </p>
           </div>
         </section>
 

--- a/content/blog/best-open-local-llms-2026.mdx
+++ b/content/blog/best-open-local-llms-2026.mdx
@@ -1,0 +1,146 @@
+---
+title: "The Best Open & Local LLMs in 2026: A Self-Host Field Guide"
+description: "Which open-weight model for which hardware — Gemma 4, gpt-oss, Phi-4, Mistral Large 3, Llama 4, DeepSeek V4, and Kimi K2.6 compared by VRAM, license, and use case. When self-hosting beats an API, with verified benchmarks."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - open-source
+  - local-llm
+  - self-hosting
+  - frontier-models
+  - ai-2026
+keywords:
+  - best open source llm 2026
+  - best local llm 2026
+  - run llm locally
+  - open weight models 2026
+  - gemma 4 vs gpt-oss
+  - self host llm vram
+  - deepseek v4 self host
+  - apache 2.0 llm
+image: "/images/blog/best-open-local-llms-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# The Best Open & Local LLMs in 2026: A Self-Host Field Guide
+
+**TL;DR**: In June 2026 you can run genuinely capable models on your own hardware — from a 2GB edge model to a frontier-class 1.6-trillion-parameter MoE. The honest picture: **Gemma 4** (Apache 2.0) is the best quality-per-consumer-GPU pick, **gpt-oss** wins reasoning-per-VRAM, **Phi-4** is the laptop/edge specialist, **Mistral Large 3** is the EU-sovereign open frontier, **Llama 4** brings multimodality and a 10M-context sibling, and **DeepSeek V4** and **Kimi K2.6** are the open-weight models that get closest to the closed frontier. None of them dethrone Claude Opus 4.8 or GPT-5.5 — the reason to self-host is control, privacy, license terms, and cost at volume, not the top of the leaderboard. Here's which one to run, and on what.
+
+---
+
+## Why self-host at all in 2026?
+
+The closed frontier — [Claude Opus 4.8](/blog/claude-opus-4-8-analysis-2026), GPT-5.5, Gemini 3.5 — still leads on raw capability. So the case for open weights isn't "it's better." It's four concrete things:
+
+1. **Data control.** Prompts and outputs never leave your environment. For regulated work (healthcare, legal, finance) or anything under a data-residency mandate, that's not a nice-to-have.
+2. **License freedom.** Apache 2.0 and MIT weights can be fine-tuned, redistributed, and embedded in a commercial product with no per-token meter and no vendor lock-in.
+3. **Cost at volume.** Open weights aren't free inference — you pay for GPUs. But past a certain steady throughput, owning the hardware beats renting tokens.
+4. **Offline and edge.** A model that runs on a laptop or a single GPU works on a plane, in a SCIF, or on a factory floor with no connectivity.
+
+If none of those apply to your workload, route to a frontier API and move on. If one or more do, read on.
+
+---
+
+## The decision in one table
+
+| Model | Org | License | Params | Min VRAM (realistic) | Context | Best for |
+|-------|-----|---------|--------|----------------------|---------|----------|
+| **Phi-4** | Microsoft | MIT | 3.8B–15B | ~3-4GB (mini) → ~8-10GB (14B Q4) | 16K–128K | Laptops, edge, STEM/extraction |
+| **Gemma 4** | Google | Apache 2.0 | E2B → 31B | ~2GB → ~18GB Q4 (31B) | 256K | Best quality on one consumer GPU |
+| **gpt-oss** | OpenAI | Apache 2.0 | 20B / 120B (MoE) | ~16GB (20b) / ~80GB (120b) | 131K | Reasoning-per-VRAM on one card |
+| **Mistral Large 3** | Mistral AI | Apache 2.0 | 675B / 41B (MoE) | 8×H200 (FP8) | 256K | EU sovereignty, multilingual |
+| **Llama 4 Maverick** | Meta | Llama Community | 400B / 17B (MoE) | 8×H100 (Scout: 1×H100) | 1M (10M Scout) | Multimodal, permissive ecosystem |
+| **DeepSeek V4** | DeepSeek | MIT | 1.6T / 49B (Pro) | Data-center (Flash 284B self-hostable) | 1M | Max open coding capability |
+| **Kimi K2.6** | Moonshot | Modified MIT | 1T / 32B (MoE) | Data-center | 256K | Top open-weights intelligence |
+
+Numbers are cross-checked against vendor model cards and the neutral [Artificial Analysis](https://artificialanalysis.ai/) Intelligence Index; "Min VRAM" reflects realistic quantized self-host, not the theoretical floor. MoE "active params" is misleading for memory — you still need every expert resident, so size for total parameters.
+
+---
+
+## Pick by your hardware
+
+### A laptop (8–16GB)
+Run **Phi-4** (the 3.8B mini fits in ~3-4GB; the 14B at Q4 needs ~8-10GB), **gpt-oss-20b** (~16GB, and it reasons well above its size), or **Gemma 4's** 12B / E4B tiers. Phi-4 is the STEM and function-calling specialist; Gemma 4 12B adds native audio and vision; gpt-oss-20b is the strongest pure reasoner of the three. See the [Phi-4 deep dive](/blog/phi-analysis-2026) and the [Gemma 4 deep dive](/blog/gemma-3-analysis-2026).
+
+### One consumer GPU (24GB — 4090/5090)
+**Gemma 4 31B** at Q4 (~18GB) is the sweet spot: frontier-tier quality, native multimodal, Apache 2.0, on a card you can buy. This is the single best "serious work on my own machine" option in 2026.
+
+### One data-center GPU (80GB — H100/MI300X)
+**gpt-oss-120b** is purpose-built for this: MXFP4 quantization puts a near-o4-mini-class reasoner on a single 80GB card. **DeepSeek V4-Flash** (284B/13B) is the other strong single-node-ish option. Details in the [gpt-oss deep dive](/blog/gpt-oss-analysis-2026) and the [DeepSeek V4 deep dive](/blog/deepseek-v4-analysis-2026).
+
+### A multi-GPU node (8×H100 / 8×H200)
+This unlocks the big MoEs: **Mistral Large 3** (Apache 2.0, FP8 on one 8×H200 node), **Llama 4 Maverick**, **DeepSeek V4-Pro** (1.6T/49B), and **Kimi K2.6** (1T/32B). These are the open models that get closest to the closed frontier — at the cost of a real infrastructure project.
+
+---
+
+## Pick by your priority
+
+- **Privacy / offline / edge** → Phi-4, Gemma 4, gpt-oss-20b.
+- **EU data sovereignty** → [Mistral Large 3](/blog/mistral-large-3-analysis-2026): Apache 2.0, EU-resident endpoints, and a single-node FP8 self-host story built for GDPR.
+- **Maximum open capability (coding/agents)** → [DeepSeek V4](/blog/deepseek-v4-analysis-2026) (80.6% SWE-bench Verified, MIT) and [Kimi K2.6](/blog/kimi-k2-analysis-2026) (top open-weights on the AA Intelligence Index at 54).
+- **Multimodal, run locally** → Gemma 4 (text/vision/audio) and [Llama 4](/blog/llama-4-analysis-2026) (native text+image, 10M-context Scout sibling).
+- **Cleanest license** → Apache 2.0 (Gemma 4, gpt-oss, Mistral Large 3) or MIT (Phi-4, DeepSeek V4). Watch the **Llama Community License** (free only under 700M MAU) and **Kimi's Modified MIT**.
+
+---
+
+## The license landscape actually matters
+
+A quiet but important 2026 story: **Gemma 4 moved to Apache 2.0**, dropping the custom "Gemma Terms" that governed Gemma 3. That puts Google's open family on the same permissive footing as gpt-oss and Mistral — unrestricted commercial use, no fine-tune disclosure, no redistribution friction.
+
+The hierarchy, from most to least permissive for a commercial product:
+
+1. **MIT** (Phi-4, DeepSeek V4) and **Apache 2.0** (Gemma 4, gpt-oss, Mistral Large 3) — do essentially anything.
+2. **Modified MIT** (Kimi K2.6) — permissive with minor conditions; read the text.
+3. **Llama Community License** (Llama 4) — free commercial use, but only under 700M monthly active users, with attribution requirements.
+
+If you're embedding a model in a product you intend to scale, the license is as load-bearing as the benchmark.
+
+---
+
+## Self-host vs API: the economics nobody likes
+
+Open weights are free; **inference is not**. A single 8×H100 node is a six-figure capital expense or roughly $20–40/hour rented. The math that decides it:
+
+- **Low or spiky volume** → a hosted endpoint (open models run ~$0.04–$1.50 per 1M tokens depending on size) is almost always cheaper than idle GPUs. Several of these models are available via OpenRouter, Together, Fireworks, and Groq.
+- **High steady volume** → owning (or reserving) the hardware wins, because you amortize a fixed cost across saturated utilization.
+- **Data-residency mandate** → the API option may simply be off the table, and self-host is the only path regardless of cost.
+
+The trap is treating "$0 weights" as "$0 to run." For most teams, the right pattern is hybrid: prototype and burst on a hosted open endpoint, and only stand up your own GPUs once volume and/or compliance justify it.
+
+---
+
+## Where these sit against the closed frontier
+
+Be honest about the gap. On the neutral Artificial Analysis Intelligence Index, Claude Opus 4.8 sits around 61 and GPT-5.5 around 59–60. The best open weights — Kimi K2.6 (54) and Qwen3.7-Max (56.6, though closed) — are a real step behind, and the locally-runnable models (Gemma 4, gpt-oss, Phi-4) trade more capability for the privilege of fitting on your hardware.
+
+That's the correct trade, not a disappointment. You self-host to *own* the model, run it *offline*, keep data *in-house*, and avoid a *per-token meter* — and in 2026 you can do all of that with quality that would have been frontier-class barely a year ago. For the full proprietary comparison, see the [Frontier AI Models Intelligence Hub](/ai-ops/models-2026).
+
+---
+
+## FAQ
+
+### What's the best open-source LLM in 2026?
+For raw capability, **DeepSeek V4** and **Kimi K2.6** lead the open-weight field (Kimi tops the neutral Artificial Analysis Intelligence Index among open models at 54). For something you can actually run on your own hardware, **Gemma 4** (best on one consumer GPU) and **gpt-oss** (best reasoning-per-VRAM) are the picks. There's no single winner — it depends on your hardware and license needs.
+
+### What's the best LLM I can run on a laptop?
+**Phi-4** (3.8B mini in ~3-4GB, 14B in ~8-10GB at Q4), **gpt-oss-20b** (~16GB), or **Gemma 4's** 12B / E4B tiers. Phi-4 is the STEM/extraction specialist; gpt-oss-20b is the strongest reasoner; Gemma 4 12B adds native audio and vision.
+
+### Is "17B active" the amount of VRAM I need?
+No. Mixture-of-Experts models like Llama 4 Maverick (400B total / 17B active) or DeepSeek V4 still need every expert resident in memory, so you size for **total** parameters, not active. "17B active" describes compute per token, not memory footprint.
+
+### Are open weights free to run?
+The weights are free; the inference is not. You pay for GPUs (capex or rental). Self-hosting only beats a hosted API at high steady volume or under a data-residency requirement. For low or spiky usage, a hosted open-model endpoint (~$0.04–$1.50 per 1M tokens) is usually cheaper.
+
+### Which open model has the most permissive license?
+The MIT-licensed (Phi-4, DeepSeek V4) and Apache 2.0 (Gemma 4, gpt-oss, Mistral Large 3) models — all allow unrestricted commercial use, fine-tuning, and redistribution. Gemma 4 notably moved to Apache 2.0 from the custom Gemma Terms. Llama 4's Community License is free only under 700M monthly active users.
+
+### Can an open model match Claude Opus 4.8 or GPT-5.5?
+Not on raw capability — the best open weights trail the closed frontier by a meaningful margin on neutral benchmarks. They match or beat the frontier on the axes that make people self-host: data control, license freedom, offline operation, and cost at scale.
+
+---
+
+*Analysis by Frank — AI Architect, builder of the Agentic Creator Operating System.
+Compiled June 5, 2026 from vendor model cards and independent sources (Artificial Analysis, llm-stats, LMArena, NIST/CAISI). Verified vs vendor-claimed figures are distinguished in each model's linked deep dive.*

--- a/content/blog/gemma-3-analysis-2026.mdx
+++ b/content/blog/gemma-3-analysis-2026.mdx
@@ -107,24 +107,24 @@ The honest read: **Qwen 3.5 narrowly out-scores Gemma 4 on pure reasoning** (MML
 
 ## Why Does the Apache 2.0 License Matter More Than the Benchmarks?
 
-This is the part that VentureBeat called bigger than the benchmarks, and I agree. Gemma 1 through 3 shipped under Google's custom **"Gemma Terms of Use."** More permissive than many, but not standard — it carried use restrictions (carve-outs around harm, critical infrastructure, and so on) that were reasonable in spirit but legally ambiguous in practice. For an enterprise, "legally ambiguous" means a compliance review, which means weeks of procurement delay, which means the model quietly doesn't get adopted.
+VentureBeat called this bigger than the benchmarks, and I agree. Gemma 1 through 3 shipped under Google's custom **"Gemma Terms of Use"** — more permissive than many, but not standard, with use restrictions (carve-outs around harm, critical infrastructure) that were reasonable in spirit but legally ambiguous in practice. For an enterprise, "legally ambiguous" means a compliance review, weeks of procurement delay, and a model that quietly never gets adopted.
 
-Gemma 4 replaces all of it with **plain Apache 2.0** — OSI-approved, no custom clauses, no industry restrictions, no competitive-use prohibitions, no obligation to disclose training data or share your fine-tuned weights. You can fine-tune Gemma 4 on proprietary data and ship the result as a commercial product you sell, with no agreement with Google and no licensing fee.
+Gemma 4 replaces all of it with **plain Apache 2.0** — OSI-approved, no custom clauses, no industry restrictions, no competitive-use prohibitions, no obligation to disclose training data or share your fine-tuned weights. Fine-tune on proprietary data, ship the result as a commercial product, no agreement with Google and no fee.
 
-For self-host economics, this is the whole game. Open weights already mean the model itself is **$0** — no per-token API cost, no rate limits, no data leaving your infrastructure. Apache 2.0 removes the last thing that made "free" come with an asterisk. The cost of running Gemma 4 is now purely your hardware and electricity, and the legal cost is zero. That combination is why this release lands differently than a benchmark bump would.
+For self-host economics, this is the whole game. Open weights already mean the model is **$0** — no per-token cost, no rate limits, no data leaving your infrastructure. Apache 2.0 removes the last asterisk on "free." The cost of running Gemma 4 is now purely hardware and electricity, and the legal cost is zero. That's why this release lands differently than a benchmark bump would.
 
 ---
 
 ## Self-Host vs API: Which Size for Which Job?
 
-Open weights change the question. With a closed API model the decision is "is the quality worth the per-token price." With Gemma 4 the price is fixed (your GPU) and the question becomes "which tier gives me the quality I need at the throughput I need." Here's how I'd route it:
+Open weights flip the question. With a closed API the decision is "is the quality worth the per-token price." With Gemma 4 the price is fixed (your GPU) and the question becomes "which tier gives me the quality and throughput I need." How I'd route it:
 
 - **E2B / E4B — edge and on-device.** Phone apps, browser extensions, offline classification, PII-sensitive extraction that can't leave the device. Don't expect frontier reasoning; expect fast, private, good-enough.
 - **12B — local multimodal.** The new pick for anything involving images, audio, or video that you want running on a laptop without a cloud round-trip. Native audio input on a 16GB machine is the differentiator. This is the model for a privacy-respecting meeting summarizer or an offline document-and-screenshot agent.
 - **26B A4B — high-throughput agentic.** When you're running loops — many tool calls, many short turns — the MoE's ~4B active params give you speed without dropping to a tiny model's quality. Serve it with vLLM, batch aggressively.
 - **31B — max quality on one box.** The default for "I want the best open model I can run on a single GPU." Coding, analysis, RAG over your own corpus, anything where the answer quality is load-bearing and you want it on-prem.
 
-When do you *not* self-host? When your volume is low and spiky, a closed API is cheaper than amortizing a GPU. When you need the absolute frontier — the kind of reasoning [Claude Opus 4.8](/blog/claude-opus-4-8-analysis-2026) or DeepSeek V4 deliver — Gemma 4 isn't trying to compete there, and you shouldn't make it. Self-hosting Gemma 4 wins on a specific axis: **predictable cost, full data control, and no per-call latency to a third party.** Match the tier to the cost-of-error, not the leaderboard.
+When do you *not* self-host? When volume is low and spiky, a closed API beats amortizing a GPU. And when you need the absolute frontier — the reasoning [Claude Opus 4.8](/blog/claude-opus-4-8-analysis-2026) or DeepSeek V4 deliver — Gemma 4 isn't competing there, and you shouldn't make it. Self-hosting Gemma 4 wins on one axis: **predictable cost, full data control, and no per-call latency to a third party.** Match the tier to the cost-of-error, not the leaderboard.
 
 ---
 
@@ -132,19 +132,15 @@ When do you *not* self-host? When your volume is low and spiky, a closed API is 
 
 ### For local-first and privacy-sensitive products
 
-This is the clearest win. A 31B model at 80% LiveCodeBench and 85% MMLU-Pro, running entirely on your own hardware under Apache 2.0, means you can build a genuinely capable assistant that never sends a token to anyone. Healthcare, legal, finance, on-prem enterprise — the categories that couldn't touch a cloud API now have a real option. The 12B's native audio and vision extend that to multimodal without the infrastructure tax.
+The clearest win. A 31B model at 80% LiveCodeBench and 85% MMLU-Pro, running entirely on your own hardware under Apache 2.0, means a genuinely capable assistant that never sends a token to anyone. Healthcare, legal, finance, on-prem enterprise — categories that couldn't touch a cloud API now have a real option, and the 12B's native audio and vision extend it to multimodal without the infrastructure tax.
 
 ### For cost-conscious agentic systems
 
-The 26B A4B is the quiet star for anyone running agent loops at volume. MoE throughput plus zero per-token cost plus vLLM batching is a fundamentally different cost curve than paying an API per call. If you've been watching your agentic API bill climb, a self-hosted 26B on rented or owned GPUs is worth a serious back-of-envelope.
+The 26B A4B is the quiet star for agent loops at volume. MoE throughput plus zero per-token cost plus vLLM batching is a fundamentally different cost curve than paying an API per call. If your agentic API bill is climbing, a self-hosted 26B on rented or owned GPUs is worth a serious back-of-envelope.
 
-### For fine-tuners
+### For fine-tuners and open-model evaluators
 
-Apache 2.0 plus full availability of base and instruction-tuned checkpoints (`google/gemma-4-*-it` on HuggingFace) plus Unsloth-grade tooling means you can fine-tune on proprietary data, deploy commercially, and keep the weights private — no disclosure, no fee. For a vertical product built on a fine-tuned small model, this is close to ideal.
-
-### For everyone evaluating open models
-
-Don't pick on the headline Elo alone. Qwen 3.5 narrowly out-reasons Gemma 4; DeepSeek V4 out-everythings it at the frontier with a cluster. Gemma 4's edge is the *whole package* — quality that fits one GPU, native multimodal, a clean license, and day-zero support across Ollama, llama.cpp, LM Studio, vLLM, and the major cloud platforms. Run all three on your own eval set before committing. The right open model is the one that wins *your* benchmark, on *your* hardware, under a license *your* lawyers sign off on.
+Apache 2.0 plus base and instruction-tuned checkpoints (`google/gemma-4-*-it`) plus Unsloth-grade tooling means you fine-tune on proprietary data, deploy commercially, and keep the weights private — no disclosure, no fee. And when you evaluate, don't pick on headline Elo alone: Qwen 3.5 narrowly out-reasons Gemma 4, DeepSeek V4 out-everythings it at the frontier with a cluster. Gemma 4's edge is the *whole package* — quality that fits one GPU, native multimodal, a clean license, and day-zero support across Ollama, llama.cpp, LM Studio, vLLM, and the major clouds. Run all three on your own eval set. The right open model wins *your* benchmark, on *your* hardware, under a license *your* lawyers sign off on.
 
 ---
 

--- a/content/blog/gemma-3-analysis-2026.mdx
+++ b/content/blog/gemma-3-analysis-2026.mdx
@@ -1,0 +1,180 @@
+---
+title: "Gemma 4: Google's Open-Weight Family Now Runs a 31B Frontier Model on One GPU"
+description: "Google's current open-weight Gemma is Gemma 4 (April 2026), now Apache 2.0, in E2B/E4B/12B/26B-A4B/31B tiers. The 31B dense model hits 1452 LMArena Elo and runs in ~18GB VRAM at Q4. Self-host specifics, verified benchmarks, license analysis, and which size for which job."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - google
+  - gemma
+  - open-weight-models
+  - local-llms
+  - ai-2026
+  - benchmarks
+keywords:
+  - gemma 4
+  - gemma 4 benchmarks
+  - gemma 4 vram requirements
+  - gemma 4 31b local
+  - gemma 4 vs gemma 3
+  - gemma 4 apache 2.0 license
+  - run gemma 4 ollama
+  - gemma 4 12b multimodal
+  - best open weight model 2026
+  - gemma 4 model sizes
+image: "/images/blog/gemma-3-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Gemma 4: Google's Open-Weight Family Now Runs a 31B Frontier Model on One GPU
+
+**TL;DR**: Google's current run-it-yourself model is **Gemma 4**, released April 2, 2026 — not Gemma 3 anymore. The headline change is the license: Gemma 4 drops Google's custom "Gemma Terms" for plain **Apache 2.0**, which removes the biggest friction enterprises had with the prior generations. The lineup ships in five tiers — E2B, E4B, the new **12B** (added June 3, 2026), a **26B A4B** mixture-of-experts, and a **31B dense** flagship. The 31B hits a **1452 LMArena Elo** (vendor-reported #3 among open models) and runs in roughly **18GB of VRAM at Q4** — one consumer GPU. Context is up to 256K, with native vision and (on E2B/E4B/12B) audio. Here's what's verifiable, what's vendor-claimed, and which tier to actually run.
+
+---
+
+## Wait — Gemma 3 or Gemma 4?
+
+Quick housekeeping, because the URL says `gemma-3` and the model says Gemma 4. If you came here looking for Gemma 3, the short version is: it was superseded. **Gemma 3** (March 2025) shipped 1B/4B/12B/27B tiers under the Gemma Terms of Use, with a 128K context and text+vision. It was an excellent open model for its moment — the 27B posted a ~1338 Chatbot Arena Elo on a single H100, which was genuinely impressive for a dense model that size.
+
+As of June 2026, the current open-weight flagship is **Gemma 4**, and it's a real generational jump, not a point release. If you're standing up a self-hosted model today, Gemma 4 is the one to evaluate. Gemma 3 still works and the weights aren't going anywhere, but every number below is Gemma 4 unless I say otherwise.
+
+A note on sourcing, because precision matters with open models. Figures here are cross-referenced against Google's official [Gemma 4 announcement](https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/), the [Gemma 4 model card](https://ai.google.dev/gemma/docs/core/model_card_4) and [release notes](https://ai.google.dev/gemma/docs/releases), the [HuggingFace launch post](https://huggingface.co/blog/gemma4), independent coverage from [VentureBeat](https://venturebeat.com/technology/google-releases-gemma-4-under-apache-2-0-and-that-license-change-may-matter), and community self-host guides ([Unsloth](https://unsloth.ai/docs/models/gemma-4), Ollama). Where a benchmark is Google's own and not yet independently reproduced, I mark it **vendor-claimed**.
+
+---
+
+## What Are the Gemma 4 Size Tiers — and What Hardware Do They Need?
+
+This is the part that actually decides whether you can run it. Gemma 4 launched April 2, 2026 with four sizes; Google added a 12B dense multimodal model on June 3, 2026. The "E" in E2B/E4B stands for **effective** parameters — these models use Per-Layer Embeddings to hit a quality target with a smaller active footprint on-device.
+
+| Tier | Type | Params | Min VRAM (Q4) | Where it runs | Best for |
+|------|------|--------|---------------|---------------|----------|
+| **E2B** | Dense (PLE) | ~2.3B effective | ~2GB | Phone, Raspberry Pi, any laptop | On-device, edge, drafts |
+| **E4B** | Dense (PLE) | ~4.5B effective | ~4-6GB (8GB comfortable) | 8GB laptop GPU, M-series Mac | Edge chat, classification |
+| **12B** | Dense, unified multimodal | 12B | ~16GB | 16GB laptop / Mac unified memory | Local multimodal, audio+video |
+| **26B A4B** | MoE (4B active) | 26B total / ~3.8B active | ~15.6GB (24GB comfortable) | Single mid-range GPU | High throughput, agentic |
+| **31B** | Dense | ~30.7B | ~18GB (20GB safe) | One RTX 4090 / 5090, A100 | Max quality on one GPU |
+
+A few things worth pulling out of that table:
+
+**The 31B fits on one consumer GPU.** At Q4_K_M — the quantization the community has converged on — the 31B dense flagship needs roughly 18GB of VRAM, which a single 24GB card (4090, 5090) handles with headroom. Full BF16 precision wants ~64GB; 8-bit lands around 34GB. The Q4 sweet spot trades 3-5% benchmark quality for ~75% less memory — the trade nearly everyone running locally should take.
+
+**The 26B A4B is the throughput play.** Gemma's first mixture-of-experts model: 26B parameters loaded, but only ~3.8-4B active per token. You pay the full 26B in memory (~15.6GB at int4) but get tokens-per-second closer to a 4B model. The efficient pick when latency compounds across many calls.
+
+**The 12B is the news.** Released June 3, 2026 — two days before this post — it's a *unified, encoder-free* multimodal model: vision and audio flow directly into the LLM backbone with no separate encoder. It's the first mid-sized Gemma with **native audio input**, and it runs entirely locally on a typical 16GB enterprise laptop. A real capability shift for offline multimodal work, not a spec bump.
+
+**E2B runs basically anywhere** — two gigabytes at Q4, phone-class. The quality ceiling is what you'd expect from a ~2B effective model, but for on-device classification, extraction, and drafts it's a legitimate tool.
+
+To run any of these: `ollama run gemma4:31b` (needs Ollama v0.20+), `gemma4:26b`, `gemma4:12b`, `gemma4:4b`, or `gemma4:2b`. Ollama auto-selects a quantization that fits your memory, or pin it with `gemma4:31b-q4_K_M`. For more control there's **llama.cpp** with GGUF weights (the [Unsloth GGUF repos](https://unsloth.ai/docs/models/gemma-4) at `unsloth/gemma-4-31B-it-GGUF` are popular), **LM Studio** for a GUI, **HF Transformers** for fine-tuning (`google/gemma-4-31B-it`), and **vLLM** when you're serving the model to multiple users in production.
+
+---
+
+## What Are the Verified Benchmarks?
+
+Gemma 4's pitch is "byte for byte, the most capable open models" — and the benchmark story is built around the 31B dense flagship punching above its parameter class. Here's where the numbers actually land. Treat the LMArena Elo and the cross-checked academic benchmarks as well-corroborated; treat single-source academic jumps as vendor-claimed until third parties reproduce them.
+
+| Benchmark | Gemma 3 27B | Gemma 4 31B | What it measures |
+|-----------|-------------|-------------|------------------|
+| LMArena Elo (text) | ~1338 | **1452** | Human preference, head-to-head |
+| MMLU-Pro | 67.5 | **85.2%** | Hard multitask knowledge |
+| GPQA Diamond | ~42.4 | **84.3%** | Graduate-level science |
+| AIME 2026 | ~20.8 | **89.2%** | Competition math |
+| LiveCodeBench | ~29.x | **80.0%** | Real coding problems |
+| MMMU (multimodal) | 67.6 | **85.2%** | Multimodal reasoning |
+| MMMU-Pro | 49.7 | **76.9%** | Harder multimodal |
+
+The standouts:
+
+**LMArena Elo of 1452** puts the 31B at a vendor-reported **#3 among open models**, with the 26B A4B MoE close behind at ~1441 (#6). A 31B dense model sitting in human-preference territory occupied by models 20x its size is the genuine headline — and it's the number I'd anchor on, because LMArena is human preference at scale and the hardest to game.
+
+**The AIME 2026 jump from ~20.8% to 89.2%** and **GPQA from ~42.4% to 84.3%** are the eye-catchers, and the ones to read carefully. Enormous single-generation deltas on reasoning-heavy benchmarks that lean on Google's own evals — plausible given how hard the industry moved on reasoning this year, but **vendor-claimed** until independent reproduction lands. The direction is real; the exact decimals deserve skepticism.
+
+**80.0% LiveCodeBench from a 31B dense model** matters most for builders. Coding is where small open models usually fall apart, and 80% is exceptional for this weight class — the difference between "toy" and "I can route real work here."
+
+How it stacks against the rest of the open field (June 2026):
+
+| Model | Params | MMLU-Pro | GPQA Diamond | License | Note |
+|-------|--------|----------|--------------|---------|------|
+| **Gemma 4 31B** | ~31B dense | 85.2% | 84.3% | Apache 2.0 | Runs on one GPU |
+| Qwen 3.5 ~27B | ~27B | 86.1% | 85.5% | Apache 2.0 | Edges Gemma on reasoning |
+| DeepSeek V4 | ~1T MoE | 92.8% | — | Open | Frontier, needs a cluster |
+| Llama 4 Maverick | MoE | 80.5% | — | Llama license | 10M context on Scout |
+
+The honest read: **Qwen 3.5 narrowly out-scores Gemma 4 on pure reasoning** (MMLU-Pro and GPQA), and [DeepSeek V4](/blog/deepseek-v4-analysis-2026) dominates the frontier — but DeepSeek is a trillion-parameter MoE that needs serious hardware. Gemma 4's argument isn't "highest score." It's "highest score *that fits on hardware you already own*, under a license your legal team won't fight you on." For a fuller cross-model breakdown including the closed frontier, see the [FrankX models tracker](/ai-ops/models-2026) and the [best open local LLMs guide](/blog/best-open-local-llms-2026).
+
+---
+
+## Why Does the Apache 2.0 License Matter More Than the Benchmarks?
+
+This is the part that VentureBeat called bigger than the benchmarks, and I agree. Gemma 1 through 3 shipped under Google's custom **"Gemma Terms of Use."** More permissive than many, but not standard — it carried use restrictions (carve-outs around harm, critical infrastructure, and so on) that were reasonable in spirit but legally ambiguous in practice. For an enterprise, "legally ambiguous" means a compliance review, which means weeks of procurement delay, which means the model quietly doesn't get adopted.
+
+Gemma 4 replaces all of it with **plain Apache 2.0** — OSI-approved, no custom clauses, no industry restrictions, no competitive-use prohibitions, no obligation to disclose training data or share your fine-tuned weights. You can fine-tune Gemma 4 on proprietary data and ship the result as a commercial product you sell, with no agreement with Google and no licensing fee.
+
+For self-host economics, this is the whole game. Open weights already mean the model itself is **$0** — no per-token API cost, no rate limits, no data leaving your infrastructure. Apache 2.0 removes the last thing that made "free" come with an asterisk. The cost of running Gemma 4 is now purely your hardware and electricity, and the legal cost is zero. That combination is why this release lands differently than a benchmark bump would.
+
+---
+
+## Self-Host vs API: Which Size for Which Job?
+
+Open weights change the question. With a closed API model the decision is "is the quality worth the per-token price." With Gemma 4 the price is fixed (your GPU) and the question becomes "which tier gives me the quality I need at the throughput I need." Here's how I'd route it:
+
+- **E2B / E4B — edge and on-device.** Phone apps, browser extensions, offline classification, PII-sensitive extraction that can't leave the device. Don't expect frontier reasoning; expect fast, private, good-enough.
+- **12B — local multimodal.** The new pick for anything involving images, audio, or video that you want running on a laptop without a cloud round-trip. Native audio input on a 16GB machine is the differentiator. This is the model for a privacy-respecting meeting summarizer or an offline document-and-screenshot agent.
+- **26B A4B — high-throughput agentic.** When you're running loops — many tool calls, many short turns — the MoE's ~4B active params give you speed without dropping to a tiny model's quality. Serve it with vLLM, batch aggressively.
+- **31B — max quality on one box.** The default for "I want the best open model I can run on a single GPU." Coding, analysis, RAG over your own corpus, anything where the answer quality is load-bearing and you want it on-prem.
+
+When do you *not* self-host? When your volume is low and spiky, a closed API is cheaper than amortizing a GPU. When you need the absolute frontier — the kind of reasoning [Claude Opus 4.8](/blog/claude-opus-4-8-analysis-2026) or DeepSeek V4 deliver — Gemma 4 isn't trying to compete there, and you shouldn't make it. Self-hosting Gemma 4 wins on a specific axis: **predictable cost, full data control, and no per-call latency to a third party.** Match the tier to the cost-of-error, not the leaderboard.
+
+---
+
+## What Does It Mean for Builders?
+
+### For local-first and privacy-sensitive products
+
+This is the clearest win. A 31B model at 80% LiveCodeBench and 85% MMLU-Pro, running entirely on your own hardware under Apache 2.0, means you can build a genuinely capable assistant that never sends a token to anyone. Healthcare, legal, finance, on-prem enterprise — the categories that couldn't touch a cloud API now have a real option. The 12B's native audio and vision extend that to multimodal without the infrastructure tax.
+
+### For cost-conscious agentic systems
+
+The 26B A4B is the quiet star for anyone running agent loops at volume. MoE throughput plus zero per-token cost plus vLLM batching is a fundamentally different cost curve than paying an API per call. If you've been watching your agentic API bill climb, a self-hosted 26B on rented or owned GPUs is worth a serious back-of-envelope.
+
+### For fine-tuners
+
+Apache 2.0 plus full availability of base and instruction-tuned checkpoints (`google/gemma-4-*-it` on HuggingFace) plus Unsloth-grade tooling means you can fine-tune on proprietary data, deploy commercially, and keep the weights private — no disclosure, no fee. For a vertical product built on a fine-tuned small model, this is close to ideal.
+
+### For everyone evaluating open models
+
+Don't pick on the headline Elo alone. Qwen 3.5 narrowly out-reasons Gemma 4; DeepSeek V4 out-everythings it at the frontier with a cluster. Gemma 4's edge is the *whole package* — quality that fits one GPU, native multimodal, a clean license, and day-zero support across Ollama, llama.cpp, LM Studio, vLLM, and the major cloud platforms. Run all three on your own eval set before committing. The right open model is the one that wins *your* benchmark, on *your* hardware, under a license *your* lawyers sign off on.
+
+---
+
+## FAQ
+
+### Is Gemma 4 better than Gemma 3?
+
+Yes, substantially. Gemma 4 is a generational jump, not a point release. The 31B flagship reports a 1452 LMArena Elo (vs ~1338 for Gemma 3 27B), MMLU-Pro of 85.2% (vs 67.5%), and large gains on math and coding. It also adds a mixture-of-experts tier (26B A4B), a unified encoder-free multimodal 12B with native audio, a 256K context (up from 128K), and — most importantly for commercial users — an Apache 2.0 license replacing the custom Gemma Terms.
+
+### What hardware do I need to run Gemma 4 31B?
+
+At Q4_K_M quantization, the 31B dense model needs roughly 18GB of VRAM, so a single 24GB consumer GPU (RTX 4090/5090) or an Apple Silicon Mac with sufficient unified memory runs it comfortably. Full BF16 precision wants ~64GB; 8-bit lands near 34GB. For smaller footprints, the 12B runs on 16GB, the 26B A4B MoE on ~15.6GB at int4, E4B on ~8GB, and E2B in about 2GB.
+
+### How much does Gemma 4 cost?
+
+The weights are free — $0. Gemma 4 is an open-weight model under Apache 2.0, so there's no per-token API charge, no licensing fee, and no agreement with Google required. Your only costs are the hardware and electricity to run it (or rented GPU time). You can also access it through cloud APIs if you'd rather not self-host, where you'd pay that provider's compute rates.
+
+### Which Gemma 4 size should I use?
+
+Use E2B/E4B for on-device and edge work, the 12B for local multimodal (images, audio, video) on a laptop, the 26B A4B MoE for high-throughput agentic loops, and the 31B dense for maximum quality on a single GPU. Match the tier to your throughput and quality needs, not to the largest number.
+
+### Where can I run Gemma 4?
+
+Ollama (`ollama run gemma4:31b`, needs v0.20+), llama.cpp with GGUF weights, LM Studio for a GUI, HuggingFace Transformers for fine-tuning (`google/gemma-4-31B-it`), and vLLM for production serving. It also has day-zero support on Google Cloud and AMD hardware. The community-standard quantization is Q4_K_M.
+
+### Which Gemma 4 benchmarks are verified vs vendor-claimed?
+
+The 1452 LMArena Elo is human-preference data and the most trustworthy single number. The academic benchmarks (MMLU-Pro 85.2%, GPQA 84.3%, AIME 89.2%, LiveCodeBench 80.0%) come largely from Google's own evals and should be treated as vendor-claimed until independently reproduced — the direction is corroborated by the LMArena ranking and cross-model comparisons, but the exact decimals deserve skepticism. Independent comparisons show Qwen 3.5 narrowly ahead on pure reasoning, so Gemma 4 leads on package, not on every score.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI.
+Published June 5, 2026 with specs and benchmarks validated against Google DeepMind's official announcement and model card, the HuggingFace launch post, LMArena, and independent self-host guides. Vendor-claimed figures are marked as such.*

--- a/content/blog/gpt-oss-analysis-2026.mdx
+++ b/content/blog/gpt-oss-analysis-2026.mdx
@@ -97,7 +97,7 @@ This is where the honesty has to sharpen, because the open-weight field moved ha
 | DeepSeek V4 | MIT | 671B-class MoE | Top overall open score | Multi-GPU server |
 | Qwen 3.5 | Apache 2.0 | 397B / 17B | Vision, 201 languages, 1M context | Multi-GPU server |
 | GLM-5 | MIT | Large MoE | 77.8% SWE-Bench Verified (coding) | Multi-GPU server |
-| Gemma 4 | Gemma terms | Dense + MoE | Google ecosystem, on-device | Varies |
+| Gemma 4 | Apache 2.0 | Dense + MoE | Google ecosystem, on-device | Varies |
 
 The verdict that holds up: **gpt-oss is no longer the highest-scoring open model, and that's fine, because it was never competing on raw score.** [DeepSeek V4](/blog/deepseek-v4-analysis-2026), Qwen 3.5, and GLM-5 top the aggregate leaderboards — but they're 400B-to-671B-class models that need a multi-GPU server to self-host. gpt-oss competes on a different axis: **capability per gigabyte of VRAM**. If your constraint is "one H100" or "my laptop," the comparison isn't 120b vs DeepSeek V4 — it's 120b vs whatever else fits on your hardware, and there gpt-oss is still one of the best reasoning-per-VRAM options with a clean Apache 2.0 license.
 

--- a/content/blog/gpt-oss-analysis-2026.mdx
+++ b/content/blog/gpt-oss-analysis-2026.mdx
@@ -1,0 +1,187 @@
+---
+title: "gpt-oss in 2026: OpenAI's Open-Weight Models, One Year On"
+description: "OpenAI's gpt-oss-120b and gpt-oss-20b are Apache 2.0, free to download, and run on a single 80GB GPU or a 16GB laptop. The full self-host breakdown: VRAM, MXFP4 quantization, where to run, verified benchmarks, and how they stack up against Qwen, DeepSeek, and GLM in June 2026."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - openai
+  - gpt-oss
+  - open-weight-models
+  - local-llms
+  - ai-2026
+  - benchmarks
+keywords:
+  - gpt-oss
+  - gpt-oss-120b
+  - gpt-oss-20b
+  - gpt-oss benchmarks
+  - gpt-oss self-host
+  - gpt-oss vram requirements
+  - openai open weight model
+  - gpt-oss vs qwen deepseek
+  - run gpt-oss locally ollama
+  - best open source llm 2026
+image: "/images/blog/gpt-oss-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# gpt-oss in 2026: OpenAI's Open-Weight Models, One Year On
+
+**TL;DR**: gpt-oss-120b and gpt-oss-20b are OpenAI's open-weight models — Apache 2.0, free to download, no API key required. The 120b (116.8B total, 5.1B active, MoE) runs on a single 80GB GPU; the 20b (21B total, 3.6B active) runs in ~16GB of memory, including laptops. Both ship MXFP4-quantized with a 131,072-token (128K) context and low/medium/high reasoning effort levels. On OpenAI's own evals the 120b scores 80.1% GPQA Diamond and 97.9% AIME 2025 (with tools); the 20b posts 98.7% AIME 2025. They run on Ollama, vLLM, LM Studio, llama.cpp, and Hugging Face Transformers. As of June 2026 there's no "gpt-oss-2" — but the family has been busy: a safeguard variant shipped in October 2025, and gpt-oss-120b became an official MLPerf Inference v6.0 benchmark in March 2026. Here's the honest builder's take on what to run and when.
+
+---
+
+## What Is gpt-oss?
+
+gpt-oss is OpenAI's open-weight model family, released August 5, 2025 — their first open-weight language models since GPT-2 in 2019. Two variants: **gpt-oss-120b** and **gpt-oss-20b**, both under the [Apache 2.0 license](https://github.com/openai/gpt-oss). That license is the whole story. Apache 2.0 is permissive, commercial-friendly, and carries no copyleft and no monthly-active-user ceiling — the kind of trap that has bitten teams building on more restrictive "open" licenses. You download the weights, you run them wherever you want, you ship products on top, and you owe OpenAI nothing.
+
+Both are **Mixture-of-Experts (MoE)** transformers, which is the trick that makes them deployable. The 120b carries 116.8B total parameters but activates only **5.1B per token**; the 20b is 21B total with **3.6B active**. You pay the memory cost of holding all the experts, but the compute cost of running just a few — so a 120-billion-parameter model thinks at roughly the speed of a 5-billion-parameter one.
+
+Three things define this family in mid-2026:
+
+1. **It's a self-host play, not an API product.** The economics aren't "cheaper per token" — they're "your hardware, your weights, your data never leaves the building." For regulated or privacy-sensitive workloads, that's the entire pitch.
+2. **The reasoning is real and adjustable.** Both models are reasoning models with a built-in chain of thought and three effort levels — low, medium, high — that you set in the system prompt to trade latency for accuracy.
+3. **It became infrastructure.** When MLCommons added gpt-oss-120b as a standard [MLPerf Inference v6.0 benchmark](https://mlcommons.org/2026/03/mlperf-inference-gpt-oss/) in March 2026, that was the tell: the hardware industry now treats this model as a reference workload, not a curiosity.
+
+---
+
+## What Are the Variants and Hardware Requirements?
+
+This is the table that actually matters when you're deciding what to run. The headline trick is **MXFP4 quantization** — OpenAI post-trained the MoE weights in a 4-bit format, which is what collapses the memory footprint enough to make the 120b fit on one card and the 20b fit on a laptop.
+
+| Variant | Total / Active params | Architecture | Min VRAM | Context | Where to run |
+|---------|----------------------|--------------|----------|---------|--------------|
+| **gpt-oss-120b** | 116.8B / 5.1B | MoE, 36 layers, MXFP4 | **~80GB** (single H100 / MI300X) | 131,072 | vLLM, Ollama, LM Studio, Transformers, llama.cpp |
+| **gpt-oss-20b** | 21B / 3.6B | MoE, MXFP4 | **~16GB** | 131,072 | Ollama, LM Studio, llama.cpp, Transformers |
+
+A few honest notes on those VRAM figures. The "~80GB single GPU" and "~16GB" numbers are [OpenAI's own claims](https://openai.com/index/introducing-gpt-oss/), and they hold up — but they describe the *minimum* to load the model with the native MXFP4 weights, not a comfortable production buffer. In practice you want headroom for the KV cache, and a full 131K-token context will push memory well past the floor. The 20b genuinely runs on a 16GB consumer GPU or an Apple Silicon laptop with unified memory; it's the one most people will actually self-host. The 120b is a single-server-card model, not a home-lab one, unless you're comfortable with aggressive offload and slow tokens.
+
+Both models require OpenAI's **harmony response format**. This is the one footgun worth flagging up front: feed gpt-oss raw chat messages without the harmony structure and, per OpenAI's own repo, "they will not work correctly." If you're going through Ollama, vLLM, or LM Studio, the runner handles harmony for you. If you're calling the weights directly, you have to build it yourself — budget an afternoon.
+
+---
+
+## What Are the Verified Benchmarks?
+
+A sourcing note, because the distinction matters. The numbers below come from OpenAI's [gpt-oss model card](https://arxiv.org/abs/2508.10925) (arXiv 2508.10925) and the [launch post](https://openai.com/index/introducing-gpt-oss/). These are **vendor-reported** evals run by OpenAI at the high reasoning level. They've held up reasonably well in independent testing, but treat them as the model's strongest foot forward, not a neutral referee's scorecard.
+
+| Benchmark | gpt-oss-120b | gpt-oss-20b | What it measures |
+|-----------|--------------|-------------|------------------|
+| AIME 2025 (with tools) | **97.9%** | **98.7%** | Competition mathematics |
+| AIME 2024 (with tools) | 96.6% | — | Competition mathematics |
+| GPQA Diamond (no tools) | **80.1%** | 71.5% | Graduate-level science Q&A |
+| MMLU-Pro | ~90.0% | — | Broad knowledge / reasoning |
+| Humanity's Last Exam | ~19% | ~9.8% | Frontier multidisciplinary reasoning |
+| SWE-Bench Verified | ~62.4% | — | Real GitHub issue resolution |
+
+A couple of these deserve a second look.
+
+**The 20b out-scoring the 120b on AIME 2025 (98.7% vs 97.9%)** is not a typo, and it's a useful reminder of how narrow saturated math benchmarks are. Both models, given a Python tool, are essentially solving every problem — the gap is noise, not a signal that the small model reasons better. Don't read AIME as a general-capability ranking.
+
+**GPQA Diamond at 80.1%** is the more honest capability signal. OpenAI positioned the 120b as reaching near-parity with their own o4-mini on core reasoning, and 80.1% on graduate-level science is genuinely strong for a model you can run on one GPU. The 20b's 71.5% is the number that tells you what fits on a laptop now.
+
+**HealthBench** is the one OpenAI leans on hardest: they claim the 120b nearly matches o3 on HealthBench and HealthBench Hard, beating GPT-4o, o1, o3-mini, and o4-mini. I'm marking that **vendor-claimed** and leaving the exact figure out — it's a single-source claim on a benchmark OpenAI co-authored, and I couldn't independently corroborate the number.
+
+---
+
+## How Does gpt-oss Compare to Other Open Models?
+
+This is where the honesty has to sharpen, because the open-weight field moved hard in the year after gpt-oss shipped. In August 2025, gpt-oss-120b was a genuine frontier open model. By June 2026, the [open-source leaderboard](/blog/best-open-local-llms-2026) is crowded with bigger, newer Chinese-lab models that post higher raw scores.
+
+| Model | License | Params (total/active) | Notable strength | Self-host reality |
+|-------|---------|----------------------|------------------|-------------------|
+| **gpt-oss-120b** | Apache 2.0 | 116.8B / 5.1B | Reasoning per VRAM, single-GPU | **One 80GB card** |
+| **gpt-oss-20b** | Apache 2.0 | 21B / 3.6B | Runs on a laptop | **16GB** |
+| DeepSeek V4 | MIT | 671B-class MoE | Top overall open score | Multi-GPU server |
+| Qwen 3.5 | Apache 2.0 | 397B / 17B | Vision, 201 languages, 1M context | Multi-GPU server |
+| GLM-5 | MIT | Large MoE | 77.8% SWE-Bench Verified (coding) | Multi-GPU server |
+| Gemma 4 | Gemma terms | Dense + MoE | Google ecosystem, on-device | Varies |
+
+The verdict that holds up: **gpt-oss is no longer the highest-scoring open model, and that's fine, because it was never competing on raw score.** [DeepSeek V4](/blog/deepseek-v4-analysis-2026), Qwen 3.5, and GLM-5 top the aggregate leaderboards — but they're 400B-to-671B-class models that need a multi-GPU server to self-host. gpt-oss competes on a different axis: **capability per gigabyte of VRAM**. If your constraint is "one H100" or "my laptop," the comparison isn't 120b vs DeepSeek V4 — it's 120b vs whatever else fits on your hardware, and there gpt-oss is still one of the best reasoning-per-VRAM options with a clean Apache 2.0 license.
+
+One more honest caveat: I'm citing the competitor scores from June 2026 leaderboard aggregates, and the open-model rankings churn monthly. Treat the relative ordering as a snapshot, not a law. For the live cross-model view, the [FrankX models tracker](/ai-ops/models-2026) stays more current than any single article can.
+
+---
+
+## What's the Self-Host Economics Story?
+
+Here's the part most "free model" write-ups get lazy about. **Open weights don't mean free inference — they mean you choose where the cost lands.** There are three real options, and the right one depends on volume.
+
+**Option 1 — Hosted API (someone else's GPU).** Plenty of providers serve gpt-oss-120b on a per-token basis, and because it's open and competitively served, the price floor is brutal. As of June 2026, [DeepInfra lists it around $0.04 per 1M input / $0.19 per 1M output](https://computeprices.com/models/gpt-oss-120b); Together.ai is around $0.15 / $0.60. Prices vary up to ~7x across providers. If you just want the model's intelligence and don't care whose hardware it runs on, this is cheaper than self-hosting until you hit serious volume — and you skip the ops entirely.
+
+**Option 2 — Self-host the 20b.** A 16GB GPU or an Apple Silicon laptop runs gpt-oss-20b for the cost of electricity, fully offline. This is the configuration that makes the open-weight pitch real: your prompts and outputs never touch a third party, there's no per-token meter, and it works on a plane. For privacy-sensitive prototyping, local agent loops, and anything you can't legally send to an API, the 20b is the answer.
+
+**Option 3 — Self-host the 120b on your own 80GB card.** This only pencils out at high, steady volume or under a hard data-residency requirement. An H100 isn't cheap to rent or own, and at low utilization the hosted API will beat your amortized cost every time. The math flips when you're running the GPU near-continuously, or when "the data cannot leave our VPC" is a non-negotiable rather than a preference.
+
+The clean way to think about it: **the API price is the make-or-buy benchmark.** If your projected monthly token spend on a hosted gpt-oss endpoint is less than the cost of the GPU plus the engineer-hours to run it, don't self-host the big one. The open weights are still worth it — for the 20b on local hardware, for the audit-grade control, and for the day a provider changes terms and you need an exit.
+
+---
+
+## Which Variant Should You Run?
+
+A short decision tree, because "it depends" isn't an answer.
+
+- **You want to ship a product on a privacy-sensitive workload, on a budget, today** → gpt-oss-20b, local, via Ollama or LM Studio. 16GB, offline, Apache 2.0, done.
+- **You need maximum reasoning quality and have (or can rent) an 80GB GPU** → gpt-oss-120b. It's near-o4-mini-class on reasoning and fits on one card.
+- **You want gpt-oss intelligence but don't want to run GPUs** → a hosted provider (DeepInfra, Together, Groq, Fireworks). Cheapest path to the capability, zero ops.
+- **You're building content-moderation or policy-classification** → gpt-oss-safeguard (more below), the fine-tuned variant built for exactly that.
+- **You need the highest possible open score and have a multi-GPU server** → honestly, look at DeepSeek V4 or Qwen 3.5 instead. gpt-oss wins on VRAM efficiency, not on topping the leaderboard.
+
+---
+
+## What Is gpt-oss-safeguard?
+
+A development worth knowing about: on October 29, 2025, OpenAI [released gpt-oss-safeguard](https://www.helpnetsecurity.com/2025/10/29/openai-gpt-oss-safeguard-safety-models/) in two sizes — **gpt-oss-safeguard-120b** and **gpt-oss-safeguard-20b** — as a research preview, also under Apache 2.0 and downloadable from Hugging Face.
+
+These are fine-tuned versions of the base gpt-oss models built for one job: **policy-based classification at inference time.** Instead of training a fixed safety classifier, you hand the model your *own* written policy as a prompt, and it reasons over user messages, completions, or whole conversations to classify them against your rules — and produces a transparent chain of thought showing how it decided. For trust-and-safety teams, that's a meaningfully different shape than a black-box classifier: you can change the policy by editing text, and you can audit every decision. It's the most genuinely novel thing the family has shipped since launch.
+
+---
+
+## What Does It Mean for Builders?
+
+### For local-first and privacy-sensitive products
+
+gpt-oss-20b is the most useful model in this family for the most people. It's the one that makes "the data never leaves the device" a real architecture instead of a slide. Run it through Ollama for a one-line setup, or vLLM if you need throughput. The 131K context means you can hold a substantial document set in a single offline session. The constraint to design around is the harmony format and the reasoning-effort knob — set `low` for snappy interactive use, `high` when correctness matters more than latency.
+
+### For agentic systems
+
+Both models have native function calling, web browsing, Python execution, and structured outputs baked in. That's the table-stakes set for tool-using agents, and having it in an Apache 2.0 model you can run yourself is the appeal: you can build a local agent loop with no per-call API cost and no rate limit but your own GPU. The catch is the same as every open reasoning model — the 120b is near-o4-mini-class, not near-frontier, so for the hardest agentic coding tasks the [proprietary frontier](/ai-ops/models-2026) still pulls ahead. Match the model to the cost-of-error: route the cheap, high-volume, error-tolerant steps to local gpt-oss and reserve the expensive frontier calls for the steps where a silent mistake is costly.
+
+### For cost-conscious teams
+
+The discipline here is make-or-buy, run the numbers honestly, and don't self-host the 120b for ego. The 20b on local hardware is close to free. The 120b on a hosted endpoint is pennies per million tokens. The 120b on your own H100 only wins at scale or under a data-residency mandate. Pick deliberately.
+
+---
+
+## FAQ
+
+### Is gpt-oss free to use?
+
+The weights are free to download under the Apache 2.0 license — no API key, no royalties, no usage caps. But running them isn't free: you either pay for your own GPU (electricity plus hardware) or pay a hosted provider per token. The 20b runs on a 16GB consumer GPU for the cost of electricity; the 120b needs an 80GB card. Apache 2.0 means you can use them commercially and ship products on top with zero licensing cost.
+
+### What hardware do I need to run gpt-oss?
+
+gpt-oss-20b runs in about 16GB of memory — a single consumer GPU or an Apple Silicon laptop with unified memory. gpt-oss-120b runs on a single 80GB GPU like an NVIDIA H100 or AMD MI300X. Both ship MXFP4-quantized, which is what makes those footprints possible. Note that those are minimums to load the model; a full 131K-token context needs extra headroom for the KV cache.
+
+### Where can I run gpt-oss locally?
+
+Ollama and LM Studio are the easiest one-line setups for the 20b. vLLM is the production choice for throughput. llama.cpp and Hugging Face Transformers also support both models. All of these handle OpenAI's required harmony response format for you — you only have to deal with harmony directly if you call the raw weights.
+
+### Is gpt-oss better than Qwen, DeepSeek, or GLM?
+
+Not on raw benchmark scores. As of June 2026, DeepSeek V4, Qwen 3.5, and GLM-5 top the open-model leaderboards — but they're 400B-to-671B-class models that need a multi-GPU server. gpt-oss wins on a different axis: capability per gigabyte of VRAM. If your constraint is one GPU or a laptop, gpt-oss is one of the best reasoning options that actually fits, with a clean Apache 2.0 license.
+
+### Is there a gpt-oss-2 or newer version?
+
+As of June 2026, no. The base family is still gpt-oss-120b and gpt-oss-20b from August 2025. What's new since launch: gpt-oss-safeguard (a policy-classification fine-tune) shipped in October 2025, and gpt-oss-120b became an official MLPerf Inference v6.0 benchmark in March 2026. There's been no successor base model announced.
+
+### Which benchmark numbers are verified vs vendor-claimed?
+
+All the headline figures (AIME, GPQA Diamond, MMLU, HLE, SWE-Bench) come from OpenAI's own model card and launch evals — treat them as vendor-reported. They've held up reasonably in independent testing, but the GPQA Diamond 80.1% is the most trustworthy general-capability signal; the saturated AIME scores tell you less than they appear to. The HealthBench claims are single-source on a benchmark OpenAI co-authored, so I marked them vendor-claimed and left the exact figure out.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI.
+Published June 5, 2026. Benchmarks are OpenAI's own model-card and launch-post figures (arXiv 2508.10925), cross-referenced against the gpt-oss GitHub repo, MLCommons, and independent pricing trackers. Vendor-reported numbers are marked as such; figures I couldn't independently corroborate were omitted rather than guessed.*

--- a/content/blog/llama-4-analysis-2026.mdx
+++ b/content/blog/llama-4-analysis-2026.mdx
@@ -81,7 +81,7 @@ This is the uncomfortable part, and pretending otherwise would be dishonest. Her
 | Model | Open weights | MMLU-Pro | GPQA Diamond | Position |
 |-------|--------------|----------|--------------|----------|
 | **Llama 4 Maverick** | Yes (Community License) | 80.5 | 69.8 | Solid generalist, trailing |
-| Gemma 4 (~31B) | Yes (Gemma License) | 85.2 | 84.3 | Smaller, stronger on knowledge |
+| Gemma 4 (~31B) | Yes (Apache 2.0) | 85.2 | 84.3 | Smaller, stronger on knowledge |
 | Qwen 3.5 | Yes (Apache 2.0) | — | 88.4 | Strongest open science reasoner |
 | DeepSeek V4 Pro | Yes (MIT-style) | — | — | Top open Intelligence Index (~52) |
 | Kimi K2.6 | Yes | — | — | Highest open Intelligence Index (~54) |

--- a/content/blog/llama-4-analysis-2026.mdx
+++ b/content/blog/llama-4-analysis-2026.mdx
@@ -1,0 +1,195 @@
+---
+title: "Llama 4 Maverick in 2026: Still Meta's Open Flagship, Now Running Behind the Pack"
+description: "Llama 4 Maverick (400B total / 17B active MoE, 1M context, Llama 4 Community License) is still Meta's open-weight flagship in June 2026 — Behemoth never shipped. Verified benchmarks, real VRAM and self-host requirements, how it stacks up against DeepSeek V4, Qwen 3.5, and Kimi K2.6, and what it means for builders."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - meta
+  - llama
+  - open-weights
+  - local-llms
+  - ai-2026
+  - benchmarks
+keywords:
+  - llama 4 maverick
+  - llama 4 maverick benchmarks
+  - llama 4 maverick vram
+  - llama 4 behemoth release
+  - llama 4 self host
+  - llama 4 vs deepseek v4
+  - best open weight model 2026
+  - llama 4 community license
+  - llama 4 scout 10m context
+  - meta open source ai 2026
+image: "/images/blog/llama-4-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Llama 4 Maverick in 2026: Still Meta's Open Flagship, Now Running Behind the Pack
+
+**TL;DR**: As of June 2026, Meta's flagship open-weight model is still **Llama 4 Maverick** (`meta-llama/Llama-4-Maverick-17B-128E-Instruct`) — a 400B-total / 17B-active mixture-of-experts model with a 1M-token context window, native text-and-image input, and a 16K max output, released April 5, 2025 under the Llama 4 Community License. There is no Llama 4.5 and no Llama 5. **Llama 4 Behemoth** (~2T parameters, 288B active) never shipped public weights and was paused in May 2026. The weights are free, but the verified benchmarks — MMLU-Pro 80.5, GPQA Diamond 69.8, LiveCodeBench 43.4 — now sit behind the open frontier set by DeepSeek V4, Qwen 3.5, Kimi K2.6, and even Gemma 4. Maverick is still a legitimate, permissively licensed, multimodal workhorse. It is no longer the model that wins the leaderboard. Here's the honest picture for builders deciding whether to self-host it.
+
+---
+
+## What Is the Current Llama Flagship in June 2026?
+
+It is the same one that shipped fourteen months ago: **Llama 4 Maverick**.
+
+When Meta launched the Llama 4 "herd" on April 5, 2025, the plan read like a three-model ladder — **Scout** (the efficient one), **Maverick** (the flagship), and **Behemoth** (the ~2T-parameter teacher model that would eventually anchor the top). Behemoth was previewed as "still in training." It stayed that way. Independent reporting through 2026 indicates Behemoth's public release was paused in May 2026 amid internal capability concerns, and no public weights have shipped. So the ladder Meta actually ships in mid-2026 has two rungs, and Maverick is the top one.
+
+This matters because the repo and a lot of secondary coverage still treat "the next Llama" as imminent. It isn't here yet. If you're choosing an open Meta model today, you're choosing between Scout and Maverick — full stop. No 4.x point release, no Behemoth GA, no Llama 5.
+
+Three things define where Maverick stands now:
+
+1. **It's an early-fusion, natively multimodal MoE.** 128 experts, 17B parameters active per token out of 400B total, text and image in, text out. That architecture was genuinely ahead of the pack in April 2025.
+
+2. **The license is the real product.** The Llama 4 Community License permits commercial use for any organization under 700M monthly active users. For almost everyone reading this, that's "free, including commercially." That hasn't changed and it's still the strongest reason to reach for it.
+
+3. **The benchmarks have aged.** The open-weight frontier moved hard in late 2025 and early 2026. Maverick didn't move with it. It's competent, not leading.
+
+---
+
+## What Are the Verified Benchmarks?
+
+A note on sourcing first. The numbers below are drawn from Meta's own Llama 4 materials, the Hugging Face release notes, OpenRouter's model card, and aggregators including Artificial Analysis and independent benchmark roundups. Where a figure is Meta-reported and not independently reproduced, I mark it **vendor-claimed**. And there's a specific trap with Maverick that every honest write-up has to flag: the LMArena number Meta led with at launch was *not* the public weights. More on that below.
+
+| Benchmark | Llama 4 Maverick | What it measures |
+|-----------|------------------|------------------|
+| MMLU-Pro | **80.5** | Graduate-level multi-domain knowledge |
+| GPQA Diamond | **69.8** | Hard graduate science Q&A |
+| LiveCodeBench | **43.4** | Contamination-resistant coding |
+| Context window | **1M tokens** | Long-document / multi-file reasoning |
+| Max output | **16K tokens** | Single-pass generation ceiling |
+| LMArena ELO (public weights) | **~32nd place** | Human-preference voting |
+| LMArena ELO (experimental variant) | **1417** (vendor-claimed) | Human-preference voting, tuned variant |
+
+Two of these rows need the asterisk spelled out.
+
+**The LMArena story.** At launch, Meta promoted an ELO of **1417**, which put Maverick ahead of GPT-4o and just behind Gemini 2.5 Pro. But the model submitted to the arena was `Llama-4-Maverick-03-26-Experimental` — a chat-tuned variant optimized for conversationality (longer, friendlier, emoji-studded answers that human raters reward). The *publicly downloadable weights* produced plainer output and ranked roughly 32nd on the same leaderboard once tested. LMArena updated its policies on April 7-8, 2025 in response, stating that Meta's interpretation of the submission rules "did not match what we expect from model providers." When you read "Maverick beats GPT-4o on LMArena," that's the experimental variant, not the weights you can download. Treat the 1417 as vendor-claimed and effectively unreproducible with the open weights.
+
+**The coding gap.** LiveCodeBench 43.4 was respectable at launch — above GPT-4o-era models — but it's the axis where the Chinese open labs pulled decisively ahead. The verified picture in 2026: Maverick is a solid generalist that is no longer a strong coder relative to its open peers.
+
+---
+
+## How Does It Compare to the Open Frontier?
+
+This is the uncomfortable part, and pretending otherwise would be dishonest. Here is where Maverick sits against the open-weight models that actually lead in mid-2026.
+
+| Model | Open weights | MMLU-Pro | GPQA Diamond | Position |
+|-------|--------------|----------|--------------|----------|
+| **Llama 4 Maverick** | Yes (Community License) | 80.5 | 69.8 | Solid generalist, trailing |
+| Gemma 4 (~31B) | Yes (Gemma License) | 85.2 | 84.3 | Smaller, stronger on knowledge |
+| Qwen 3.5 | Yes (Apache 2.0) | — | 88.4 | Strongest open science reasoner |
+| DeepSeek V4 Pro | Yes (MIT-style) | — | — | Top open Intelligence Index (~52) |
+| Kimi K2.6 | Yes | — | — | Highest open Intelligence Index (~54) |
+
+On the Artificial Analysis Intelligence Index v4.0 — which aggregates ten evals including GPQA Diamond, Humanity's Last Exam, Terminal-Bench Hard, and SciCode — the leading *open-weight* models in 2026 are **Kimi K2.6 (~54)** and **DeepSeek V4 Pro (~52)**, both within striking distance of Gemini 3.1 Pro's ~57 at the closed frontier. Maverick is not in that conversation. Even **Gemma 4**, a model an order of magnitude smaller in active footprint, posts higher MMLU-Pro and dramatically higher GPQA Diamond.
+
+The honest one-line summary: **Maverick is the most permissively licensed, easiest-to-source multimodal MoE in its weight class — but it is no longer the smartest open model you can run.** If raw capability per dollar is your only axis, DeepSeek V4 or Qwen 3.5 win. If license clarity, multimodality, and the Meta/Hugging Face ecosystem matter more, Maverick still earns a slot. For the broader open-vs-closed map, see the [FrankX models tracker](/ai-ops/models-2026) and the [best open and local LLMs guide](/blog/best-open-local-llms-2026).
+
+---
+
+## What Does It Actually Take to Self-Host?
+
+This is where Llama 4 gets misunderstood. "17B active parameters" sounds like a model you can run on a gaming GPU. You cannot. In an MoE, **all the experts have to live in memory even though only a fraction fire per token.** Maverick's 400B total parameters set the VRAM floor, not its 17B active count.
+
+| Variant | Total / Active | Experts | Context | Realistic VRAM | Where to run |
+|---------|----------------|---------|---------|----------------|--------------|
+| **Llama 4 Scout** | 109B / 17B | 16 | 10M | ~55 GB at Q4 (fits 1× H100 80GB) | vLLM, Ollama, HF, single-GPU cloud |
+| **Llama 4 Maverick** | 400B / 17B | 128 | 1M | FP8 ≈ 75 GB/GPU on 8× H100 node (~600 GB); 200 GB+ at Q4 | vLLM (tensor-parallel 8), 8× H100/H200 cloud |
+| Llama 4 Behemoth | ~2T / 288B | 16 | — | Not released | — (paused, no public weights) |
+
+The practical takeaways:
+
+- **Scout is the self-hostable one.** With 4-bit quantization (AWQ/GPTQ), Scout fits on a single H100 80GB at roughly 55 GB, leaving headroom for KV cache at moderate context lengths. That's a real single-GPU deployment. Its 10M-token context is the genuinely differentiated feature here — nothing else open touches it. Note FP16 Scout needs ~218 GB; quantization is mandatory for single-GPU.
+- **Maverick is a data-center model.** Meta ships official FP8 weights specifically so it fits on a single 8× H100 node (~75 GB per GPU). At BF16/FP16 you're looking at ~800 GB and needing 8× H200. At Q4 it's still 200 GB+ — effectively out of reach for anything but multi-GPU server hardware. A typical Maverick FP8 8× H100 deployment runs roughly $17,500-23,000/month in rented compute. This is not a laptop model and no amount of quantization makes it one.
+- **The 10M / 1M context numbers are theoretical ceilings, not free.** Every token in context consumes KV-cache VRAM. Don't set `--max-model-len` to 10M because Scout *can*; size it to your actual workload (e.g. 32K) and spend the saved memory on batching. `--kv-cache-dtype fp8` can roughly double usable context with little accuracy loss.
+
+**Where to run it:**
+
+- **vLLM** is the production path. For Maverick: `vllm serve meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --tensor-parallel-size 8 --max-model-len 430000`. Note A100s don't support FP8 natively — you need H100/H200.
+- **Ollama** works for Scout-class single-GPU/single-user setups; Maverick is impractical there.
+- **Hugging Face** hosts the official weights (`meta-llama/Llama-4-Maverick-17B-128E-Instruct` and the `-FP8` variant) behind the license gate.
+- **Managed APIs** if you don't want to run it: OpenRouter, Together, Fireworks, Groq, AWS Bedrock, and Oracle/IBM all serve Maverick. OpenRouter pricing is around **$0.15 / $0.60 per 1M** input/output — the weights are $0, you pay for hosting either way.
+
+---
+
+## Which Variant Should You Pick?
+
+A short decision tree, because the two shipped variants serve genuinely different jobs:
+
+- **Pick Scout if** you want to actually self-host on accessible hardware (single H100), you need the 10M-token context for whole-codebase or whole-corpus reasoning, and your quality bar is "good enough generalist." Scout is the only Llama 4 model a small team can realistically run on one GPU.
+- **Pick Maverick if** you need the stronger generalist quality and multimodality and you either have an 8× H100/H200 node or you're fine consuming it via API. Its edge over Scout is real but you're paying for it in hardware.
+- **Pick neither if** capability-per-dollar is the deciding factor and the license terms work for you. In mid-2026, DeepSeek V4 and Qwen 3.5 are stronger open models, and Qwen ships under Apache 2.0 — a cleaner license than Llama's MAU-gated Community License. See the [DeepSeek V4 analysis](/blog/deepseek-v4-analysis-2026) for that side of the comparison.
+
+---
+
+## What Does It Mean for Builders?
+
+### For teams who self-host
+
+Maverick's FP8 weights are well-engineered for the 8× H100 node — Meta clearly optimized the release for that deployment target, and vLLM support is mature. If you already run that class of hardware and you want a permissively licensed multimodal MoE inside your own VPC, Maverick is a defensible choice. The data-residency and no-per-token-cost story is the whole pitch. Just don't choose it expecting frontier benchmarks; choose it for control and license clarity.
+
+### For long-context work
+
+Scout's 10M-token window remains the standout open-weight feature in 2026 — nothing else you can download comes close. If your problem is "reason over an enormous corpus on one GPU," Scout is uniquely positioned even though its raw reasoning trails newer models. The capability/context tradeoff is the actual decision.
+
+### For multimodal builders
+
+Native image input is real and useful, and it's permissively licensed. If you need open-weight vision-plus-text and want to avoid API lock-in, Maverick covers it. The vision quality is solid rather than class-leading, but "open, multimodal, self-hostable, commercially licensed" is a narrow field and Maverick is in it.
+
+### For cost-conscious routing
+
+If you're consuming via API rather than self-hosting, Maverick at ~$0.15/$0.60 is cheap — but so are its stronger open competitors, and the closed budget tier (Gemini Flash-class models) often beats it on quality-per-dollar. The case for Maverick-via-API is weak; the case for Maverick-self-hosted-for-control is the real one. Match the model to the constraint that actually binds you: license, hardware, residency, or raw capability. They rarely point at the same model.
+
+---
+
+## What Changed Since Launch?
+
+Mechanically, almost nothing — and that's the story. The weights you download in June 2026 are the same April 2025 release. What changed is the *context* around them:
+
+| Dimension | At launch (Apr 2025) | Now (Jun 2026) |
+|-----------|----------------------|----------------|
+| Position vs open peers | Near the top | Trailing DeepSeek V4, Qwen 3.5, Kimi K2.6, Gemma 4 |
+| Behemoth | "In training" | Paused May 2026, no public weights |
+| LMArena framing | 1417 ELO headline | Revealed as experimental variant; public weights ~32nd |
+| Ecosystem support | Day-one vLLM, Bedrock | Mature across all major inference providers |
+| Best use case | "Best open multimodal MoE" | "Permissively licensed multimodal MoE for self-hosting" |
+
+The model didn't get worse. The field got better, faster, and the flagship Meta promised to put on top — Behemoth — never arrived.
+
+---
+
+## FAQ
+
+### Is Llama 4 Maverick still Meta's flagship open model in 2026?
+
+Yes. As of June 2026, Llama 4 Maverick (400B total / 17B active, 128 experts, 1M context) remains Meta's top publicly available open-weight model. There is no Llama 4.5 or Llama 5, and Llama 4 Behemoth — the ~2T-parameter model meant to sit above Maverick — never shipped public weights and was paused in May 2026.
+
+### What VRAM do I need to run Llama 4 Maverick?
+
+Maverick is a data-center model. Meta's official FP8 weights are sized to fit a single 8× H100 80GB node (~75 GB per GPU, ~600 GB total). At Q4 it's still 200 GB+; at BF16 roughly 800 GB. It does not run on consumer hardware. If you want single-GPU self-hosting, use **Llama 4 Scout** instead — it fits on one H100 80GB at ~55 GB with 4-bit quantization.
+
+### How does Llama 4 Maverick compare to DeepSeek V4 and Qwen 3.5?
+
+On verified 2026 benchmarks, Maverick trails. DeepSeek V4 Pro and Kimi K2.6 lead the open-weight Artificial Analysis Intelligence Index (~52 and ~54), and Qwen 3.5 posts a markedly higher GPQA Diamond (88.4 vs Maverick's 69.8). Maverick's advantages are its native multimodality, its 1M context, and the Meta/Hugging Face ecosystem — not raw capability.
+
+### Is Llama 4 free? What's the license?
+
+The weights are free to download and use under the **Llama 4 Community License**, which allows commercial use for any organization with fewer than 700 million monthly active users. That covers essentially every team likely to read this. You pay only for hardware (self-hosting) or per-token hosting (via APIs like OpenRouter at ~$0.15/$0.60 per 1M). Note this is more restrictive than Apache 2.0, which Qwen 3.5 ships under.
+
+### What was the LMArena controversy about?
+
+At launch Meta promoted a 1417 ELO that put Maverick ahead of GPT-4o. But the submitted model was `Llama-4-Maverick-03-26-Experimental`, a chat-tuned variant optimized for human-preference voting — not the public weights, which ranked around 32nd on the same leaderboard. LMArena updated its policies on April 7-8, 2025, noting Meta's submission "did not match what we expect from model providers." Treat the 1417 as vendor-claimed and not reproducible with the open weights.
+
+### Should I wait for Llama 4 Behemoth or Llama 5?
+
+Don't build a plan around either. Behemoth was paused in May 2026 with no public weights and no committed release date, and there's no announced Llama 5. If you need an open model today, choose between Scout (self-hostable, 10M context) and Maverick (stronger, needs an 8× H100 node), or look at the stronger non-Meta open models like DeepSeek V4 and Qwen 3.5.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI.
+Published June 5, 2026. Specs and benchmarks validated against Meta's Llama 4 materials, Hugging Face, OpenRouter, Artificial Analysis, and independent coverage including The Register's reporting on the LMArena variant. Vendor-claimed figures — including the 1417 LMArena ELO and the ~2T Behemoth specs — are marked as such. Behemoth had not shipped public weights as of this writing.*

--- a/content/blog/mistral-large-3-analysis-2026.mdx
+++ b/content/blog/mistral-large-3-analysis-2026.mdx
@@ -1,0 +1,185 @@
+---
+title: "Mistral Large 3: The 675B Open-Weight Frontier Model Europe Has Been Waiting For"
+description: "Mistral Large 3 (mistral-large-2512) is a 675B/41B-active MoE released under Apache 2.0, December 2025. 256K context, $0.50/$1.50 API pricing, runs on one 8xH200 node. Verified benchmarks, EU sovereignty angle, self-host specifics, and what it means for builders."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - mistral
+  - open-weight
+  - frontier-models
+  - ai-2026
+  - benchmarks
+  - eu-sovereign-ai
+keywords:
+  - mistral large 3
+  - mistral large 3 review
+  - mistral large 3 benchmarks
+  - mistral large 3 pricing
+  - mistral large 3 apache 2.0
+  - mistral large 3 self host
+  - mistral large 3 vram
+  - mistral large 3 vs deepseek
+  - mistral 3 open weight
+  - best open weight model 2026
+image: "/images/blog/mistral-large-3-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Mistral Large 3: The 675B Open-Weight Frontier Model Europe Has Been Waiting For
+
+**TL;DR**: On December 2, 2025, Mistral shipped Mistral Large 3 (`mistral-large-2512`) — a sparse Mixture-of-Experts model with 675B total / 41B active parameters, **released under Apache 2.0**. Base and instruct weights are on Hugging Face; there is no commercial-license catch on this one. It has a 256K context window, accepts text and images, and the FP8 checkpoint fits on a single 8xH200 node. API access on Mistral's la Plateforme runs $0.50 input / $1.50 output per million tokens — a 75% cut from Mistral Large 2. The benchmarks tell an honest story: it is one of the strongest *non-reasoning* open-weight models in the world (LMArena Elo ~1418, #2 among open-source non-reasoning models, ~73% MMLU-Pro, ~92% HumanEval), but it trails the dedicated reasoners — DeepSeek, Kimi K2-Thinking, GLM — on hard reasoning (GPQA Diamond ~44%). A reasoning variant is "coming soon." Here is what actually matters.
+
+---
+
+## What Is Mistral Large 3?
+
+Mistral Large 3 is the flagship of the Mistral 3 family, a 10-model release that landed on December 2, 2025. The family pairs one large frontier model with nine smaller, fully offline-capable dense models — the Ministral 3 line at 14B, 8B, and 3B, each shipping in Base, Instruct, and Reasoning variants. Large 3 is the headline act, and its model id is `mistral-large-2512` (the `2512` encodes December 2025, Mistral's standard versioning).
+
+Three things define this release:
+
+1. **It is genuinely open.** Both the base and instruction-tuned checkpoints ship under the **Apache 2.0** license — the permissive one. No "research-only" clause, no monthly-active-user threshold, no separate commercial agreement to fine-tune and redistribute. For a model at this scale, that is the rare combination. Mistral's earlier flagships (Large 2) carried the more restrictive Mistral Research License; Large 3 is a deliberate return to the permissive lane that made Mistral's name.
+
+2. **It is a sparse MoE, not a dense behemoth.** 675B total parameters, but only **41B active** per forward pass. Mistral calls it a "granular Mixture of Experts." That ratio is the whole pitch: frontier-class knowledge capacity at the inference cost of a mid-size dense model. It was trained from scratch on 3,000 NVIDIA H200 GPUs.
+
+3. **It optimizes for throughput, not deep reasoning.** This is the honest framing the independent reviews converge on — Large 3 is strong at fast recall, knowledge, multilingual coverage, and code generation, and comparatively weak on the multi-step reasoning benchmarks where the dedicated "thinking" models live. The promised reasoning variant is meant to close that gap; it had not shipped as of this writing.
+
+---
+
+## What Are the Verified Benchmarks?
+
+A note on sourcing. The figures below come from Mistral's official [Mistral 3 announcement](https://mistral.ai/news/mistral-3/) and the [Hugging Face model card](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512), cross-referenced against independent analysis from [Artificial Analysis](https://artificialanalysis.ai/models/mistral-large-3), [llm-stats](https://llm-stats.com/models/mistral-large-3-2509), and [DataCamp](https://www.datacamp.com/blog/mistral-3). Where a number is single-sourced or disputed across reports, I flag it. One caveat up front: the MMLU-Pro figure varies by source — some independent evals report ~73%, others put it in the low 80s. I quote the more conservative, more frequently cited number and mark the spread.
+
+| Benchmark | Mistral Large 3 | What it measures |
+|-----------|-----------------|------------------|
+| LMArena Elo | **~1418** (#2 OSS non-reasoning) | Crowd-sourced human preference |
+| MMLU-Pro | **~73%** (some sources higher) | Harder, distractor-rich knowledge |
+| MMLU (8-language) | **~85.5%** | Multilingual general knowledge |
+| MATH-500 | **93.6%** | Competition-style math |
+| HumanEval | **~92%** pass@1 | Code generation |
+| LiveCodeBench v6 | second-tier (below ~80% specialists) | Contamination-resistant coding |
+| GPQA Diamond | **~44%** | Graduate-level science reasoning |
+
+Two rows deserve more than a table cell.
+
+**The LMArena #2-among-open-non-reasoners result** is the cleanest signal of what Large 3 is good at. Human raters, blind, prefer its responses to almost every other open-weight model that does not do explicit chain-of-thought. That is the "feels good to use" axis — fast, fluent, knowledgeable, well-calibrated multilingual output. For chat, drafting, retrieval-augmented answering, and code completion, that ranking is the one that translates to production satisfaction.
+
+**GPQA Diamond at ~44%** is the number that keeps Large 3 honest. The dedicated reasoning models — DeepSeek-v3.2, Kimi K2-Thinking, GLM-4.6 — land in the high-70s to mid-80s on the same test, roughly double Large 3's score. On the [Artificial Analysis Intelligence Index](https://artificialanalysis.ai/models/mistral-large-3), which blends MMLU-Pro, GPQA, Humanity's Last Exam, LiveCodeBench, AIME, and more, Large 3 sits below those reasoners but comfortably above OLMo 3 and Llama 4 Maverick. The pattern is consistent: System-1 strength, System-2 gap. If your workload is hard math, multi-hop logic, or agentic problem decomposition, Large 3 is not yet the open model to reach for — wait for the reasoning variant or pair it with one.
+
+---
+
+## How Does It Compare to DeepSeek, Llama, and the Open Field?
+
+Where Large 3 sits against the June 2026 open-weight frontier:
+
+| Model | License | Active / Total params | Context | GPQA Diamond | Best at |
+|-------|---------|----------------------|---------|--------------|---------|
+| **Mistral Large 3** | **Apache 2.0** | 41B / 675B | 256K | ~44% | Multilingual, chat, fast code, EU residency |
+| DeepSeek-V4 | open (MIT-style) | (sparse MoE) | long | high-70s+ | Hard reasoning, coding, value |
+| Kimi K2-Thinking | open | reasoner | long | mid-80s | Deep reasoning |
+| GLM-4.6 | open | MoE | long | high-70s | Reasoning, agents |
+| Llama 4 Maverick | Llama license | MoE | long | below Large 3 | General-purpose, ecosystem |
+
+The honest read: **Large 3 wins on the "open and pleasant" axis and on European sovereignty; the reasoning-specialist open models win on hard cognition.** If you are choosing an open-weight model today and your tasks are knowledge work, multilingual content, RAG, or code completion, Large 3's LMArena standing and permissive license make it a top pick. If your tasks are competition math, scientific reasoning, or long-horizon agentic planning, the [DeepSeek-V4](/blog/deepseek-v4-analysis-2026)-class reasoners are the stronger fit until Mistral's reasoning variant ships. For a fuller cross-model breakdown including the closed frontier, see the [FrankX models tracker](/ai-ops/models-2026) and the [best open and local LLMs guide](/blog/best-open-local-llms-2026).
+
+One thing that does not get said enough: the Apache 2.0 license is itself a benchmark. A model that scores 5 points lower but that you can legally fine-tune, redistribute, and run inside your own walls without a commercial negotiation is, for many teams, the more valuable artifact. License terms are a capability.
+
+---
+
+## Can You Self-Host It? Hardware and Cost
+
+Yes — and this is where Large 3 earns its keep. The weights are public, so the only question is whether you can run them.
+
+| Deployment | Spec | Notes |
+|------------|------|-------|
+| **API (la Plateforme)** | $0.50 / $1.50 per 1M tokens | 256K context, EU-resident endpoints |
+| **Self-host (FP8)** | 1x 8xH200 node | `--tensor-parallel-size 8`, vLLM, Mistral tokenizer |
+| **Self-host (NVFP4)** | smaller footprint | Near-FP8 accuracy; FP8 still advised above 64K context |
+| **Open weights** | $0 license cost | Apache 2.0, base + instruct on Hugging Face |
+
+The practical headline from the [vLLM recipe](https://docs.vllm.ai/projects/recipes/en/latest/Mistral/Mistral-Large-3.html) and [Red Hat's day-zero guide](https://developers.redhat.com/articles/2025/12/02/run-mistral-large-3-ministral-3-vllm-red-hat-ai): the **FP8 checkpoint runs on a single 8xH200 node** at full 256K context, served with vLLM at tensor-parallel-size 8. Mistral also published optimized FP8 and NVFP4 variants built with `llm-compressor`. NVFP4 gives you a smaller, faster checkpoint with accuracy close to FP8 — with one caveat the maintainers call out: above ~64K context, NVFP4 showed a quality drop, so FP8 weights are recommended for long-context work.
+
+What this means in plain terms: an organization with one 8xH200 server (or equivalent Blackwell hardware) can run a frontier-class model entirely on its own infrastructure, no tokens leaving the building, at zero per-token cost. That is the proposition that the closed frontier — Opus, GPT, Gemini — structurally cannot match. For a regulated European enterprise, "one node, FP8, in our data center" is not a footnote; it is the entire reason to choose this model.
+
+The 41B-active MoE design is what makes the on-prem economics work. You are paying for 41B-parameter inference latency, not 675B, while keeping the knowledge capacity of the full model.
+
+---
+
+## Why the EU Sovereignty Angle Actually Matters
+
+Most "European AI" framing is marketing. Mistral's is closer to substance, and Large 3 is the clearest expression of it.
+
+Three concrete facts. First, **Mistral's hosted endpoints stay within EU jurisdictions** — relevant for GDPR-sensitive workloads where data-residency is a hard legal requirement, not a preference. Second, in late 2025 Mistral partnered with SAP and the French and German governments to build a sovereign AI stack for public administrations, explicitly so that government data is processed on technology compliant with EU law. Third, in March 2026 Mistral raised $830M to build datacenters near Paris and in Sweden, with a Paris facility housing 13,800 NVIDIA GB300 GPUs and coming online in Q2 2026 — physical European compute, not rebadged US cloud.
+
+Stack the Apache 2.0 license on top and you get the combination that no US frontier lab offers: **a model you can either call from EU-resident endpoints or download and run entirely inside your own EU infrastructure**, with full legal freedom to fine-tune it on your proprietary data. For a German insurer, a French ministry, or any organization where "where does the inference physically happen" is a board-level question, that is decisive in a way no benchmark row captures.
+
+The contrast with the open-vs-commercial split elsewhere in Mistral's lineup is worth noting. Mistral runs a genuine two-track strategy — some models open (the Mistral 3 / Ministral 3 weights), some commercial (the Medium tier, API-only). Large 3 lands firmly on the open track, which is precisely what makes it interesting. You are not choosing between sovereignty and capability; with Large 3 you get both.
+
+---
+
+## What's the Pricing?
+
+| Model | Input / 1M | Output / 1M | Notes |
+|-------|------------|-------------|-------|
+| **Mistral Large 3** | **$0.50** | **$1.50** | la Plateforme; 256K context; or $0 self-hosted |
+| Mistral Large 2 (prior) | $2.00 | $6.00 | The model Large 3 replaces |
+| Self-hosted Large 3 | $0 license | $0 license | Apache 2.0; you pay only compute |
+
+The API pricing is the quiet story. At $0.50 input / $1.50 output per million tokens, Large 3 is **75% cheaper than Mistral Large 2** was, and it undercuts most of the closed frontier by a wide margin while being more capable than its predecessor. For comparison, the closed leaders sit at multiples of this — and none of them can be self-hosted at all.
+
+If you self-host, the per-token cost goes to zero and your only spend is the 8xH200 (or Blackwell) compute you already own or rent. That flips the build-vs-buy math for any team with steady, high-volume inference: at sufficient scale, the amortized cost of owning the node beats per-token API billing, and you get data residency for free.
+
+---
+
+## What Does It Mean for Builders?
+
+### For European and regulated teams
+
+This is the clearest win. If data residency or GDPR compliance is a hard constraint, Large 3 is now the most capable model you can run entirely under your own control. Pull the FP8 weights, stand up vLLM on an 8xH200 node, and you have a frontier-class assistant with zero data egress and no licensing negotiation. Pair it with the Apache-licensed Ministral 3 small models (14B/8B/3B) for cheaper routing tiers — same license, same ecosystem.
+
+### For cost-conscious production
+
+At $0.50/$1.50 the API is cheap enough to be a default for high-volume chat, drafting, summarization, RAG answering, and code completion. Where Large 3 shines — fast, fluent, multilingual, knowledgeable output — maps directly to the bulk of production LLM traffic. Route the hard-reasoning minority (competition math, multi-hop logic, agentic planning) to a reasoning specialist; let Large 3 carry the volume.
+
+### For coding workflows
+
+~92% HumanEval and strong code-generation are real, but the LiveCodeBench second-tier placement is the honest caveat: on contamination-resistant, harder coding evals, Large 3 trails the dedicated coding models that cluster above 80%. Use it for completion, boilerplate, and well-specified generation; reach for a coding specialist on gnarly, multi-file, reasoning-heavy tasks.
+
+### For everyone watching the reasoning variant
+
+The most important Large 3 number may not exist yet. Mistral has promised a reasoning version, and the GPQA gap is exactly the gap such a variant is built to close. If it lands and pulls GPQA Diamond into the 70s while keeping the Apache license, Large 3's calculus changes from "great for knowledge work, weak on reasoning" to "open frontier across the board." Watch for it.
+
+---
+
+## FAQ
+
+### Is Mistral Large 3 actually open source?
+
+The weights are open under the **Apache 2.0 license** — both the base and instruction-tuned checkpoints, on Hugging Face. That is the permissive license: you can fine-tune, redistribute, and run it commercially without a separate agreement or usage threshold. It is more accurate to call it "open-weight" than "open-source" (the training data and full pipeline are not released), but on the license that governs use, it is as permissive as it gets at this scale.
+
+### How much does Mistral Large 3 cost?
+
+On Mistral's la Plateforme API, $0.50 per million input tokens and $1.50 per million output tokens — a 75% cut from Mistral Large 2's $2.00/$6.00. If you self-host the open weights, the license cost is $0 and you pay only for compute (one 8xH200 node runs the FP8 checkpoint at full context).
+
+### What hardware do I need to self-host it?
+
+The FP8 checkpoint runs on a single **8xH200 node** with vLLM at `--tensor-parallel-size 8`, supporting the full 256K context. An NVFP4 variant uses less memory with near-FP8 accuracy, though FP8 is recommended above ~64K context. FP8 is native on Hopper and Blackwell GPUs (H100, H200, B200).
+
+### What's the context window and what modalities does it support?
+
+256K tokens of context (some sources cite 262K). It accepts text and images as input and produces text output, with native function calling and structured/JSON output. It is multimodal on the input side, not an image generator.
+
+### How does it compare to DeepSeek and the reasoning models?
+
+Large 3 leads on human-preference (LMArena #2 among open non-reasoners), multilingual knowledge, and fast code generation, and it is the strongest pick for EU data residency. It trails the dedicated reasoners — DeepSeek-V4, Kimi K2-Thinking, GLM-4.6 — on hard reasoning, where its ~44% GPQA Diamond is roughly half their scores. Choose Large 3 for knowledge work and sovereignty; choose a reasoner for hard math and multi-step logic. A Mistral reasoning variant is promised but had not shipped as of June 2026.
+
+### Which numbers here are verified vs vendor-claimed?
+
+The architecture (675B/41B MoE), Apache 2.0 license, 256K context, December 2, 2025 release, $0.50/$1.50 pricing, and 8xH200 FP8 self-host requirement are all well-corroborated across Mistral's announcement, the Hugging Face card, and the vLLM/Red Hat guides. The benchmark figures (LMArena ~1418, ~73% MMLU-Pro, ~92% HumanEval, ~44% GPQA, 93.6% MATH-500) come from a mix of Mistral's evals and independent analysis; the MMLU-Pro figure in particular varies by source (~73% to low-80s), which I have flagged rather than picked the flattering number.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI.
+Published June 5, 2026 with specs and benchmarks validated against Mistral's official announcement, the Hugging Face model card, the vLLM and Red Hat deployment guides, Artificial Analysis, and llm-stats. Disputed or single-sourced figures are flagged as such.*

--- a/content/blog/phi-analysis-2026.mdx
+++ b/content/blog/phi-analysis-2026.mdx
@@ -1,0 +1,228 @@
+---
+title: "Microsoft Phi-4 in 2026: The Open-Weight Small Model That Runs on Your Laptop"
+description: "Microsoft's Phi-4 family — Phi-4 (14B), Phi-4-mini (3.8B), Phi-4-multimodal (5.6B), Phi-4-reasoning, and the March 2026 Phi-4-reasoning-vision-15B — are MIT-licensed, $0 to download, and run on consumer GPUs. Verified benchmarks, VRAM tables, and what the small-model angle means for builders."
+date: "2026-06-05"
+lastUpdated: "2026-06-05"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - microsoft
+  - phi
+  - open-weight
+  - small-language-models
+  - local-ai
+  - benchmarks
+keywords:
+  - microsoft phi-4
+  - phi-4 benchmarks
+  - phi-4 vram requirements
+  - phi-4 reasoning vision 15b
+  - phi-4 mini 3.8b
+  - run phi-4 locally ollama
+  - best small language model 2026
+  - phi-4 mmlu gpqa
+  - open weight small model
+  - phi-4 vs gemma 3
+image: "/images/blog/phi-analysis-2026-hero.svg"
+featured: true
+schema: ["Article", "FAQPage"]
+---
+
+# Microsoft Phi-4 in 2026: The Open-Weight Small Model That Runs on Your Laptop
+
+**TL;DR**: Microsoft's Phi-4 family is the small-language-model line that keeps embarrassing models several times its size — and it's MIT-licensed and free to download. The lineup spans Phi-4-mini (3.8B), Phi-4-multimodal (5.6B, text+vision+speech), the flagship Phi-4 (14B), the reasoning pair Phi-4-reasoning / Phi-4-reasoning-plus (14B), and the newest member, **Phi-4-reasoning-vision-15B**, shipped March 4, 2026, which decides on its own when to "think" and when to answer instantly. Base Phi-4 posts MMLU 84.8, GPQA 56.1, MATH 80.4, and HumanEval 82.6 — outscoring its own teacher (GPT-4o) on GPQA and MATH. The practical headline: a Q4 quant of the 14B runs in roughly 8-10GB of VRAM, so this is frontier-adjacent reasoning on a gaming laptop for $0 in API spend. There is no GA "Phi-5" as of June 2026. Here's the honest state of the family and what it means for builders.
+
+---
+
+## What Is the Phi Family in June 2026?
+
+Phi is Microsoft Research's bet that **data quality beats parameter count**. The whole program is built on "textbook-quality" curated and synthetic training data rather than scraping more of the internet, and the result is a family of small models that punch well above their weight class.
+
+As of June 2026, the current generation is the **Phi-4 family** — there is no generally available Phi-5. (You'll find "Phi-5" deployment guides floating around; treat those as speculative or pre-release until Microsoft ships an official model card. I'm not going to feature a model that doesn't have one.) The family is open-weight under the **MIT license**, which is about as permissive as it gets: use it commercially, fine-tune it, redistribute it, no royalty.
+
+Five things define where the family sits right now:
+
+1. **It's a *small* family on purpose.** The largest member is 15B parameters. Nothing here competes with a frontier model on raw breadth — the entire pitch is capability-per-parameter and the ability to run on hardware you already own.
+
+2. **The newest model is multimodal and adaptive.** Phi-4-reasoning-vision-15B (March 2026) is trained to default to fast, direct inference on perception tasks and only spend tokens on long chain-of-thought when the problem — math, science, diagrams — actually needs it.
+
+3. **Reasoning came to the small tier.** Phi-4-reasoning and Phi-4-reasoning-plus (April 2025, 14B, MIT) brought o1-mini-class math performance to a model you can run locally.
+
+4. **The economics are inverted versus the API world.** Open weights mean the per-token price is $0. Your cost is hardware and electricity. For high-volume, privacy-sensitive, or offline workloads, that changes the math entirely.
+
+5. **It runs everywhere small models run.** Ollama, LM Studio, llama.cpp, ONNX Runtime, Azure AI Foundry, Foundry Local, and Hugging Face all carry official builds.
+
+---
+
+## What Are the Current Variants?
+
+Here's the full Phi-4 lineup with the specifics that matter for self-hosting. VRAM figures are for the commonly used Q4_K_M GGUF quant on the 14B/15B models and are corroborated across community runner guides; treat them as practical estimates, not guarantees.
+
+| Variant | Params | Context | Modalities | Min VRAM (Q4) | Where to run |
+|---------|--------|---------|------------|---------------|--------------|
+| **Phi-4** | 14B | 16K | Text | ~8-10GB | Ollama, LM Studio, llama.cpp, HF, Foundry |
+| **Phi-4-mini** | 3.8B | 128K | Text | ~3-4GB | Ollama, LM Studio, ONNX, NVIDIA NIM, HF |
+| **Phi-4-multimodal** | 5.6B | 128K | Text + vision + speech | ~5-6GB | Azure AI Foundry, ONNX, HF |
+| **Phi-4-reasoning** | 14B | 32K | Text | ~8-10GB | Ollama, LM Studio, HF |
+| **Phi-4-reasoning-plus** | 14B | 32K | Text | ~8-10GB | Ollama, LM Studio, HF |
+| **Phi-4-reasoning-vision-15B** | 15B | — | Text + vision | ~10GB+ | HF, Azure AI Foundry |
+
+A few notes the table can't hold. Phi-4-mini carries a **200K-token vocabulary** for stronger multilingual coverage, grouped-query attention for efficient long-context generation, and built-in function calling — it's the one to reach for when you want a tiny, fast, tool-using model. Phi-4-multimodal was the family's first model to fuse text, vision, **and** speech in one set of weights, and specializes in speech recognition, translation, and audio Q&A. The base Phi-4's 16K context is its most notable limitation versus the 128K minis — if you need long-context, the mini or multimodal variants are the better fit despite being smaller.
+
+---
+
+## What Are the Verified Benchmarks?
+
+A sourcing note first, because it matters. The base Phi-4 numbers come from Microsoft's [Phi-4 Technical Report](https://arxiv.org/pdf/2412.08905) run through OpenAI's `simple-evals` framework and are cross-referenced against [llm-stats](https://llm-stats.com/models/phi-4-mini) and the [Hugging Face model card](https://huggingface.co/microsoft/phi-4). Where a figure is from Microsoft's own evals and not yet broadly third-party reproduced, I mark it **vendor-claimed**. Reasoning and vision scores in particular lean on Microsoft's reporting — treat them accordingly.
+
+### Base Phi-4 (14B) — the small model punching up
+
+| Benchmark | Phi-4 (14B) | What it measures |
+|-----------|-------------|------------------|
+| MMLU | **84.8** | Broad knowledge across 57 subjects |
+| GPQA | **56.1** | Graduate-level science Q&A |
+| MATH | **80.4** | Competition mathematics |
+| HumanEval | **82.6** | Python code generation |
+
+The standout context: on **GPQA and MATH, Phi-4 outscores GPT-4o** — the very model that generated much of its synthetic training data. A 14B model beating its multi-hundred-billion-parameter teacher on graduate science and competition math is the entire Phi thesis in two numbers. On HumanEval it posted the strongest coding score of any open-weight model in its size class at release.
+
+### Phi-4-reasoning / reasoning-plus (14B) — local o1-mini-class math
+
+| Benchmark | Phi-4-reasoning | Phi-4-reasoning-plus | Reference |
+|-----------|-----------------|----------------------|-----------|
+| AIME 2024 | **75.3%** | — | beats DeepSeek-R1-Distill-70B (69.3%) |
+| AIME 2025 | ~78% | **81.3%** (plus) | beats o1-mini and 70B distills |
+| GPQA Diamond | **65.8%** | **68.9%** | graduate science |
+
+These are **vendor-claimed** from Microsoft's [reasoning technical report](https://www.microsoft.com/en-us/research/wp-content/uploads/2025/04/phi_4_reasoning.pdf), but the comparison is striking: a 14B model trading blows with — and on AIME, beating — 70B-parameter distillations and o1-mini. The reasoning variant was fine-tuned on ~8.3B tokens of synthetic chain-of-thought traces generated by o3-mini; the "plus" variant added a short GRPO reinforcement-learning phase. Both are MIT-licensed and run locally on a single consumer GPU.
+
+### Phi-4-reasoning-vision-15B — adaptive multimodal (March 2026)
+
+| Benchmark | Score | What it measures |
+|-----------|-------|------------------|
+| MathVista | **75.2** | Visual math reasoning |
+| AI2D | **84.8** | Science diagrams |
+| ScreenSpot v2 | **88.2** | UI element grounding |
+| ChartQA | **83.3** | Chart understanding |
+| OCRBench | **76** | Text-in-image extraction |
+| MMMU | **54.3** | College-level multimodal understanding |
+
+All **vendor-claimed** from the [Phi-4-reasoning-vision tech report](https://www.microsoft.com/en-us/research/blog/phi-4-reasoning-vision-and-the-lessons-of-training-a-multimodal-reasoning-model/). The honest read: this model is strong on **math, science diagrams, and UI/chart grounding** and noticeably weaker on general multimodal understanding (MMMU 54.3 trails larger vision models like Qwen 3.5-class systems, which clear 80+). It was trained on just **200B multimodal tokens** — versus the 1T+ that Qwen 2.5/3 VL, Kimi-VL, and Gemma 3 used — and Microsoft's framing is that it matches "much slower models that require ten times or more compute-time" on its strong domains. Believe the targeted strengths; don't expect it to be a general-purpose vision model.
+
+---
+
+## How Does It Compare to Other Small / Open Models?
+
+Where the Phi-4 base model sits against the small/open field. Numbers are best-effort from each model's reporting; cross-model benchmark comparisons always carry methodology caveats, so read the *shape*, not the third decimal.
+
+| Model | Params | License | MMLU | GPQA | Math | Angle |
+|-------|--------|---------|------|------|------|-------|
+| **Phi-4** | 14B | MIT | **84.8** | **56.1** | 80.4 (MATH) | STEM-dense, tiny footprint |
+| Gemma 3 (12B-class) | ~12B | Gemma terms | strong | mid | strong | Multimodal, 128K, broad |
+| Qwen 2.5 (14B) | 14B | Apache 2.0 | strong | strong | strong | Multilingual, long-context |
+| Llama 3.x (8B) | 8B | Llama license | lower | lower | lower | Ubiquitous, huge ecosystem |
+| DeepSeek-R1-Distill (70B) | 70B | MIT | — | — | AIME 69.3% | Bigger; Phi-4-reasoning beats it on AIME |
+
+Two honest caveats. First, **Phi-4's base 16K context is short** next to Gemma 3 and Qwen's 128K — if long-context is your bottleneck, Phi-4-mini (128K) or a different family wins. Second, on **general multimodal breadth**, Gemma 3 and the Qwen VL line are stronger than Phi-4-reasoning-vision; Phi's vision model is a specialist, not a generalist. Where Phi wins decisively is **STEM reasoning density per parameter and per gigabyte of VRAM** — and the MIT license, which is more permissive than Gemma's or Llama's. For the broader open-local landscape, see [the best open local LLMs guide](/blog/best-open-local-llms-2026) and the [Gemma 3 deep-dive](/blog/gemma-3-analysis-2026).
+
+---
+
+## What's the Self-Host Story? (VRAM, Quantization, Runners)
+
+This is the part that actually matters for a small open model, and it's where Phi-4 shines. You are not paying per token. You are paying for a GPU you probably already have.
+
+**VRAM by quant (Phi-4 14B):**
+
+| Quant | Size on disk | Fits in | Quality |
+|-------|--------------|---------|---------|
+| Q3_K_M | ~6.5GB | 8GB VRAM (with headroom) | Aggressive, usable |
+| **Q4_K_M** | ~8.3GB | 10-12GB VRAM | **Best balance — start here** |
+| Q5_K_M | ~9.8GB | 12GB+ VRAM | Higher-fidelity math/code |
+
+Community testing puts **Q4_K_M at ~95% of full-precision quality** on reasoning tasks, which is why it's the default recommendation. The 3.8B Phi-4-mini drops to roughly 3-4GB at Q4 — it runs comfortably on an 8GB laptop GPU, an integrated GPU with enough shared memory, or even CPU-only at reduced speed.
+
+**Where to run it:**
+
+- **Ollama** — `ollama run phi4`. Official GGUFs ship in current releases; the same file works in llama.cpp, KoboldCPP, and friends.
+- **LM Studio** — official `phi4` GGUFs, GUI, one-click download. Best for non-terminal users.
+- **ONNX Runtime / Foundry Local** — Microsoft's own path for optimized on-device inference, including Windows CPU/GPU/NPU.
+- **Azure AI Foundry** — managed endpoints if you'd rather not self-host but still want the model.
+- **NVIDIA NIM** — Phi-4-mini is packaged as a NIM microservice for production deployment.
+- **Hugging Face** — raw weights for fine-tuning and custom pipelines.
+
+The same GGUF artifact is portable across the whole local ecosystem, so you're not locked into one runner. For a privacy-first local setup walkthrough, the [Ollama local AI guide](/blog/ollama-local-ai-models-privacy-guide) covers the mechanics.
+
+---
+
+## What Does On-Device / Edge Economics Actually Look Like?
+
+The open-weight angle isn't a footnote — it's the whole value proposition for a small model. Here's the calculus.
+
+**Cost.** Per-token price is **$0**. A workload that would cost real money against a hosted API — say, classifying or summarizing millions of documents — costs you electricity and the amortized price of a GPU. Once the hardware is bought, the marginal cost of inference is effectively zero. For high-volume, repetitive tasks, that flips the build-vs-buy decision hard toward self-hosting.
+
+**Privacy.** Nothing leaves the machine. For regulated data — health, legal, financial, internal source code — a model that runs entirely on-prem or on-device sidesteps an entire category of data-governance problems. No API logs, no third-party data processing agreements, no exfiltration surface.
+
+**Latency and offline.** No network round-trip. A 3.8B Phi-4-mini on a laptop NPU responds locally, works on a plane, and degrades gracefully without connectivity. For embedded and edge deployments — kiosks, IoT, field devices — this is the difference between feasible and not.
+
+**The honest tradeoff.** You give up frontier breadth. Phi-4 will not match Claude Opus or Gemini on the hardest, broadest tasks, and it never claimed to. The discipline is **matching the model to the task's difficulty and cost-of-error**: route the genuinely hard, high-stakes work to a frontier API, and run the high-volume, well-scoped, privacy-sensitive work on Phi-4 locally. That's the same routing logic the [FrankX models tracker](/ai-ops/models-2026) applies across the whole field.
+
+---
+
+## What Does It Mean for Builders?
+
+### For developers and edge deployments
+
+If you have a task that's well-scoped — structured extraction, classification, function-calling agents, code completion, on-device assistants — **start with Phi-4-mini (3.8B)** and only size up if quality demands it. It's tiny, fast, supports 128K context and function calling, and costs nothing to run. Reach for the full Phi-4 (14B) when you need stronger STEM reasoning, and Phi-4-reasoning when the task is genuinely math/logic-heavy.
+
+```bash
+# Smallest viable: 3.8B, ~3-4GB VRAM, function calling, 128K context
+ollama run phi4-mini
+
+# STEM-dense flagship: 14B, ~8-10GB at Q4
+ollama run phi4
+```
+
+### For privacy-sensitive and regulated workloads
+
+This is Phi-4's sweet spot. MIT license plus fully local inference means you can deploy it inside an air-gapped environment, fine-tune it on proprietary data without that data ever leaving your control, and ship it in a product without per-seat API costs. For document processing, internal copilots, and compliance-bound automation, the open-weight model is often the *only* viable option — and Phi-4 is among the most capable in its size class.
+
+### For multimodal and reasoning work on a budget
+
+Phi-4-reasoning-plus gives you local AIME-2025-81% math reasoning on a single consumer GPU. Phi-4-reasoning-vision-15B handles diagrams, charts, and UI grounding well — useful for document AI, screen automation, and STEM-tutoring use cases — as long as you accept it's a specialist and not a general vision model. For broad multimodal understanding, Gemma 3 or a Qwen VL model is the better pick.
+
+### The routing discipline
+
+The mental model: **Phi-4 is the local-first default for well-scoped, high-volume, or sensitive work; a frontier API is the escalation path for the genuinely hard.** Don't run a 14B model on problems that need a frontier model, and don't pay frontier API prices for work a 3.8B model nails. Match the model to the cost-of-error, not to the leaderboard.
+
+---
+
+## FAQ
+
+### Is there a Phi-5 yet?
+
+No. As of June 2026 there is no generally available Phi-5 with an official Microsoft model card. The current generation is the Phi-4 family, with the newest member being Phi-4-reasoning-vision-15B (March 4, 2026). Any "Phi-5" guides you find are speculative or based on pre-release rumor — verify against an official model card before trusting specs.
+
+### How much VRAM do I need to run Phi-4?
+
+For the 14B model at Q4_K_M (the recommended quant), roughly 8-10GB of VRAM — it fits comfortably on a 10-12GB GPU. A Q3 quant squeezes into 8GB with headroom. The 3.8B Phi-4-mini needs only ~3-4GB and runs on most laptop GPUs, integrated graphics with enough shared memory, or CPU-only at reduced speed. Q4_K_M retains roughly 95% of full-precision quality on reasoning tasks.
+
+### What's the license, and can I use it commercially?
+
+The Phi-4 family is open-weight under the **MIT license** — one of the most permissive available. You can use it commercially, fine-tune it, redistribute it, and ship it in products with no royalty. This is more permissive than Gemma's custom terms or the Llama license.
+
+### How does Phi-4 beat models larger than itself?
+
+Microsoft trains Phi on "textbook-quality" curated and synthetic data rather than maximizing scraped tokens — the thesis is that data quality beats parameter count. The result: base Phi-4 (14B) outscores GPT-4o (its synthetic-data teacher) on GPQA and MATH, and Phi-4-reasoning (14B) beats 70B distillations and o1-mini on AIME. The tradeoff is breadth — Phi models are STEM-dense specialists, not generalists with frontier-level coverage of everything.
+
+### Where can I run Phi-4 models?
+
+Ollama (`ollama run phi4`), LM Studio, llama.cpp, ONNX Runtime, Microsoft Foundry Local, Azure AI Foundry (managed endpoints), NVIDIA NIM (for Phi-4-mini), and raw weights on Hugging Face for fine-tuning. The same GGUF file is portable across the local-inference ecosystem.
+
+### Which benchmark numbers are verified vs vendor-claimed?
+
+Base Phi-4's MMLU 84.8 / GPQA 56.1 / MATH 80.4 / HumanEval 82.6 come from Microsoft's technical report via OpenAI's `simple-evals` and are corroborated on llm-stats and the HF card — well-supported. The reasoning scores (AIME, GPQA Diamond) and all the vision scores (MathVista, MMMU, etc.) are from Microsoft's own technical reports and should be treated as vendor-claimed until broadly reproduced by third parties.
+
+---
+
+*Analysis by Frank — former Oracle AI architect who helped build Oracle's AI Center of Excellence, now building agentic systems independently and making music with AI.
+Published June 5, 2026 with specs validated against Microsoft's Phi-4 and Phi-4-reasoning technical reports, the Hugging Face model cards, llm-stats, and community self-hosting guides. Vendor-claimed figures are marked as such, and no number here was invented.*

--- a/content/blog/phi-analysis-2026.mdx
+++ b/content/blog/phi-analysis-2026.mdx
@@ -118,7 +118,7 @@ Where the Phi-4 base model sits against the small/open field. Numbers are best-e
 | Model | Params | License | MMLU | GPQA | Math | Angle |
 |-------|--------|---------|------|------|------|-------|
 | **Phi-4** | 14B | MIT | **84.8** | **56.1** | 80.4 (MATH) | STEM-dense, tiny footprint |
-| Gemma 3 (12B-class) | ~12B | Gemma terms | strong | mid | strong | Multimodal, 128K, broad |
+| Gemma 4 (12B) | ~12B | Apache 2.0 | strong | mid | strong | Multimodal + audio, 128K, broad |
 | Qwen 2.5 (14B) | 14B | Apache 2.0 | strong | strong | strong | Multilingual, long-context |
 | Llama 3.x (8B) | 8B | Llama license | lower | lower | lower | Ubiquitous, huge ecosystem |
 | DeepSeek-R1-Distill (70B) | 70B | MIT | — | — | AIME 69.3% | Bigger; Phi-4-reasoning beats it on AIME |

--- a/data/model-registry.json
+++ b/data/model-registry.json
@@ -513,18 +513,188 @@
         "https://venturebeat.com/technology/alibabas-proprietary-qwen3-7-max-can-run-for-35-hours-autonomously-and-supports-external-harnesses-like-anthropics-claude-code"
       ]
     },
+    "gpt-oss": {
+      "name": "gpt-oss (120b / 20b)",
+      "id": "gpt-oss",
+      "organization": "openai",
+      "family": "gpt-oss",
+      "released": "2025-08-05",
+      "status": "ga",
+      "architecture": "moe",
+      "parameters": "116.8B total / 5.1B active (120b); 21B total / 3.6B active (20b)",
+      "context_window": 131072,
+      "modalities": ["text", "code"],
+      "pricing": {
+        "input_per_1m": 0,
+        "output_per_1m": 0
+      },
+      "benchmarks": {
+        "gpqa_diamond": 80.1,
+        "mmlu_pro": 90.0,
+        "aime_2025_tools": 97.9,
+        "swe_bench_verified": 62.4,
+        "humanitys_last_exam": 19.0
+      },
+      "key_capabilities": [
+        "Apache 2.0 open weights (free, commercial-friendly, no copyleft)",
+        "MXFP4-quantized: 120b on a single 80GB GPU (H100/MI300X), 20b in ~16GB",
+        "Run via Ollama / vLLM / LM Studio / llama.cpp / HF Transformers",
+        "131K-token context, low/medium/high reasoning-effort levels",
+        "Native function calling, browsing, Python, structured outputs (harmony format)"
+      ],
+      "frankx_notes": "Not the top-scoring open model anymore (DeepSeek V4, Qwen3.7-Max, Kimi K2.6 outscore it), but it wins on reasoning-per-VRAM: the 20b on a 16GB laptop and the 120b on one 80GB card are still among the best things that fit on constrained hardware, with a clean Apache 2.0 license. Self-host the 20b for privacy; rent the 120b unless you have high steady volume or a data-residency mandate. No gpt-oss-2 as of June 2026; gpt-oss-120b became an MLPerf Inference v6.0 benchmark Mar 2026.",
+      "sources": [
+        "https://openai.com/index/introducing-gpt-oss/",
+        "https://github.com/openai/gpt-oss",
+        "https://huggingface.co/openai/gpt-oss-120b"
+      ]
+    },
+    "gemma-4": {
+      "name": "Gemma 4",
+      "id": "gemma-4",
+      "organization": "google",
+      "family": "gemma",
+      "released": "2026-04-02",
+      "status": "ga",
+      "architecture": "mixed (dense + MoE tiers)",
+      "parameters": "E2B / E4B / 12B / 26B-A4B MoE / 31B dense",
+      "context_window": 256000,
+      "modalities": ["text", "vision", "audio"],
+      "pricing": {
+        "input_per_1m": 0,
+        "output_per_1m": 0
+      },
+      "benchmarks": {
+        "lmarena_elo": 1452,
+        "mmlu_pro": 85.2,
+        "gpqa_diamond": 84.3,
+        "livecodebench": 80.0,
+        "aime_2026": 89.2
+      },
+      "key_capabilities": [
+        "Apache 2.0 license (replaces the custom Gemma Terms used through Gemma 3)",
+        "31B dense flagship runs in ~18GB VRAM at Q4 on a single 24GB consumer GPU",
+        "26B A4B — Gemma's first MoE (~3.8B active, ~15.6GB int4) for agentic throughput",
+        "Encoder-free 12B multimodal (native audio) runs on a 16GB laptop",
+        "E2B (~2GB) to E4B (~8GB) tiers for edge / on-device",
+        "Up to 256K context; runs via Ollama / llama.cpp / LM Studio / vLLM / HF"
+      ],
+      "frankx_notes": "Gemma 4 doesn't win on raw score — Qwen3.7-Max narrowly out-reasons it and DeepSeek V4 dominates the open frontier. Its edge is the whole package: top-tier quality that fits one consumer GPU, native multimodal, a clean Apache 2.0 license, and broad day-zero tooling. The 1452 LMArena Elo (human preference) is the trustworthy number; the academic jumps (AIME 89.2%, GPQA 84.3%) are largely Google's own evals — vendor-claimed until reproduced. Best for local-first / privacy-sensitive and cost-conscious agentic builds.",
+      "sources": [
+        "https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/",
+        "https://ai.google.dev/gemma/docs/core/model_card_4",
+        "https://huggingface.co/blog/gemma4"
+      ]
+    },
     "llama-4-maverick": {
       "name": "Llama 4 Maverick",
       "id": "llama-4-maverick",
       "organization": "meta",
       "family": "llama",
-      "released": "2025-12-01",
+      "released": "2025-04-05",
       "status": "ga",
       "architecture": "moe",
-      "parameters": "400B total, 17B active",
-      "context_window": 1000000,
-      "modalities": ["text", "vision"],
-      "sources": []
+      "parameters": "400B total / 17B active, 128 experts (early-fusion multimodal MoE)",
+      "context_window": 1048576,
+      "max_output_tokens": 16384,
+      "modalities": ["text", "image"],
+      "pricing": {
+        "input_per_1m": 0,
+        "output_per_1m": 0
+      },
+      "benchmarks": {
+        "mmlu_pro": 80.5,
+        "gpqa_diamond": 69.8,
+        "livecodebench": 43.4
+      },
+      "key_capabilities": [
+        "Native text+image multimodal input via early fusion",
+        "1M-token context (Maverick); Scout sibling offers 10M",
+        "Llama 4 Community License — free commercial use under 700M MAU",
+        "Self-host: FP8 weights need an 8x H100 80GB node (~600GB); Scout (109B/17B) self-hosts on one H100 at ~55GB Q4",
+        "Run via vLLM / Ollama (Scout) / HF, or hosted APIs (~$0.15/$0.60 per 1M)"
+      ],
+      "frankx_notes": "Still Meta's open flagship in June 2026 only because nothing newer shipped — Behemoth (~2T) was paused May 2026 with no public weights, and there's no Llama 4.5 or Llama 5. Weights are free and the license is permissive, but verified benchmarks now trail DeepSeek V4, Qwen3.7-Max, Kimi K2.6 and even the much smaller Gemma 4. Maverick is a data-center model, not a laptop one — Scout is the realistically self-hostable sibling. The widely-cited 1417 LMArena Elo was an experimental chat-tuned variant, not the public weights (which ranked ~32nd).",
+      "sources": [
+        "https://ai.meta.com/blog/llama-4-multimodal-intelligence/",
+        "https://www.llama.com/models/llama-4/",
+        "https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+      ]
+    },
+    "phi-4": {
+      "name": "Microsoft Phi-4 (open-weight family)",
+      "id": "phi-4",
+      "organization": "microsoft",
+      "family": "phi",
+      "released": "2024-12-12",
+      "status": "ga",
+      "architecture": "dense",
+      "parameters": "3.8B (mini) / 5.6B (multimodal) / 14B (Phi-4, reasoning) / 15B (reasoning-vision)",
+      "context_window": 16000,
+      "modalities": ["text", "vision", "audio"],
+      "pricing": {
+        "input_per_1m": 0,
+        "output_per_1m": 0
+      },
+      "benchmarks": {
+        "mmlu": 84.8,
+        "gpqa": 56.1,
+        "math": 80.4,
+        "humaneval": 82.6,
+        "aime_2025_reasoning_plus": 81.3
+      },
+      "key_capabilities": [
+        "MIT license — fully open weights, commercial use, fine-tune and redistribute",
+        "Runs on consumer hardware: 14B at Q4 needs ~8-10GB VRAM; 3.8B mini ~3-4GB",
+        "STEM-dense: base 14B beats teacher GPT-4o on GPQA and MATH",
+        "Phi-4-mini: 128K context, built-in function calling",
+        "Phi-4-multimodal: text+vision+speech in 5.6B, 128K context",
+        "Phi-4-reasoning-vision-15B (Mar 2026): adaptive think/no-think",
+        "Runs on Ollama / LM Studio / llama.cpp / ONNX / Foundry Local / HF"
+      ],
+      "frankx_notes": "The honest small-model pick. $0 per token, MIT license, runs on a gaming laptop — ideal for high-volume, privacy-sensitive, or offline work. STEM-dense specialist, not a generalist: short 16K base context and weaker general multimodal breadth than Gemma 4. Route hard, broad tasks to a frontier API; run well-scoped local work on Phi. No GA Phi-5 exists as of June 2026; reasoning/vision numbers are largely vendor-claimed.",
+      "sources": [
+        "https://arxiv.org/pdf/2412.08905",
+        "https://huggingface.co/microsoft/phi-4",
+        "https://huggingface.co/microsoft/Phi-4-reasoning"
+      ]
+    },
+    "mistral-large-3": {
+      "name": "Mistral Large 3",
+      "id": "mistral-large-2512",
+      "organization": "mistralai",
+      "family": "mistral",
+      "released": "2025-12-02",
+      "status": "ga",
+      "architecture": "moe",
+      "parameters": "675B total / 41B active (sparse MoE)",
+      "context_window": 256000,
+      "modalities": ["text", "image"],
+      "pricing": {
+        "input_per_1m": 0.50,
+        "output_per_1m": 1.50
+      },
+      "benchmarks": {
+        "lmarena_elo": 1418,
+        "mmlu_pro": 73.11,
+        "math_500": 93.6,
+        "humaneval": 92.0,
+        "gpqa_diamond": 43.9
+      },
+      "key_capabilities": [
+        "Apache 2.0 open weights (base + instruct)",
+        "EU data-residency / GDPR-compliant hosted endpoints",
+        "Self-hostable FP8 on one 8x H200 node (vLLM TP=8)",
+        "Native function calling and JSON structured output",
+        "Strong multilingual + fast code generation",
+        "256K context window"
+      ],
+      "frankx_notes": "Best open-weight pick for EU sovereignty and knowledge/chat/code work, and #2 on LMArena among open non-reasoners proves the 'pleasant to use' axis. Honest weakness: hard reasoning (GPQA ~44%, roughly half the dedicated reasoners). The promised reasoning variant had not shipped as of June 2026. The Apache 2.0 license + single-node FP8 self-host is the moat the closed frontier can't match. Either $0 self-hosted or $0.50/$1.50 via la Plateforme.",
+      "sources": [
+        "https://mistral.ai/news/mistral-3/",
+        "https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512",
+        "https://docs.vllm.ai/projects/recipes/en/latest/Mistral/Mistral-Large-3.html"
+      ]
     },
     "mai-thinking-1": {
       "name": "MAI-Thinking-1",
@@ -603,12 +773,12 @@
     "openai": {
       "name": "OpenAI",
       "url": "https://openai.com",
-      "models": ["gpt-5-5", "gpt-5-2-pro"]
+      "models": ["gpt-5-5", "gpt-5-2-pro", "gpt-oss"]
     },
     "google": {
       "name": "Google DeepMind",
       "url": "https://deepmind.google",
-      "models": ["gemini-3-5-pro", "gemini-3-5-flash", "gemini-3-pro"]
+      "models": ["gemini-3-5-pro", "gemini-3-5-flash", "gemini-3-pro", "gemma-4"]
     },
     "xai": {
       "name": "xAI",
@@ -623,7 +793,7 @@
     "microsoft": {
       "name": "Microsoft AI",
       "url": "https://microsoft.ai",
-      "models": ["mai-thinking-1", "mai-image-2-5", "mai-code-1-flash"]
+      "models": ["mai-thinking-1", "mai-image-2-5", "mai-code-1-flash", "phi-4"]
     },
     "deepseek": {
       "name": "DeepSeek",
@@ -639,6 +809,11 @@
       "name": "Moonshot AI",
       "url": "https://moonshot.ai",
       "models": ["kimi-k2-6"]
+    },
+    "mistralai": {
+      "name": "Mistral AI",
+      "url": "https://mistral.ai",
+      "models": ["mistral-large-3"]
     }
   },
 

--- a/data/route-index.json
+++ b/data/route-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "stats": {
-    "total": 631,
+    "total": 637,
     "aliases": 19,
     "byType": {
       "core": 22,
@@ -9,7 +9,7 @@
       "community": 17,
       "tool": 10,
       "static": 15,
-      "blog": 143,
+      "blog": 149,
       "guide": 19,
       "library": 4,
       "newsletter": 1,
@@ -1070,6 +1070,19 @@
       "type": "blog"
     },
     {
+      "href": "/blog/best-open-local-llms-2026",
+      "title": "The Best Open & Local LLMs in 2026: A Self-Host Field Guide",
+      "description": "Which open-weight model for which hardware — Gemma 4, gpt-oss, Phi-4, Mistral Large 3, Llama 4, DeepSeek V4, and Kimi K2.6 compared by VRAM, license, and use case. When self-hosting beats an API, with verified benchmarks.",
+      "tags": [
+        "open-source",
+        "local-llm",
+        "self-hosting",
+        "frontier-models",
+        "ai-2026"
+      ],
+      "type": "blog"
+    },
+    {
       "href": "/blog/brand-evolution-from-consciousness-to-systems",
       "title": "Brand Evolution: From Consciousness to Systems",
       "description": "How FrankX shifted from 'soul-aligned AI' language to a systems architect identity. A transparent look at brand iteration for creators.",
@@ -1472,6 +1485,20 @@
       "type": "blog"
     },
     {
+      "href": "/blog/gemma-3-analysis-2026",
+      "title": "Gemma 4: Google's Open-Weight Family Now Runs a 31B Frontier Model on One GPU",
+      "description": "Google's current open-weight Gemma is Gemma 4 (April 2026), now Apache 2.0, in E2B/E4B/12B/26B-A4B/31B tiers. The 31B dense model hits 1452 LMArena Elo and runs in ~18GB VRAM at Q4. Self-host specifics, verified benchmarks, license analysis, and which size for which job.",
+      "tags": [
+        "google",
+        "gemma",
+        "open-weight-models",
+        "local-llms",
+        "ai-2026",
+        "benchmarks"
+      ],
+      "type": "blog"
+    },
+    {
       "href": "/blog/gencreator-3-tier-shipping-system",
       "title": "The 3-Tier Shipping System: How GenCreators Build Creative Momentum",
       "description": "Full Ship, Quick Ship, Micro Ship — energy-aware daily output. The system that turns sporadic creation into unstoppable momentum.",
@@ -1572,6 +1599,20 @@
         "ai-2026",
         "benchmarks",
         "agentic-ai"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/gpt-oss-analysis-2026",
+      "title": "gpt-oss in 2026: OpenAI's Open-Weight Models, One Year On",
+      "description": "OpenAI's gpt-oss-120b and gpt-oss-20b are Apache 2.0, free to download, and run on a single 80GB GPU or a 16GB laptop. The full self-host breakdown: VRAM, MXFP4 quantization, where to run, verified benchmarks, and how they stack up against Qwen, DeepSeek, and GLM in June 2026.",
+      "tags": [
+        "openai",
+        "gpt-oss",
+        "open-weight-models",
+        "local-llms",
+        "ai-2026",
+        "benchmarks"
       ],
       "type": "blog"
     },
@@ -1677,6 +1718,20 @@
         "ai-2026",
         "benchmarks",
         "agentic-ai"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/llama-4-analysis-2026",
+      "title": "Llama 4 Maverick in 2026: Still Meta's Open Flagship, Now Running Behind the Pack",
+      "description": "Llama 4 Maverick (400B total / 17B active MoE, 1M context, Llama 4 Community License) is still Meta's open-weight flagship in June 2026 — Behemoth never shipped. Verified benchmarks, real VRAM and self-host requirements, how it stacks up against DeepSeek V4, Qwen 3.5, and Kimi K2.6, and what it means for builders.",
+      "tags": [
+        "meta",
+        "llama",
+        "open-weights",
+        "local-llms",
+        "ai-2026",
+        "benchmarks"
       ],
       "type": "blog"
     },
@@ -1796,6 +1851,20 @@
         "realitydiffusion",
         "trust-and-safety",
         "multi-agent-systems"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/mistral-large-3-analysis-2026",
+      "title": "Mistral Large 3: The 675B Open-Weight Frontier Model Europe Has Been Waiting For",
+      "description": "Mistral Large 3 (mistral-large-2512) is a 675B/41B-active MoE released under Apache 2.0, December 2025. 256K context, $0.50/$1.50 API pricing, runs on one 8xH200 node. Verified benchmarks, EU sovereignty angle, self-host specifics, and what it means for builders.",
+      "tags": [
+        "mistral",
+        "open-weight",
+        "frontier-models",
+        "ai-2026",
+        "benchmarks",
+        "eu-sovereign-ai"
       ],
       "type": "blog"
     },
@@ -1973,6 +2042,20 @@
         "CLAUDE.md",
         "MCP Servers",
         "Workshops"
+      ],
+      "type": "blog"
+    },
+    {
+      "href": "/blog/phi-analysis-2026",
+      "title": "Microsoft Phi-4 in 2026: The Open-Weight Small Model That Runs on Your Laptop",
+      "description": "Microsoft's Phi-4 family — Phi-4 (14B), Phi-4-mini (3.8B), Phi-4-multimodal (5.6B), Phi-4-reasoning, and the March 2026 Phi-4-reasoning-vision-15B — are MIT-licensed, $0 to download, and run on consumer GPUs. Verified benchmarks, VRAM tables, and what the small-model angle means for builders.",
+      "tags": [
+        "microsoft",
+        "phi",
+        "open-weight",
+        "small-language-models",
+        "local-ai",
+        "benchmarks"
       ],
       "type": "blog"
     },

--- a/lib/llm-hub/editorial.ts
+++ b/lib/llm-hub/editorial.ts
@@ -163,10 +163,33 @@ export const MODEL_EDITORIAL: Record<string, ModelEditorial> = {
     bestFor: ['Workloads not yet migrated to Gemini 3.5', '2M-context multimodal tasks'],
     openrouterId: 'google/gemini-3-pro',
   },
+  'gpt-oss': {
+    tagline: 'OpenAI’s open-weight family — Apache 2.0 reasoning that fits on one GPU or a laptop.',
+    bestFor: [
+      'Local-first, privacy-sensitive products (gpt-oss-20b offline on 16GB)',
+      'Single-GPU reasoning workloads (gpt-oss-120b on one 80GB card)',
+      'Cost-controlled agentic loops with no per-token meter or vendor lock-in',
+    ],
+    watchOut: 'Open weights are not free inference — self-hosting the 120b only pencils out at high steady volume or under data-residency rules; otherwise a hosted endpoint at ~$0.04-$0.15/1M is cheaper. Requires OpenAI’s harmony response format. No longer tops open-model leaderboards.',
+    creatorUse: 'Run gpt-oss-20b locally via Ollama/LM Studio for offline drafting, agent prototyping, and any workflow where prompts/outputs can’t leave the machine.',
+    openrouterId: 'openai/gpt-oss-120b',
+  },
+  'gemma-4': {
+    tagline: 'Google’s open-weight flagship: a 31B frontier-tier model on one GPU, now Apache 2.0.',
+    bestFor: [
+      'Local-first / privacy-sensitive products (on-prem, healthcare, legal, finance)',
+      'Cost-conscious agentic systems (26B A4B MoE + vLLM)',
+      'Commercial fine-tuning under a clean license',
+    ],
+    watchOut: 'Academic benchmark jumps (AIME 89.2%, GPQA 84.3%) are largely Google’s own evals — vendor-claimed until reproduced. Qwen3.7-Max narrowly out-scores it on pure reasoning.',
+    creatorUse: 'Run the 12B locally for offline multimodal work (image/audio on a 16GB laptop); 31B for on-prem RAG and coding where data can’t leave your box.',
+    openrouterId: 'google/gemma-4-31b',
+  },
   'llama-4-maverick': {
-    tagline: 'Open-weight MoE leadership — 400B total, 17B active, runs on one H100.',
-    bestFor: ['Self-hosted / sovereign deployments', 'Fine-tuning ecosystems', 'Cost-controlled inference at scale'],
-    creatorUse: 'The base for creators who want to own and fine-tune their model.',
+    tagline: 'Meta’s open flagship by default — permissively licensed and multimodal, but no longer leading the open pack.',
+    bestFor: ['Permissively-licensed self-hosting in your own VPC', 'Native open-weight multimodal (text+image) work', 'Long-context reasoning via the 10M-token Scout sibling'],
+    watchOut: 'A data-center model (8x H100 for Maverick FP8), not a consumer-GPU one, and its benchmarks now trail DeepSeek V4, Qwen3.7-Max and Kimi K2.6. The headline 1417 LMArena Elo was an experimental variant, not the public weights.',
+    creatorUse: 'Self-host Scout on a single H100 for whole-corpus (10M context) multimodal drafting where you need data control and zero per-token cost.',
     openrouterId: 'meta-llama/llama-4-maverick',
   },
   'deepseek-v4': {
@@ -204,9 +227,22 @@ export const MODEL_EDITORIAL: Record<string, ModelEditorial> = {
     openrouterId: 'qwen/qwen3.7-max',
   },
   'mistral-large-3': {
-    tagline: 'European data sovereignty with a strong open/commercial split.',
-    bestFor: ['EU data-residency requirements', 'Multilingual frontier tasks', 'Apache-licensed small-model pairing'],
-    openrouterId: 'mistralai/mistral-large-3',
+    tagline: 'Europe’s 675B open-weight frontier: Apache 2.0, runs on one node, sovereign by design.',
+    bestFor: ['EU data-residency / GDPR-bound workloads', 'Multilingual knowledge work and RAG', 'Self-hosted frontier inference (FP8 on 8x H200)'],
+    watchOut: 'Trails dedicated reasoners on hard reasoning (GPQA Diamond ~44%); reasoning variant promised but not yet shipped as of June 2026.',
+    creatorUse: 'Run a sovereign, frontier-class assistant on your own hardware at $0 per-token, or call the API at $0.50/$1.50.',
+    openrouterId: 'mistralai/mistral-large-2512',
+  },
+  'phi-4': {
+    tagline: 'MIT-licensed small models that punch above their weight — and run on your laptop for $0 per token.',
+    bestFor: [
+      'On-device and edge inference (3.8B mini in ~3-4GB VRAM)',
+      'Privacy-sensitive / regulated workloads with fully local hosting',
+      'High-volume, well-scoped STEM, extraction, and function-calling tasks',
+    ],
+    watchOut: 'Base Phi-4 has only a 16K context window, and the vision model is a math/diagram specialist, not a general multimodal model. Most reasoning/vision benchmarks are vendor-claimed.',
+    creatorUse: 'Local document AI, on-device assistants, STEM tutoring, screen/UI automation, and offline drafting — no API cost, full data control.',
+    openrouterId: 'microsoft/phi-4',
   },
   'qwen3-coder-next': {
     tagline: 'The efficiency breakthrough — 70.6% SWE-bench at 3B active params, Apache 2.0.',

--- a/public/images/blog/best-open-local-llms-2026-hero.svg
+++ b/public/images/blog/best-open-local-llms-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0D9488" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#5EEAD4" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#14B8A6" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#14B8A6" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#5EEAD4" /><stop offset="1" stop-color="#0D9488" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="276" height="36" rx="18" fill="#0D9488" fill-opacity="0.18" stroke="#0D9488" stroke-opacity="0.5" />
+    <text x="328" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#5EEAD4" text-anchor="middle">FRANKX INTELLIGENCE</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Open &amp; Local LLMs</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">June 2026 field guide — Gemma 4, gpt-oss, Phi-4, Mistral, Llama, DeepSeek, Kimi</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#0D9488" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">7+</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Models compared</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">Apache/MIT</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Open licenses</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">2GB–640GB</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">VRAM range</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$0</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Per-token cost</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Self-host field guide · all figures cited</text>
+  </g>
+</svg>

--- a/public/images/blog/gemma-3-analysis-2026-hero.svg
+++ b/public/images/blog/gemma-3-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2563EB" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#93C5FD" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#3B82F6" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#3B82F6" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#93C5FD" /><stop offset="1" stop-color="#2563EB" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="228" height="36" rx="18" fill="#2563EB" fill-opacity="0.18" stroke="#2563EB" stroke-opacity="0.5" />
+    <text x="304" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#93C5FD" text-anchor="middle">GOOGLE DEEPMIND</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Gemma 4</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Open-weight, Apache 2.0 — a 31B dense model that runs on one GPU and tops the open arena</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#2563EB" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">1452</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">LMArena Elo (31B)</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">~18GB</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">VRAM (31B Q4)</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">256K</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Context window</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$0</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Open weights</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via Google DeepMind, HuggingFace, LMArena</text>
+  </g>
+</svg>

--- a/public/images/blog/gpt-oss-analysis-2026-hero.svg
+++ b/public/images/blog/gpt-oss-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#059669" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#6EE7B7" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#10B981" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#10B981" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6EE7B7" /><stop offset="1" stop-color="#059669" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="150" height="36" rx="18" fill="#059669" fill-opacity="0.18" stroke="#059669" stroke-opacity="0.5" />
+    <text x="265" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#6EE7B7" text-anchor="middle">OPENAI</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">gpt-oss</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Open-weight, Apache 2.0 — 120b runs on one 80GB GPU, 20b runs on a 16GB laptop</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#059669" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">80.1%</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">GPQA Diamond (120b)</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">~16GB</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">VRAM (20b)</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">128K</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Context window</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$0</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Open weights</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via OpenAI model card, GitHub, MLCommons</text>
+  </g>
+</svg>

--- a/public/images/blog/llama-4-analysis-2026-hero.svg
+++ b/public/images/blog/llama-4-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#93C5FD" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#3B82F6" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#3B82F6" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#93C5FD" /><stop offset="1" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="150" height="36" rx="18" fill="#1D4ED8" fill-opacity="0.18" stroke="#1D4ED8" stroke-opacity="0.5" />
+    <text x="265" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#93C5FD" text-anchor="middle">META</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Llama 4 Maverick</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Open multimodal MoE — still Meta’s flagship, but a data-center model (Scout self-hosts)</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1D4ED8" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">400B/17B</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">MoE params</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">8×H100</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">VRAM (Maverick FP8)</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">1M</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Context (10M Scout)</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$0</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Open weights</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via Meta AI, HuggingFace, vLLM</text>
+  </g>
+</svg>

--- a/public/images/blog/mistral-large-3-analysis-2026-hero.svg
+++ b/public/images/blog/mistral-large-3-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#E11D48" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#FDA4AF" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#F43F5E" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#F43F5E" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FDA4AF" /><stop offset="1" stop-color="#E11D48" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="168" height="36" rx="18" fill="#E11D48" fill-opacity="0.18" stroke="#E11D48" stroke-opacity="0.5" />
+    <text x="274" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#FDA4AF" text-anchor="middle">MISTRAL AI</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Mistral Large 3</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">Europe’s 675B open-weight frontier — Apache 2.0, EU-sovereign, one node</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#E11D48" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">1418</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">LMArena Elo</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">675B/41B</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">MoE params</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">256K</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Context window</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$0 / $0.50</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Self-host / API in</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via Mistral, HuggingFace, vLLM</text>
+  </g>
+</svg>

--- a/public/images/blog/phi-analysis-2026-hero.svg
+++ b/public/images/blog/phi-analysis-2026-hero.svg
@@ -1,0 +1,55 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#05070F" />
+      <stop offset="0.5" stop-color="#0B1530" />
+      <stop offset="1" stop-color="#070B18" />
+    </linearGradient>
+    <linearGradient id="glimmer" x1="320" y1="120" x2="1320" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0078D4" stop-opacity="0.28" />
+      <stop offset="0.5" stop-color="#7FD3FF" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0.20" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 430) rotate(90) scale(640 540)">
+      <stop offset="0" stop-color="#0078D4" stop-opacity="0.42" />
+      <stop offset="1" stop-color="#0078D4" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#16233F" />
+      <stop offset="1" stop-color="#0C1428" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7FD3FF" /><stop offset="1" stop-color="#0078D4" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <rect width="1600" height="900" fill="url(#pulse)" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="#0A1224" fill-opacity="0.72" stroke="#1E2C4C" stroke-opacity="0.55" />
+  <rect x="120" y="90" width="1360" height="720" rx="56" fill="url(#glimmer)" fill-opacity="0.5" />
+
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif">
+    <rect x="190" y="160" width="156" height="36" rx="18" fill="#0078D4" fill-opacity="0.18" stroke="#0078D4" stroke-opacity="0.5" />
+    <text x="268" y="184" font-size="17" font-weight="600" letter-spacing="2" fill="#7FD3FF" text-anchor="middle">MICROSOFT</text>
+    <text x="190" y="300" font-size="92" font-weight="800" fill="#FFFFFF">Microsoft Phi-4</text>
+    <text x="190" y="362" font-size="29" font-weight="400" fill="#9FB3D1">MIT-licensed small models that run on a laptop and beat their weight class</text>
+
+    <rect x="190" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#0078D4" stroke-opacity="0.7" />
+    <rect x="218" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="218" y="608" font-size="52" font-weight="800" fill="#FFFFFF">3.8–15B</text>
+    <text x="218" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Param tiers</text>
+    <rect x="501" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="529" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="529" y="608" font-size="52" font-weight="800" fill="#FFFFFF">~8GB</text>
+    <text x="529" y="658" font-size="19" font-weight="500" fill="#8FA6C4">VRAM (14B Q4)</text>
+    <rect x="812" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="840" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="840" y="608" font-size="52" font-weight="800" fill="#FFFFFF">MIT</text>
+    <text x="840" y="658" font-size="19" font-weight="500" fill="#8FA6C4">License</text>
+    <rect x="1123" y="470" width="287" height="250" rx="24" fill="url(#tile)" stroke="#1E2E51" stroke-opacity="0.6" />
+    <rect x="1151" y="500" width="46" height="6" rx="3" fill="url(#accent)" />
+    <text x="1151" y="608" font-size="52" font-weight="800" fill="#FFFFFF">$0</text>
+    <text x="1151" y="658" font-size="19" font-weight="500" fill="#8FA6C4">Open weights</text>
+    <text x="190" y="772" font-size="16" fill="#5C6F8E">FrankX · Intelligence Dispatch · Verified via Microsoft Research, HuggingFace, arXiv</text>
+  </g>
+</svg>

--- a/scripts/visuals/generate-model-hero.mjs
+++ b/scripts/visuals/generate-model-hero.mjs
@@ -114,6 +114,9 @@ const PALETTE = {
   moonshot: { accentFrom: '#A5B4FC', accentTo: '#4F46E5', glowHex: '#6366F1' },
   meta: { accentFrom: '#93C5FD', accentTo: '#1D4ED8', glowHex: '#3B82F6' },
   mistral: { accentFrom: '#FDA4AF', accentTo: '#E11D48', glowHex: '#F43F5E' },
+  mistralai: { accentFrom: '#FDA4AF', accentTo: '#E11D48', glowHex: '#F43F5E' },
+  microsoft: { accentFrom: '#7FD3FF', accentTo: '#0078D4', glowHex: '#0078D4' },
+  roundup: { accentFrom: '#5EEAD4', accentTo: '#0D9488', glowHex: '#14B8A6' },
 }
 
 // ---- CONFIGS: filled with VERIFIED values from research ------------------
@@ -122,7 +125,7 @@ const PALETTE = {
 // Complete source of truth for model-hero regeneration. Output is deterministic,
 // so re-running reproduces every committed hero byte-for-byte.
 const CONFIGS = [
-  // Open-weight flagship:
+  // Phase 3 — open & local models:
   {
     slug: 'gemma-3-analysis-2026',
     orgKey: 'google',
@@ -136,6 +139,76 @@ const CONFIGS = [
       { value: '$0', label: 'Open weights' },
     ],
     footer: 'FrankX · Intelligence Dispatch · Verified via Google DeepMind, HuggingFace, LMArena',
+  },
+  {
+    slug: 'gpt-oss-analysis-2026',
+    orgKey: 'openai',
+    org: 'OpenAI',
+    name: 'gpt-oss',
+    subtitle: 'Open-weight, Apache 2.0 — 120b runs on one 80GB GPU, 20b runs on a 16GB laptop',
+    tiles: [
+      { value: '80.1%', label: 'GPQA Diamond (120b)' },
+      { value: '~16GB', label: 'VRAM (20b)' },
+      { value: '128K', label: 'Context window' },
+      { value: '$0', label: 'Open weights' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via OpenAI model card, GitHub, MLCommons',
+  },
+  {
+    slug: 'llama-4-analysis-2026',
+    orgKey: 'meta',
+    org: 'Meta',
+    name: 'Llama 4 Maverick',
+    subtitle: 'Open multimodal MoE — still Meta’s flagship, but a data-center model (Scout self-hosts)',
+    tiles: [
+      { value: '400B/17B', label: 'MoE params' },
+      { value: '8×H100', label: 'VRAM (Maverick FP8)' },
+      { value: '1M', label: 'Context (10M Scout)' },
+      { value: '$0', label: 'Open weights' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via Meta AI, HuggingFace, vLLM',
+  },
+  {
+    slug: 'mistral-large-3-analysis-2026',
+    orgKey: 'mistralai',
+    org: 'Mistral AI',
+    name: 'Mistral Large 3',
+    subtitle: 'Europe’s 675B open-weight frontier — Apache 2.0, EU-sovereign, one node',
+    tiles: [
+      { value: '1418', label: 'LMArena Elo' },
+      { value: '675B/41B', label: 'MoE params' },
+      { value: '256K', label: 'Context window' },
+      { value: '$0 / $0.50', label: 'Self-host / API in' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via Mistral, HuggingFace, vLLM',
+  },
+  {
+    slug: 'phi-analysis-2026',
+    orgKey: 'microsoft',
+    org: 'Microsoft',
+    name: 'Microsoft Phi-4',
+    subtitle: 'MIT-licensed small models that run on a laptop and beat their weight class',
+    tiles: [
+      { value: '3.8–15B', label: 'Param tiers' },
+      { value: '~8GB', label: 'VRAM (14B Q4)' },
+      { value: 'MIT', label: 'License' },
+      { value: '$0', label: 'Open weights' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via Microsoft Research, HuggingFace, arXiv',
+  },
+  {
+    slug: 'best-open-local-llms-2026',
+    orgKey: 'roundup',
+    org: 'FrankX Intelligence',
+    name: 'Open & Local LLMs',
+    subtitle: 'June 2026 field guide — Gemma 4, gpt-oss, Phi-4, Mistral, Llama, DeepSeek, Kimi',
+    tiles: [
+      { value: '7+', label: 'Models compared' },
+      { value: 'Apache/MIT', label: 'Open licenses' },
+      { value: '2GB–640GB', label: 'VRAM range' },
+      { value: '$0', label: 'Per-token cost' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Self-host field guide · all figures cited',
   },
   // Phase 1 — Western flagships:
   {

--- a/scripts/visuals/generate-model-hero.mjs
+++ b/scripts/visuals/generate-model-hero.mjs
@@ -122,6 +122,21 @@ const PALETTE = {
 // Complete source of truth for model-hero regeneration. Output is deterministic,
 // so re-running reproduces every committed hero byte-for-byte.
 const CONFIGS = [
+  // Open-weight flagship:
+  {
+    slug: 'gemma-3-analysis-2026',
+    orgKey: 'google',
+    org: 'Google DeepMind',
+    name: 'Gemma 4',
+    subtitle: 'Open-weight, Apache 2.0 — a 31B dense model that runs on one GPU and tops the open arena',
+    tiles: [
+      { value: '1452', label: 'LMArena Elo (31B)' },
+      { value: '~18GB', label: 'VRAM (31B Q4)' },
+      { value: '256K', label: 'Context window' },
+      { value: '$0', label: 'Open weights' },
+    ],
+    footer: 'FrankX · Intelligence Dispatch · Verified via Google DeepMind, HuggingFace, LMArena',
+  },
   // Phase 1 — Western flagships:
   {
     slug: 'claude-opus-4-8-analysis-2026',


### PR DESCRIPTION
## Phase 3 of 3 — open & local (run-it-yourself) models

Final phase. Builds on Phases 1–2 (#155, #156). Adds the open-weight / self-host wave to the registry, LLM Hub editorial layer, and the `/ai-ops/models-2026` arena — with five model deep-dives **plus an OSS/local self-host field guide** and on-brand hero art. Every benchmark traces to a cited source; verified vs **vendor-claimed** numbers are distinguished throughout.

### What shipped

**New deep-dive articles** (`content/blog/*.mdx`) + hero SVGs:
| Model | License | The honest take |
|---|---|---|
| **Gemma 4** (Apr 2) | **Apache 2.0** (was Gemma Terms) | 31B dense runs in ~18GB on one consumer GPU; multimodal; LMArena 1452 — best quality-per-GPU |
| **gpt-oss** 120b/20b | Apache 2.0 | Best reasoning-per-VRAM; 120b on one 80GB card, 20b on a 16GB laptop |
| **Microsoft Phi-4** | MIT | 3.8B–15B laptop/edge STEM specialist (no GA Phi-5 exists) |
| **Mistral Large 3** | Apache 2.0 | 675B/41B EU-sovereign open frontier; #2 OSS on LMArena |
| **Llama 4 Maverick** | Llama Community | *Updated* entry — corrected release date (2025-04-05), real benchmarks, data-center VRAM reality, Scout self-host note |

**Plus the centerpiece:** `best-open-local-llms-2026.mdx` — a self-host field guide that ties the whole wave together by **hardware** (laptop → consumer GPU → 80GB card → multi-GPU node), **license** (MIT / Apache 2.0 / Llama Community / Modified MIT), and **use case**, including the self-host-vs-API economics and an honest "where these sit vs the closed frontier" section. All five model articles link into it.

**Registry** (`data/model-registry.json`): added `gpt-oss`, `gemma-4`, `phi-4`, `mistral-large-3` + new org `mistralai`; updated `llama-4-maverick` (richer + corrected data); wired org lists. **24 models, 10 orgs.**

**Editorial** (`lib/llm-hub/editorial.ts`): verdicts for gpt-oss / gemma-4 / phi-4; refreshed Llama 4 (the old "runs on one H100" line was wrong — Maverick needs 8×H100) and the orphaned `mistral-large-3` entry (corrected OpenRouter id).

**Arena** (`app/ai-ops/models-2026`): a new **"Open & Local Models"** section — a VRAM / context / license / runner card grid, visually distinct from the proprietary frontier grid, each card linking its deep dive + the field guide.

**Tooling**: `generate-model-hero.mjs` is now the complete source of truth (all 13 heroes, deterministic) — addresses the Phase 2 review note.

### Verification
- `node -e require('./data/model-registry.json')` parses; no dangling org→model refs; **all 24 models** have editorial entries
- `npx tsc --noEmit` clean; `eslint` clean on touched files
- All six articles: TL;DR-first, FAQ ≥5, `schema:["Article","FAQPage"]`, hero on disk, internal links resolve; no banned voice terms
- `build-route-index` picks up the six new blog routes; heroes rasterized and visually checked

### Series complete
With this, the model layer is current to June 5 2026 across Western flagships (P1), open-frontier labs (P2), and open/local (P3): **24 models, 13 deep-dive articles, the arena fully modernized.**

https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum)_