### PR TITLE
Refresh LLM Hub compare + decision matrix to June 2026 flagships

### DIFF
--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -328,7 +328,14 @@ export default function Models2026Page() {
         <section className="pt-16 pb-16 md:pt-24 md:pb-20 px-6">
           <div className="max-w-6xl mx-auto">
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
-              <p className="text-[#a855f7] font-mono text-sm mb-4 tracking-wider uppercase">Updated June 2026</p>
+              <div className="inline-flex items-center gap-2 mb-4 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25" role="status" aria-label="Data last verified June 5, 2026">
+                <span className="relative flex h-2 w-2" aria-hidden="true">
+                  <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
+                </span>
+                <span className="text-emerald-300 font-mono text-xs tracking-wider uppercase">Last verified · June 5, 2026</span>
+                <span className="text-white/30 font-mono text-xs hidden sm:inline">· verified snapshot, not a live feed</span>
+              </div>
               <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">Frontier AI Models Intelligence Hub</h1>
               <p className="text-white/60 text-lg md:text-xl max-w-3xl mb-8 leading-relaxed">
                 Benchmarks, pricing, context windows, and capabilities for every frontier model worth tracking.

--- a/lib/llm-hub/comparisons.ts
+++ b/lib/llm-hub/comparisons.ts
@@ -4,6 +4,11 @@
  * high-intent, and poorly served by quality content — this is the wedge.
  *
  * slug convention: `${a}-vs-${b}` using registry model ids.
+ *
+ * June 2026 refresh: marquee current matchups added (Opus 4.8 / GPT-5.5 /
+ * Grok 4.3 / DeepSeek V4 / Qwen3.7-Max / Kimi K2.6 / gpt-oss / Gemma 4).
+ * Earlier-generation pages are kept (URLs preserved) with a currency note.
+ * Verified-vs-vendor-claimed distinctions are called out where it matters.
  */
 
 export interface Comparison {
@@ -26,6 +31,192 @@ export interface Comparison {
 }
 
 export const COMPARISONS: Comparison[] = [
+  // ─────────────────────────────────────────────────────────────────────────
+  // Current marquee matchups (June 2026)
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    slug: 'claude-opus-4-8-vs-gpt-5-5',
+    models: ['claude-opus-4-8', 'gpt-5.5'],
+    title: 'Claude Opus 4.8 vs GPT-5.5',
+    description:
+      'Claude Opus 4.8 vs GPT-5.5: benchmarks, pricing, and which frontier model to use for reasoning, agentic coding, and computer use in 2026.',
+    verdict:
+      'Opus 4.8 leads aggregate intelligence and SWE-Bench Pro; GPT-5.5 wins computer-use, terminal-agent loops, and native voice. The split is real enough to run both.',
+    analysis: [
+      'These are the two flagship picks of mid-2026. Claude Opus 4.8 tops the aggregate intelligence index — GDPval-AA 1890 and SWE-Bench Pro 69.2% lead the field — with a 1M-token context and unchanged $5/$25 pricing. GPT-5.5 ("Spud") answers with the strongest published computer-use and knowledge-work scores: 84.9% GDPval, 78.7% OSWorld, 98% Tau2 Telecom, and a narrow terminal-agent edge.',
+      'Cost is a genuine differentiator. Opus 4.8 held its price; GPT-5.5 doubled output to $30/1M, offset only on output-heavy workloads by a ~40% token-efficiency gain. For most builders, Opus 4.8 is the cheaper path to top-tier reasoning, while GPT-5.5 earns its premium where computer-use autonomy or native voice is the bottleneck.',
+      'Honest caveat: GPT-5.5’s SWE-bench Verified and ARC-AGI-2 figures vary across sources and are treated cautiously; Opus 4.8’s GPQA/USAMO numbers lean on Anthropic’s own evals. The coding and GDPval deltas are the well-corroborated ones.',
+    ],
+    pickFirst: [
+      'Hardest reasoning and codebase-scale work (SWE-Bench Pro lead)',
+      'You want top-tier capability at unchanged $5/$25',
+      '1M context with the strongest long-horizon agentic depth',
+    ],
+    pickSecond: [
+      'Computer-use / OSWorld automation is the bottleneck',
+      'Terminal-agent and Codex-style autonomous loops',
+      'Native voice is core to the product',
+    ],
+    keywords: [
+      'claude opus 4.8 vs gpt-5.5',
+      'opus 4.8 vs gpt 5.5 benchmarks',
+      'best frontier model 2026',
+      'claude vs gpt 2026',
+    ],
+  },
+  {
+    slug: 'deepseek-v4-vs-claude-opus-4-8',
+    models: ['deepseek-v4', 'claude-opus-4-8'],
+    title: 'DeepSeek V4 vs Claude Opus 4.8',
+    description:
+      'DeepSeek V4 vs Claude Opus 4.8: open-weight MIT frontier vs the closed intelligence leader. Cost, self-host, and capability compared for 2026.',
+    verdict:
+      'Opus 4.8 is the stronger model outright; DeepSeek V4 is the open-weight value play — frontier-class coding at roughly a third of the price, and you can own the weights.',
+    analysis: [
+      'This is the open-vs-closed decision at the top of the market. DeepSeek V4 (MIT, open weights) posts 80.6% SWE-bench Verified and an Artificial Analysis Intelligence Index around 52 — genuinely frontier-adjacent — at roughly $1.74/$3.48 per 1M via API, or $0 marginal cost self-hosted. Claude Opus 4.8 leads the aggregate index (GDPval-AA 1890, SWE-Bench Pro 69.2%) and brings a 1M context plus deep agentic tooling.',
+      'The gap is real but narrower than the price gap. Independent US-government testing (NIST/CAISI) put the DeepSeek line a few months behind the closed frontier — so for the hardest reasoning and longest-horizon agents, Opus 4.8 still wins. For high-volume coding, data control, or sovereignty, DeepSeek V4 delivers most of the capability at a fraction of the cost.',
+      'Rule of thumb: route the expensive-failure, top-of-funnel reasoning to Opus 4.8 and run the high-volume, verifiable, or data-sensitive work on self-hosted DeepSeek V4.',
+    ],
+    pickFirst: [
+      'You want open weights / self-hosting under MIT',
+      'High-volume coding at a fraction of frontier cost',
+      'Data sovereignty or air-gapped deployment',
+    ],
+    pickSecond: [
+      'You need the absolute top of the intelligence index',
+      '1M-context synthesis and long-horizon agentic depth',
+      'Managed reliability over owning the stack',
+    ],
+    keywords: [
+      'deepseek v4 vs claude opus 4.8',
+      'open weight vs closed frontier 2026',
+      'deepseek v4 benchmarks',
+      'best open source llm vs claude',
+    ],
+  },
+  {
+    slug: 'grok-4-3-vs-gpt-5-5',
+    models: ['grok-4.3', 'gpt-5.5'],
+    title: 'Grok 4.3 vs GPT-5.5',
+    description:
+      'Grok 4.3 vs GPT-5.5: the budget-frontier vs premium-flagship tradeoff. Intelligence, price, and speed compared for 2026 builders.',
+    verdict:
+      'GPT-5.5 is clearly the stronger model; Grok 4.3 delivers a large share of the capability at roughly a fifth of the price — the budget-frontier default.',
+    analysis: [
+      'Grok 4.3 is xAI’s value play: an Artificial Analysis Intelligence Index of 53 and GDPval-AA around 1500 at $1.25/$2.50 per 1M — the cheapest frontier-class price, with fast output and a 2M-token window. GPT-5.5 sits higher on intelligence (84.9% GDPval, 78.7% OSWorld) but costs $5/$30 and is tuned for the hardest agentic and computer-use work.',
+      'The decision is almost entirely about where the task sits on the value curve. For high-volume, cost-sensitive workloads where "good enough frontier" wins, Grok 4.3 is hard to beat on price-per-intelligence. For the steps where capability is the bottleneck — autonomous computer use, the hardest coding — GPT-5.5 earns its premium.',
+      'A common pattern: Grok 4.3 as the cost-anchored default runtime, GPT-5.5 reserved for the critical path.',
+    ],
+    pickFirst: [
+      'Cheapest frontier-class intelligence ($1.25/$2.50)',
+      'High-volume workloads where cost compounds',
+      '2M context and fast output matter',
+    ],
+    pickSecond: [
+      'You need the stronger model on hard agentic tasks',
+      'Computer-use / OSWorld automation',
+      'Native voice and broad multimodal',
+    ],
+    keywords: [
+      'grok 4.3 vs gpt-5.5',
+      'cheapest frontier model 2026',
+      'grok 4.3 pricing vs openai',
+      'budget llm vs gpt',
+    ],
+  },
+  {
+    slug: 'qwen3-7-max-vs-deepseek-v4',
+    models: ['qwen3.7-max', 'deepseek-v4'],
+    title: 'Qwen3.7-Max vs DeepSeek V4',
+    description:
+      'Qwen3.7-Max vs DeepSeek V4: the open-frontier showdown — closed top-5 intelligence vs MIT open weights. Cost, capability, and control for 2026.',
+    verdict:
+      'Qwen3.7-Max has the higher raw intelligence but is closed and API-only; DeepSeek V4 is open-weight MIT, cheaper, and self-hostable. Capability vs control.',
+    analysis: [
+      'Both are the leading Chinese-lab flagships, but they sit on opposite sides of the open-weight line. Qwen3.7-Max posts a top-5 Artificial Analysis Intelligence Index of 56.6 and a documented 35-hour autonomous run — but it is closed-weight, API-only ($2.50/$7.50), with an undisclosed architecture. DeepSeek V4 trails slightly on aggregate (~52) yet ships under MIT as open weights you can self-host, at lower cost.',
+      'If your priority is the highest capability-per-dollar via an API and you can live with a closed model, Qwen3.7-Max leads. If you need to own the weights, audit the model, or deploy in a sovereign/air-gapped setting, DeepSeek V4 is the only one of the two that qualifies.',
+      'Caveat: several of Qwen3.7-Max’s headline figures (the 35-hour run, some coding evals) are vendor-claimed and pending independent reproduction; it is also a verbose reasoner, so effective cost-per-task runs above the rate card.',
+    ],
+    pickFirst: [
+      'Highest open-frontier intelligence via API',
+      'Long autonomous tool-loops (35-hour demo)',
+      'Anthropic Messages-compatible harness (Claude Code)',
+    ],
+    pickSecond: [
+      'You need open weights you can self-host (MIT)',
+      'Lower cost and auditable architecture',
+      'Sovereign / air-gapped deployment',
+    ],
+    keywords: [
+      'qwen3.7-max vs deepseek v4',
+      'best chinese ai model 2026',
+      'qwen vs deepseek open weights',
+      'open frontier model comparison',
+    ],
+  },
+  {
+    slug: 'kimi-k2-6-vs-deepseek-v4',
+    models: ['kimi-k2.6', 'deepseek-v4'],
+    title: 'Kimi K2.6 vs DeepSeek V4',
+    description:
+      'Kimi K2.6 vs DeepSeek V4: the top open-weights matchup of 2026. Intelligence index, coding, license, and self-host compared.',
+    verdict:
+      'Kimi K2.6 edges the open-weights intelligence lead; DeepSeek V4 counters with MIT licensing, strong coding, and a deeper ecosystem. Both are self-hostable giants.',
+    analysis: [
+      'This is the fight for "best model you can actually download." Kimi K2.6 (Moonshot, ~1T-parameter MoE) holds the highest open-weights Artificial Analysis Intelligence Index at 54; DeepSeek V4 sits just behind at ~52 but pairs frontier-class coding (80.6% SWE-bench Verified) with a clean MIT license and broad tooling support.',
+      'For a pure intelligence ceiling among open weights, Kimi K2.6 is the pick. For coding-heavy pipelines, license clarity, and ecosystem maturity, DeepSeek V4 is the safer foundation. Both are large MoE models that need a multi-GPU server to self-host — neither is a single-consumer-GPU option.',
+      'Caveat: some of Kimi K2.6’s coding evals are vendor-reported; the Intelligence Index placement is the independently measured signal.',
+    ],
+    pickFirst: [
+      'Highest open-weights intelligence (AA 54)',
+      'General reasoning and agentic breadth',
+      'You want the top downloadable model',
+    ],
+    pickSecond: [
+      'Coding-heavy pipelines (SWE-bench lead)',
+      'MIT license clarity and ecosystem maturity',
+      'You want a proven self-host coding foundation',
+    ],
+    keywords: [
+      'kimi k2.6 vs deepseek v4',
+      'best open weights model 2026',
+      'kimi vs deepseek',
+      'top open source llm',
+    ],
+  },
+  {
+    slug: 'gpt-oss-vs-gemma-4',
+    models: ['gpt-oss', 'gemma-4'],
+    title: 'gpt-oss vs Gemma 4',
+    description:
+      'gpt-oss vs Gemma 4: the best self-host model for one GPU. Reasoning-per-VRAM, multimodality, license, and hardware compared for 2026.',
+    verdict:
+      'Gemma 4 wins for multimodal work on a single consumer GPU; gpt-oss wins on reasoning-per-gigabyte and scales to 120b on one 80GB card. Both are Apache 2.0.',
+    analysis: [
+      'These are the two best "runs on my hardware" open models. Gemma 4’s 31B dense flagship fits in roughly 18GB at Q4 — one consumer GPU — adds native vision (and audio on the smaller tiers), and posts a 1452 LMArena Elo. gpt-oss ships 20b (~16GB) and 120b (one 80GB GPU) MoE variants tuned for the best reasoning-per-VRAM with adjustable reasoning effort.',
+      'Pick by constraint. If you want multimodality and the strongest single-consumer-GPU quality, Gemma 4 is the default. If you want maximum reasoning that still fits on one card — or the headroom to scale to 120b on an 80GB GPU — gpt-oss is the sharper tool. Both carry clean Apache 2.0 licenses, so neither adds legal friction.',
+      'For an edge deployment, also weigh Gemma 4’s E2B/E4B tiers and Phi-4 — they go smaller than either flagship here.',
+    ],
+    pickFirst: [
+      'Reasoning-per-VRAM on one GPU; scales to 120b on 80GB',
+      'Adjustable reasoning effort',
+      'Pure text/reasoning self-host',
+    ],
+    pickSecond: [
+      'Native multimodal (vision/audio) on one consumer GPU',
+      'Strongest single-card general quality (LMArena 1452)',
+      'Google-ecosystem tooling + small E2B/E4B tiers',
+    ],
+    keywords: [
+      'gpt-oss vs gemma 4',
+      'best self-host llm 2026',
+      'best local model one gpu',
+      'open weight model comparison',
+    ],
+  },
+  // ─────────────────────────────────────────────────────────────────────────
+  // Earlier-generation pages — kept for URL/SEO continuity, with a currency note.
+  // ─────────────────────────────────────────────────────────────────────────
   {
     slug: 'gemini-3-5-flash-vs-claude-opus-4-6',
     models: ['gemini-3-5-flash', 'claude-opus-4-6'],
@@ -33,11 +224,11 @@ export const COMPARISONS: Comparison[] = [
     description:
       'Gemini 3.5 Flash vs Claude Opus 4.6: benchmarks, pricing, and which to use for agentic coding, reasoning, and long-context work in 2026.',
     verdict:
-      'Different tiers, different jobs. Flash wins cost-sensitive agentic coding (76.2% Terminal-Bench 2.1 at a fraction of the cost); Opus 4.6 wins high-stakes reasoning (68.8% ARC-AGI-2) and computer-use.',
+      'Different tiers, different jobs. Flash wins cost-sensitive agentic coding (76.2% Terminal-Bench 2.1); Opus 4.6 wins high-stakes reasoning. Note: Opus 4.6 is now superseded by Opus 4.8 — see Opus 4.8 vs GPT-5.5 for the current flagship matchup.',
     analysis: [
-      'These are not direct competitors — they are the two ends of a sensible routing strategy. Gemini 3.5 Flash, announced at Google I/O ’26, posts frontier agentic-coding numbers (76.2% Terminal-Bench 2.1, 83.6% MCP Atlas) at less than half the cost of comparable flagships. Claude Opus 4.6 leads abstract reasoning (68.8% ARC-AGI-2), computer-use (72.7% OSWorld), and offers a 1M-token beta context with Agent Teams for parallel execution.',
-      'For a production agentic system, the cost delta is large enough to be architectural: route routine and high-volume steps to Flash, reserve Opus 4.6 for the critical reasoning path. Running both is usually correct.',
-      'Caveat: Gemini 3.5 Flash’s headline figures are vendor-published and pending independent reproduction. Opus 4.6’s ARC-AGI-2 lead is corroborated by the ARC Prize Foundation.',
+      'These are the two ends of a sensible routing strategy. Gemini 3.5 Flash, announced at Google I/O ’26, posts frontier agentic-coding numbers (76.2% Terminal-Bench 2.1, 83.6% MCP Atlas) at less than half the cost of comparable flagships. Claude Opus 4.6 led abstract reasoning (68.8% ARC-AGI-2), computer-use (72.7% OSWorld), and offered a 1M-token beta context with Agent Teams.',
+      'For a production agentic system, the cost delta is large enough to be architectural: route routine and high-volume steps to Flash, reserve the top Claude tier for the critical reasoning path. Running both is usually correct.',
+      'Currency note: Opus 4.6 has since been superseded by Opus 4.8 (May 2026), which now tops the intelligence index. The Flash routing logic here still holds against the current Opus tier.',
     ],
     pickFirst: [
       'You run high-volume agent loops where cost compounds',
@@ -53,21 +244,21 @@ export const COMPARISONS: Comparison[] = [
       'gemini 3.5 flash vs claude opus 4.6',
       'gemini vs claude 2026',
       'best agentic coding model',
-      'claude opus 4.6 vs gemini',
+      'claude opus vs gemini',
     ],
   },
   {
     slug: 'claude-opus-4-6-vs-gpt-5-2-pro',
-    models: ['claude-opus-4-6', 'gpt-5-2-pro'],
+    models: ['claude-opus-4-6', 'gpt-5.2-pro'],
     title: 'Claude Opus 4.6 vs GPT-5.2 Pro',
     description:
-      'Claude Opus 4.6 vs GPT-5.2 Pro: reasoning, multimodal, voice, and pricing compared. Which frontier model to pick in 2026.',
+      'Claude Opus 4.6 vs GPT-5.2 Pro: reasoning, multimodal, voice, and pricing compared. Both are now superseded — see the current flagship matchup.',
     verdict:
-      'Opus 4.6 for reasoning and long-context depth; GPT-5.2 Pro for native voice and the broadest multimodal + integration footprint.',
+      'Opus 4.6 for reasoning and long-context depth; GPT-5.2 Pro for native voice and the broadest multimodal footprint. Note: both are superseded — Opus 4.8 and GPT-5.5 are the current flagships; see Opus 4.8 vs GPT-5.5.',
     analysis: [
-      'Claude Opus 4.6 leads the reasoning benchmarks that matter for hard agentic work — 68.8% ARC-AGI-2 (vs 54.2%), 72.7% OSWorld, 90.2% BigLaw Bench — plus a 1M-token beta context and the Compaction API for effectively unbounded sessions.',
-      'GPT-5.2 Pro answers with breadth: native audio modality (voice in, voice out), strong general multimodal performance, the first 90% ARC-AGI-1, and the widest enterprise integration ecosystem. For voice-native products there is no close runner-up.',
-      'Both are premium-tier. The choice usually comes down to modality needs (voice → GPT) versus reasoning depth and long-context synthesis (→ Opus).',
+      'Claude Opus 4.6 led the reasoning benchmarks that matter for hard agentic work — 68.8% ARC-AGI-2 (vs 54.2%), 72.7% OSWorld, 90.2% BigLaw Bench — plus a 1M-token beta context and the Compaction API for effectively unbounded sessions.',
+      'GPT-5.2 Pro answered with breadth: native audio modality, strong general multimodal performance, the first 90% ARC-AGI-1, and the widest enterprise integration ecosystem. For voice-native products there was no close runner-up.',
+      'Currency note: this matchup is preserved for reference. Opus 4.6 has been superseded by Opus 4.8 (May 2026) and GPT-5.2 Pro by GPT-5.5 (April 2026). For a current decision, see Claude Opus 4.8 vs GPT-5.5.',
     ],
     pickFirst: [
       'Hard reasoning, computer-use, or legal/technical depth',
@@ -88,16 +279,16 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'gemini-3-5-flash-vs-gpt-5-2-pro',
-    models: ['gemini-3-5-flash', 'gpt-5-2-pro'],
+    models: ['gemini-3-5-flash', 'gpt-5.2-pro'],
     title: 'Gemini 3.5 Flash vs GPT-5.2 Pro',
     description:
       'Gemini 3.5 Flash vs GPT-5.2 Pro: cost, agentic coding, multimodal, and voice compared for 2026 builders.',
     verdict:
-      'Flash for cost-efficient agentic coding at scale; GPT-5.2 Pro for voice-native and broad multimodal applications.',
+      'Flash for cost-efficient agentic coding at scale; GPT-5.2 Pro for voice-native and broad multimodal apps. Note: GPT-5.2 Pro is superseded by GPT-5.5 — see Grok 4.3 vs GPT-5.5 or Opus 4.8 vs GPT-5.5 for current matchups.',
     analysis: [
       'Gemini 3.5 Flash is built for the agent runtime: 76.2% Terminal-Bench 2.1, 83.6% MCP Atlas, 1M context, at sub-flagship pricing. If your bottleneck is running many agent steps affordably, Flash is hard to beat.',
-      'GPT-5.2 Pro is the generalist with native voice and the deepest integration ecosystem. It is the better default for consumer-facing multimodal and voice products, less optimal as a high-volume coding-agent runtime on cost grounds.',
-      'For many builders the answer is both: Flash as the agent runtime, GPT-5.2 Pro at the voice/multimodal edge.',
+      'GPT-5.2 Pro was the generalist with native voice and the deepest integration ecosystem — the better default for consumer-facing multimodal and voice products, less optimal as a high-volume coding-agent runtime on cost grounds.',
+      'Currency note: GPT-5.2 Pro has since been superseded by GPT-5.5 (April 2026), which extends the lead on computer-use and knowledge work. The Flash-as-runtime logic still applies against the current OpenAI flagship.',
     ],
     pickFirst: [
       'Cost-sensitive, high-volume agentic coding',
@@ -117,77 +308,17 @@ export const COMPARISONS: Comparison[] = [
     ],
   },
   {
-    slug: 'deepseek-v3-2-vs-gemini-3-5-flash',
-    models: ['deepseek-v3-2', 'gemini-3-5-flash'],
-    title: 'DeepSeek V3.2 vs Gemini 3.5 Flash',
-    description:
-      'DeepSeek V3.2 vs Gemini 3.5 Flash: the budget frontier showdown — open-weight MIT vs closed sub-flagship pricing.',
-    verdict:
-      'DeepSeek V3.2 wins on raw cost and open-weight control; Gemini 3.5 Flash wins on agentic-coding benchmarks and managed tooling.',
-    analysis: [
-      'Both target the cost-sensitive frontier. DeepSeek V3.2 is a 671B/37B MoE under MIT license at roughly $0.27 / $1.10 per 1M tokens — the most cost-effective frontier-class option, and self-hostable.',
-      'Gemini 3.5 Flash costs a little more but brings stronger published agentic-coding numbers (76.2% Terminal-Bench 2.1), 1M context, and the managed Google tooling (AI Studio, Antigravity, Agent Platform).',
-      'If you want to own the weights and minimize cost, DeepSeek. If you want the strongest managed agentic runtime at low cost, Flash.',
-    ],
-    pickFirst: [
-      'You want open weights / self-hosting',
-      'Absolute lowest cost per token',
-      'MIT license matters',
-    ],
-    pickSecond: [
-      'You want managed tooling + agent platform',
-      'Agentic-coding benchmark performance matters',
-      'You need 1M context out of the box',
-    ],
-    keywords: [
-      'deepseek v3.2 vs gemini 3.5 flash',
-      'cheapest llm 2026',
-      'open weight vs gemini',
-      'budget frontier model',
-    ],
-  },
-  {
-    slug: 'gemini-omni-vs-sora-2',
-    models: ['gemini-omni', 'gpt-5-2-pro'],
-    title: 'Gemini Omni vs Sora 2 (video generation)',
-    description:
-      'Gemini Omni vs Sora 2: AI video generation compared — editing control, integration, and creator workflows in 2026.',
-    verdict:
-      'Gemini Omni leads on natural-language editing and agentic integration; Sora 2 may still lead pure cinematic generation. Independent head-to-heads pending.',
-    analysis: [
-      'Gemini Omni (announced at Google I/O ’26) folds native video generation into the standard Gemini API — text/audio/image/video to dynamic video, with natural-language editing (swap subject, change background, regenerate camera angle). Because it lives in the Gemini surface, an agent can author, narrate, and produce a video in one tool-use sequence.',
-      'Sora 2 (OpenAI) remains a strong dedicated video model with high cinematic fidelity. The structural difference: Omni is a capability of the flagship model and thus easier to wire into agentic content pipelines; Sora is a specialized product.',
-      'Honest caveat: neither has been independently benchmarked head-to-head yet. Treat this as a positioning comparison, not a quality verdict.',
-    ],
-    pickFirst: [
-      'You need natural-language video editing',
-      'You want video inside an agentic pipeline',
-      'You are in the Google / Gemini ecosystem',
-    ],
-    pickSecond: [
-      'Pure cinematic generation fidelity is the goal',
-      'You are in the OpenAI ecosystem',
-      'You need Sora-specific creative controls',
-    ],
-    keywords: [
-      'gemini omni vs sora 2',
-      'best ai video generator 2026',
-      'gemini video generation',
-      'ai video editing model',
-    ],
-  },
-  {
     slug: 'claude-sonnet-4-5-vs-gemini-3-5-flash',
-    models: ['claude-sonnet-4-5', 'gemini-3-5-flash'],
+    models: ['claude-sonnet-4-5-20250929', 'gemini-3-5-flash'],
     title: 'Claude Sonnet 4.5 vs Gemini 3.5 Flash',
     description:
       'Claude Sonnet 4.5 vs Gemini 3.5 Flash: the mid-tier workhorse comparison for production coding and content agents.',
     verdict:
-      'Gemini 3.5 Flash edges ahead on agentic-coding benchmarks and cost; Claude Sonnet 4.5 remains a proven, well-integrated production workhorse.',
+      'Gemini 3.5 Flash edges ahead on agentic-coding benchmarks and cost; Claude Sonnet 4.5 remains a proven production workhorse. Note: Sonnet 4.6 (Feb 2026) is the current Anthropic mid-tier.',
     analysis: [
       'This is the mid-tier decision most teams actually face. Gemini 3.5 Flash posts stronger published agentic-coding numbers at lower cost and ships with 1M context. Claude Sonnet 4.5 is the battle-tested workhorse with excellent Claude Code / Agent SDK integration and predictable behavior.',
-      'If you are already on Claude Code and value the tooling, Sonnet 4.5 is a safe, strong default. If you are cost-optimizing a high-volume agent runtime from scratch, Flash is the sharper pick.',
-      'A common pattern: Flash for the agent runtime, Sonnet/Opus for the steps where Claude’s behavior is a known quantity.',
+      'If you are already on Claude Code and value the tooling, the Sonnet tier is a safe, strong default. If you are cost-optimizing a high-volume agent runtime from scratch, Flash is the sharper pick.',
+      'Currency note: Sonnet 4.6 (February 2026) is now the current Anthropic mid-tier — a 1M-context upgrade that approaches Opus 4.6 at ~40% lower cost — and is the version to actually deploy in this slot.',
     ],
     pickFirst: [
       'You are standardized on Claude Code / Agent SDK',

--- a/lib/llm-hub/comparisons.ts
+++ b/lib/llm-hub/comparisons.ts
@@ -36,7 +36,7 @@ export const COMPARISONS: Comparison[] = [
   // ─────────────────────────────────────────────────────────────────────────
   {
     slug: 'claude-opus-4-8-vs-gpt-5-5',
-    models: ['claude-opus-4-8', 'gpt-5.5'],
+    models: ['claude-opus-4-8', 'gpt-5-5'],
     title: 'Claude Opus 4.8 vs GPT-5.5',
     description:
       'Claude Opus 4.8 vs GPT-5.5: benchmarks, pricing, and which frontier model to use for reasoning, agentic coding, and computer use in 2026.',
@@ -96,7 +96,7 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'grok-4-3-vs-gpt-5-5',
-    models: ['grok-4.3', 'gpt-5.5'],
+    models: ['grok-4-3', 'gpt-5-5'],
     title: 'Grok 4.3 vs GPT-5.5',
     description:
       'Grok 4.3 vs GPT-5.5: the budget-frontier vs premium-flagship tradeoff. Intelligence, price, and speed compared for 2026 builders.',
@@ -126,7 +126,7 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'qwen3-7-max-vs-deepseek-v4',
-    models: ['qwen3.7-max', 'deepseek-v4'],
+    models: ['qwen3-7-max', 'deepseek-v4'],
     title: 'Qwen3.7-Max vs DeepSeek V4',
     description:
       'Qwen3.7-Max vs DeepSeek V4: the open-frontier showdown — closed top-5 intelligence vs MIT open weights. Cost, capability, and control for 2026.',
@@ -156,7 +156,7 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'kimi-k2-6-vs-deepseek-v4',
-    models: ['kimi-k2.6', 'deepseek-v4'],
+    models: ['kimi-k2-6', 'deepseek-v4'],
     title: 'Kimi K2.6 vs DeepSeek V4',
     description:
       'Kimi K2.6 vs DeepSeek V4: the top open-weights matchup of 2026. Intelligence index, coding, license, and self-host compared.',
@@ -249,7 +249,7 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'claude-opus-4-6-vs-gpt-5-2-pro',
-    models: ['claude-opus-4-6', 'gpt-5.2-pro'],
+    models: ['claude-opus-4-6', 'gpt-5-2-pro'],
     title: 'Claude Opus 4.6 vs GPT-5.2 Pro',
     description:
       'Claude Opus 4.6 vs GPT-5.2 Pro: reasoning, multimodal, voice, and pricing compared. Both are now superseded — see the current flagship matchup.',
@@ -279,7 +279,7 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'gemini-3-5-flash-vs-gpt-5-2-pro',
-    models: ['gemini-3-5-flash', 'gpt-5.2-pro'],
+    models: ['gemini-3-5-flash', 'gpt-5-2-pro'],
     title: 'Gemini 3.5 Flash vs GPT-5.2 Pro',
     description:
       'Gemini 3.5 Flash vs GPT-5.2 Pro: cost, agentic coding, multimodal, and voice compared for 2026 builders.',
@@ -309,7 +309,7 @@ export const COMPARISONS: Comparison[] = [
   },
   {
     slug: 'claude-sonnet-4-5-vs-gemini-3-5-flash',
-    models: ['claude-sonnet-4-5-20250929', 'gemini-3-5-flash'],
+    models: ['claude-sonnet-4-5', 'gemini-3-5-flash'],
     title: 'Claude Sonnet 4.5 vs Gemini 3.5 Flash',
     description:
       'Claude Sonnet 4.5 vs Gemini 3.5 Flash: the mid-tier workhorse comparison for production coding and content agents.',

--- a/lib/llm-hub/decisions.ts
+++ b/lib/llm-hub/decisions.ts
@@ -2,7 +2,13 @@
  * Decision matrix — "pick your constraint → get a recommendation."
  * The fastest path from "which model?" to an answer. Each row maps a
  * single dominant constraint to a primary pick + runner-up, with the
- * one-line reason. Model ids reference the registry.
+ * one-line reason. Model ids reference the registry (use the `id` field so
+ * each link resolves to a pre-rendered /llm-hub/[id] page).
+ *
+ * Refreshed to the June 2026 frontier (Opus 4.8 / GPT-5.5 / Grok 4.3 /
+ * DeepSeek V4 / Qwen3.7-Max / Kimi K2.6 / Gemma 4 / gpt-oss / Phi-4).
+ * Every reason cites a figure carried in the registry; verified-vs-vendor
+ * distinctions live in the per-model pages.
  */
 
 export interface DecisionRow {
@@ -14,61 +20,75 @@ export interface DecisionRow {
 
 export const DECISION_MATRIX: DecisionRow[] = [
   {
-    constraint: 'Lowest cost (closed)',
-    primaryId: 'gemini-3-5-flash',
-    altId: 'claude-haiku-4-5',
-    reason: 'Frontier agentic performance at less than half the cost of comparable flagships.',
+    constraint: 'Hardest reasoning + knowledge work',
+    primaryId: 'claude-opus-4-8',
+    altId: 'gpt-5.5',
+    reason: 'Tops the intelligence index — GDPval-AA 1890 and SWE-Bench Pro 69.2% lead the field.',
+  },
+  {
+    constraint: 'Agentic coding + computer use',
+    primaryId: 'gpt-5.5',
+    altId: 'claude-opus-4-8',
+    reason: 'Best published computer-use scores (84.9% GDPval, 78.7% OSWorld); Opus 4.8 counters on SWE-Bench Pro.',
+  },
+  {
+    constraint: 'Lowest cost (closed frontier)',
+    primaryId: 'grok-4.3',
+    altId: 'gemini-3-5-flash',
+    reason: 'Fourth-best intelligence (AA 53) at the cheapest frontier price — $1.25/$2.50 per 1M.',
+  },
+  {
+    constraint: 'Top open weights',
+    primaryId: 'kimi-k2.6',
+    altId: 'deepseek-v4',
+    reason: 'Highest open-weights intelligence (AA Index 54); DeepSeek V4 is the close, MIT-licensed runner-up.',
   },
   {
     constraint: 'Lowest cost (open weights)',
-    primaryId: 'deepseek-v3-2',
-    altId: 'qwen3-coder-next',
-    reason: 'Frontier-class reasoning at fraction-of-a-cent economics under MIT license.',
-  },
-  {
-    constraint: 'Hardest reasoning',
-    primaryId: 'claude-opus-4-6',
-    altId: 'gpt-5-2-pro',
-    reason: '#1 ARC-AGI-2 (68.8%) and OSWorld (72.7%).',
-  },
-  {
-    constraint: 'Agentic coding',
-    primaryId: 'gemini-3-5-flash',
-    altId: 'claude-opus-4-6',
-    reason: '76.2% Terminal-Bench 2.1 and 83.6% MCP Atlas at low cost.',
+    primaryId: 'deepseek-v4',
+    altId: 'gpt-oss',
+    reason: 'Frontier-class coding (80.6% SWE-bench Verified) at open-weight economics under MIT.',
   },
   {
     constraint: 'Longest context',
-    primaryId: 'grok-4-1',
-    altId: 'gemini-3-pro',
-    reason: '2M-token native context with aggressive pricing.',
+    primaryId: 'grok-4.3',
+    altId: 'gpt-5.5',
+    reason: '2M-token native window; GPT-5.5 offers 1M at GA.',
   },
   {
-    constraint: 'Native voice',
-    primaryId: 'gpt-5-2-pro',
-    reason: 'Native audio modality with no close runner-up.',
+    constraint: 'Native voice + broad multimodal',
+    primaryId: 'gpt-5.5',
+    altId: 'gemini-3-5-pro',
+    reason: 'Native audio modality plus the widest general multimodal coverage.',
   },
   {
-    constraint: 'Multimodal understanding',
-    primaryId: 'gemini-3-pro',
-    altId: 'gpt-5-2-pro',
-    reason: 'Widest modality support; 81% MMMU-Pro.',
-  },
-  {
-    constraint: 'Video generation',
-    primaryId: 'gemini-omni',
-    reason: 'Native frontier video gen with natural-language editing.',
+    constraint: 'Widest modality (incl. video)',
+    primaryId: 'gemini-3-5-pro',
+    altId: 'gemini-3-5-flash',
+    reason: 'Google’s top reasoning tier across text/vision/audio/video (Pro in preview; Flash is the GA workhorse).',
   },
   {
     constraint: 'EU data sovereignty',
-    primaryId: 'mistral-large-3',
-    altId: 'command-a-reasoning',
-    reason: 'Paris-based, full EU residency; Apache-licensed small-model pairing.',
+    primaryId: 'mistral-large-2512',
+    altId: 'deepseek-v4',
+    reason: 'Apache 2.0, EU-resident endpoints, self-hostable frontier on a single 8×H200 node.',
   },
   {
     constraint: 'Self-host / own the weights',
-    primaryId: 'llama-4-maverick',
-    altId: 'deepseek-v3-2',
-    reason: 'Open-weight MoE (400B/17B) that runs on a single H100.',
+    primaryId: 'deepseek-v4',
+    altId: 'llama-4-maverick',
+    reason: 'Open-weight MoE frontier; Llama 4 for a permissive license + native multimodality.',
+  },
+  {
+    constraint: 'Run on one consumer GPU',
+    primaryId: 'gemma-4',
+    altId: 'gpt-oss',
+    reason: 'Gemma 4 31B runs in ~18GB at Q4 (LMArena 1452); gpt-oss-20b is the ~16GB reasoning alternative.',
+  },
+  {
+    constraint: 'Laptop / edge (smallest footprint)',
+    primaryId: 'phi-4',
+    altId: 'gemma-4',
+    reason: 'MIT-licensed 3.8B–15B STEM specialist that runs on a laptop; Gemma 4’s E2B/E4B tiers go smaller still.',
   },
 ]

--- a/lib/llm-hub/decisions.ts
+++ b/lib/llm-hub/decisions.ts
@@ -3,7 +3,8 @@
  * The fastest path from "which model?" to an answer. Each row maps a
  * single dominant constraint to a primary pick + runner-up, with the
  * one-line reason. Model ids reference the registry (use the `id` field so
- * each link resolves to a pre-rendered /llm-hub/[id] page).
+ * each link resolves to a pre-rendered /llm-hub/[key] page — the registry
+ * canonicalizes every model's id to its registry key, which is the routing slug).
  *
  * Refreshed to the June 2026 frontier (Opus 4.8 / GPT-5.5 / Grok 4.3 /
  * DeepSeek V4 / Qwen3.7-Max / Kimi K2.6 / Gemma 4 / gpt-oss / Phi-4).
@@ -22,24 +23,24 @@ export const DECISION_MATRIX: DecisionRow[] = [
   {
     constraint: 'Hardest reasoning + knowledge work',
     primaryId: 'claude-opus-4-8',
-    altId: 'gpt-5.5',
+    altId: 'gpt-5-5',
     reason: 'Tops the intelligence index — GDPval-AA 1890 and SWE-Bench Pro 69.2% lead the field.',
   },
   {
     constraint: 'Agentic coding + computer use',
-    primaryId: 'gpt-5.5',
+    primaryId: 'gpt-5-5',
     altId: 'claude-opus-4-8',
     reason: 'Best published computer-use scores (84.9% GDPval, 78.7% OSWorld); Opus 4.8 counters on SWE-Bench Pro.',
   },
   {
     constraint: 'Lowest cost (closed frontier)',
-    primaryId: 'grok-4.3',
+    primaryId: 'grok-4-3',
     altId: 'gemini-3-5-flash',
     reason: 'Fourth-best intelligence (AA 53) at the cheapest frontier price — $1.25/$2.50 per 1M.',
   },
   {
     constraint: 'Top open weights',
-    primaryId: 'kimi-k2.6',
+    primaryId: 'kimi-k2-6',
     altId: 'deepseek-v4',
     reason: 'Highest open-weights intelligence (AA Index 54); DeepSeek V4 is the close, MIT-licensed runner-up.',
   },
@@ -51,13 +52,13 @@ export const DECISION_MATRIX: DecisionRow[] = [
   },
   {
     constraint: 'Longest context',
-    primaryId: 'grok-4.3',
-    altId: 'gpt-5.5',
+    primaryId: 'grok-4-3',
+    altId: 'gpt-5-5',
     reason: '2M-token native window; GPT-5.5 offers 1M at GA.',
   },
   {
     constraint: 'Native voice + broad multimodal',
-    primaryId: 'gpt-5.5',
+    primaryId: 'gpt-5-5',
     altId: 'gemini-3-5-pro',
     reason: 'Native audio modality plus the widest general multimodal coverage.',
   },
@@ -69,7 +70,7 @@ export const DECISION_MATRIX: DecisionRow[] = [
   },
   {
     constraint: 'EU data sovereignty',
-    primaryId: 'mistral-large-2512',
+    primaryId: 'mistral-large-3',
     altId: 'deepseek-v4',
     reason: 'Apache 2.0, EU-resident endpoints, self-hostable frontier on a single 8×H200 node.',
   },


### PR DESCRIPTION
## What & why

Phases 1–3 brought the registry, arena, and 13 deep-dive articles current to June 2026 — but the **`/llm-hub/compare` pages and the decision matrix still pointed at the prior generation**, and two compare pages **404'd** on models that were never in the registry (`deepseek-v3-2`, `gemini-omni`). This wires both surfaces to the current frontier and adds a freshness badge to the arena.

## Changes

**Comparisons (`lib/llm-hub/comparisons.ts`)**
- **+6 current marquee matchups** (high-intent "X vs Y" SEO): Opus 4.8 vs GPT-5.5 · DeepSeek V4 vs Opus 4.8 · Grok 4.3 vs GPT-5.5 · Qwen3.7-Max vs DeepSeek V4 · Kimi K2.6 vs DeepSeek V4 · gpt-oss vs Gemma 4. Every benchmark traces to the registry; verified-vs-vendor-claimed flagged.
- **Dropped the 2 dead entries** that referenced non-registry models (they returned 404) — replaced by live, current pages.
- **All previously-working slugs preserved** (no URL deletion) with a June 2026 currency note pointing to the successor matchup; switched registry-*key* refs to *id* refs so reverse cross-linking on model pages resolves.

**Decision matrix (`lib/llm-hub/decisions.ts`)**
- Rebuilt every row on current models (ids resolve to pre-rendered `/llm-hub/[id]` pages); dropped 4 orphaned ids that rendered as gray id-strings.
- Added self-host lanes leveraging Phase 3: **top open weights**, **one consumer GPU**, **laptop/edge**.

**Arena (`app/ai-ops/models-2026`)**
- Replaced the static "Updated June 2026" label with a **"Last verified · June 5, 2026"** freshness badge — honest "verified snapshot, not a live feed" framing, with `aria-label` for screen readers.

## Verification
- Script confirms **every** comparison + decision model id resolves against the registry; all decision links hit pre-rendered hub pages.
- `tsc --noEmit` clean · `eslint` clean on all touched files.
- No dangling references to the two removed slugs anywhere in the repo.

Follow-up to the June 2026 frontier refresh (#155 / #156 / #157).

https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Status indicator enhanced to display "Last verified · June 5, 2026" with verification badge, clarifying content is a verified snapshot rather than a live feed
  * Refreshed model comparison database with June 2026 data, featuring latest head-to-head matchups across current LLM models
  * Updated decision guidance matrix with current model recommendations reflecting the latest available frontier models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->