### PR TITLE
fix(voice): de-slop multi-cloud comparison copy (seamless/cutting-edge)

### DIFF
--- a/app/ai-architect/multi-cloud-comparison/page.tsx
+++ b/app/ai-architect/multi-cloud-comparison/page.tsx
@@ -188,7 +188,7 @@ const cloudProviders = {
     tagline: 'Enterprise Integration Champion',
     color: 'from-blue-600 to-indigo-600',
     pricing: 'Premium',
-    description: 'Enterprise-ready cloud with seamless Microsoft ecosystem integration',
+    description: 'Enterprise-ready cloud with native Microsoft ecosystem integration',
     strengths: ['Microsoft ecosystem', 'Enterprise compliance', 'Hybrid cloud', '.NET excellence'],
     weaknesses: ['Complex pricing', 'Steeper learning curve', 'Less startup-friendly'],
     aiServices: ['Azure OpenAI', 'Cognitive Services', 'ML Studio', 'Form Recognizer'],
@@ -652,7 +652,7 @@ function DecisionFramework() {
               <h3 className="text-xl font-bold text-white">Innovation-Focused</h3>
             </div>
             <p className="text-white/70 mb-4">
-              Cutting-edge AI, rapid experimentation
+              Frontier AI models, rapid experimentation
             </p>
             <div className="space-y-2">
               <p className="text-sm text-white/60">

--- a/app/ai-architecture/multi-cloud-comparison/page.tsx
+++ b/app/ai-architecture/multi-cloud-comparison/page.tsx
@@ -189,7 +189,7 @@ const cloudProviders = {
     tagline: 'Enterprise Integration Champion',
     color: 'from-blue-600 to-indigo-600',
     pricing: 'Premium',
-    description: 'Enterprise-ready cloud with seamless Microsoft ecosystem integration',
+    description: 'Enterprise-ready cloud with native Microsoft ecosystem integration',
     strengths: ['Microsoft ecosystem', 'Enterprise compliance', 'Hybrid cloud', '.NET excellence'],
     weaknesses: ['Complex pricing', 'Steeper learning curve', 'Less startup-friendly'],
     aiServices: ['Azure OpenAI', 'Cognitive Services', 'ML Studio', 'Form Recognizer'],
@@ -653,7 +653,7 @@ function DecisionFramework() {
               <h3 className="text-xl font-bold text-white">Innovation-Focused</h3>
             </div>
             <p className="text-white/70 mb-4">
-              Cutting-edge AI, rapid experimentation
+              Frontier AI models, rapid experimentation
             </p>
             <div className="space-y-2">
               <p className="text-sm text-white/60">


### PR DESCRIPTION
## What
Final voice fix of this batch — removes two slop terms from the multi-cloud comparison copy (both `/ai-architecture` and `/ai-architect` copies):
- "Enterprise-ready cloud with **seamless** Microsoft ecosystem integration" → "**native** Microsoft ecosystem integration" (accurate — Azure is native to the MS ecosystem)
- "**Cutting-edge** AI, rapid experimentation" → "**Frontier AI models**, rapid experimentation"

Copy only — no logic/layout changes. Closes the open item tracked in `docs/HUB_REGISTRY.csv` (multi-cloud row).

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_