### PR TITLE
fix(blog): escape MDX-breaking '<$60' blocking all production builds

### DIFF
--- a/content/blog/faceless-youtube-ai-tools-2026.mdx
+++ b/content/blog/faceless-youtube-ai-tools-2026.mdx
@@ -113,7 +113,7 @@ This is the multiplier. One long upload becomes 5–10 vertical clips for Shorts
 
 Three configurations, all verified at June-2026 prices. Pick the row that matches your stage.
 
-| Station | Lean ($0–5) | Recommended (<$60) | Tool |
+| Station | Lean ($0–5) | Recommended (under $60) | Tool |
 |---|---|---|---|
 | Script | Free | $0 (Claude free) | Claude / ChatGPT |
 | Voice | $5 | $5 | ElevenLabs Starter |


### PR DESCRIPTION
## 🚨 Production deploy blocker — fix

`content/blog/faceless-youtube-ai-tools-2026.mdx` (added 2026-06-06) contains, in a markdown table:

```
| Station | Lean ($0–5) | Recommended (<$60) | Tool |
```

MDX parses `<$60)` as a JSX tag and fails: **`[88:44: Unexpected character ')' ...]`** → `Error occurred prerendering page "/blog/faceless-youtube-ai-tools-2026"` → `npm run build exited with 1`. This **blocks every production build/deploy** (and is why CI Build fails on open PRs like #159 — unrelated to their diffs).

**Fix:** `(<$60)` → `(under $60)`.

**Verified:** a fence-aware sweep (`awk` skipping ``` blocks) across all `content/blog/*.mdx` found **no other** MDX-unsafe `<` in prose/tables. The `< 2.5s` / `<500 lines` style hits elsewhere are inside code fences (safe).

Why now: this post landed after the Jun 5 PRs (#147/#152/#153) merged green, so it's a fresh regression on `main`.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_