### PR TITLE
Excellence pass: model↔article interlinking, sitemap coverage, JSON-LD hardening

### DIFF
--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -308,6 +308,34 @@ const ociModels = [
   { name: 'Gemini 2.5 Flash-Lite', provider: 'Google', context: '-', useCase: 'Budget, high-volume', eu: false },
 ]
 
+// Card name -> FrankX deep-dive article slug (/blog/[slug]).
+const deepDiveSlugs: Record<string, string> = {
+  'Claude Opus 4.8': 'claude-opus-4-8-analysis-2026',
+  'GPT-5.5': 'gpt-5-5-analysis-2026',
+  'Grok 4.3': 'grok-4-3-analysis-2026',
+  'DeepSeek V4': 'deepseek-v4-analysis-2026',
+  'Kimi K2.6': 'kimi-k2-analysis-2026',
+  'Qwen3.7-Max': 'qwen3-max-analysis-2026',
+  'Gemini 3.5 Pro': 'gemini-3-5-pro-analysis-2026',
+  'Llama 4 Maverick': 'llama-4-analysis-2026',
+  'MAI-Thinking-1': 'microsoft-mai-frontier-models-2026',
+}
+
+// Card name -> LLM Hub model page (/llm-hub/[registry key]).
+const hubSlugs: Record<string, string> = {
+  'Claude Opus 4.8': 'claude-opus-4-8',
+  'GPT-5.5': 'gpt-5-5',
+  'Gemini 3.5 Flash': 'gemini-3-5-flash',
+  'Grok 4.3': 'grok-4-3',
+  'DeepSeek V4': 'deepseek-v4',
+  'Kimi K2.6': 'kimi-k2-6',
+  'Qwen3.7-Max': 'qwen3-7-max',
+  'Claude Sonnet 4.6': 'claude-sonnet-4-6',
+  'Gemini 3.5 Pro': 'gemini-3-5-pro',
+  'Llama 4 Maverick': 'llama-4-maverick',
+  'MAI-Thinking-1': 'mai-thinking-1',
+}
+
 export default function Models2026Page() {
   return (
     <div className="min-h-screen bg-[#0a0a0b] text-white">
@@ -353,6 +381,9 @@ export default function Models2026Page() {
                 </Link>
                 <Link href="/blog/deepseek-v4-analysis-2026" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#06b6d4]/10 border border-[#06b6d4]/20 hover:border-[#06b6d4]/40 text-[#06b6d4] text-sm transition-colors">
                   <Cpu className="w-4 h-4" /> Open-frontier: DeepSeek V4
+                </Link>
+                <Link href="/llm-hub" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 border border-white/10 hover:border-white/25 text-white/70 text-sm transition-colors">
+                  <Globe className="w-4 h-4" /> Explore the LLM Hub
                 </Link>
               </div>
             </motion.div>
@@ -419,6 +450,20 @@ export default function Models2026Page() {
                       <span key={tag} className="px-2 py-0.5 text-xs rounded-full bg-white/5 text-white/40">{tag}</span>
                     ))}
                   </div>
+                  {(deepDiveSlugs[m.name] || hubSlugs[m.name]) && (
+                    <div className="mt-4 flex items-center gap-4 border-t border-white/5 pt-3 text-xs">
+                      {deepDiveSlugs[m.name] && (
+                        <Link href={`/blog/${deepDiveSlugs[m.name]}`} className="inline-flex items-center gap-1 text-white/50 hover:text-white transition-colors" aria-label={`Read the ${m.name} deep dive`}>
+                          Deep dive <ArrowUpRight className="w-3 h-3" aria-hidden="true" />
+                        </Link>
+                      )}
+                      {hubSlugs[m.name] && (
+                        <Link href={`/llm-hub/${hubSlugs[m.name]}`} className="inline-flex items-center gap-1 text-white/40 hover:text-white/70 transition-colors" aria-label={`${m.name} on the LLM Hub`}>
+                          Specs &amp; verdict <ArrowUpRight className="w-3 h-3" aria-hidden="true" />
+                        </Link>
+                      )}
+                    </div>
+                  )}
                 </motion.div>
               ))}
             </div>

--- a/app/llm-hub/[slug]/page.tsx
+++ b/app/llm-hub/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { ArrowLeft, ArrowRight, ExternalLink, Zap } from 'lucide-react'
+import { ArrowLeft, ArrowRight, BookOpen, ExternalLink, Zap } from 'lucide-react'
 
 import {
   formatContext,
@@ -13,7 +13,9 @@ import {
 } from '@/lib/llm-hub/registry'
 import { getEditorial } from '@/lib/llm-hub/editorial'
 import { comparisonsForModel } from '@/lib/llm-hub/comparisons'
+import { articleForModel } from '@/lib/llm-hub/articles'
 import { fetchLivePricing } from '@/lib/llm-hub/openrouter'
+import { ldJson } from '@/lib/seo/jsonld'
 import { CapabilityBadge } from '@/components/llm-hub/CapabilityBadge'
 
 export const revalidate = 3600
@@ -74,6 +76,7 @@ export default async function ModelPage({ params }: { params: Promise<{ slug: st
   const outputPrice = live?.outputPer1m ?? (typeof model.pricing?.output_per_1m === 'number' ? model.pricing.output_per_1m : null)
 
   const comparisons = comparisonsForModel(slug)
+  const articleSlug = articleForModel(model.id)
   const platforms = (org?.agentic_platforms || [])
     .map((id) => getPlatform(id))
     .filter(Boolean)
@@ -121,8 +124,8 @@ export default async function ModelPage({ params }: { params: Promise<{ slug: st
 
   return (
     <div className="min-h-screen bg-[#0a0a0b] text-white">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(ld) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(breadcrumb) }} />
 
       <main className="relative z-10 mx-auto max-w-4xl px-6 py-10">
         <nav className="mb-8">
@@ -148,6 +151,16 @@ export default async function ModelPage({ params }: { params: Promise<{ slug: st
           </div>
           <h1 className="mb-3 text-4xl font-bold md:text-5xl">{model.name}</h1>
           {ed?.tagline ? <p className="max-w-2xl text-lg text-white/60">{ed.tagline}</p> : null}
+          {articleSlug ? (
+            <Link
+              href={`/blog/${articleSlug}`}
+              className="mt-4 inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+              style={{ borderColor: `${accent}55`, color: accent, backgroundColor: `${accent}14` }}
+            >
+              <BookOpen className="h-4 w-4" aria-hidden="true" /> Read the full {model.name} analysis
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          ) : null}
           {org?.capability_focus && org.capability_focus.length > 0 ? (
             <div className="mt-4 flex flex-wrap gap-1.5">
               {org.capability_focus.map((c) => (

--- a/app/llm-hub/compare/[slug]/page.tsx
+++ b/app/llm-hub/compare/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { COMPARISONS, getComparison } from '@/lib/llm-hub/comparisons'
 import { formatContext, getModel, getProviders, type ModelEntry, type OrganizationEntry } from '@/lib/llm-hub/registry'
 import { getEditorial } from '@/lib/llm-hub/editorial'
 import { fetchLivePricing, type LivePricingMap } from '@/lib/llm-hub/openrouter'
+import { ldJson } from '@/lib/seo/jsonld'
 
 export const revalidate = 3600
 
@@ -103,8 +104,8 @@ export default async function ComparePage({ params }: { params: Promise<{ slug: 
 
   return (
     <div className="min-h-screen bg-[#0a0a0b] text-white">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(faqLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(breadcrumb) }} />
 
       <main className="relative z-10 mx-auto max-w-4xl px-6 py-10">
         <nav className="mb-8">

--- a/app/llm-hub/page.tsx
+++ b/app/llm-hub/page.tsx
@@ -9,6 +9,7 @@ import { CreatorStackCard } from '@/components/llm-hub/CreatorStackCard'
 import { getAllPlatforms, getProviders } from '@/lib/llm-hub/registry'
 import { buildModelRows } from '@/lib/llm-hub/rows'
 import { fetchLivePricing } from '@/lib/llm-hub/openrouter'
+import { ldJson } from '@/lib/seo/jsonld'
 import { CREATOR_STACKS } from '@/lib/llm-hub/creator-stacks'
 
 export const revalidate = 3600
@@ -95,9 +96,9 @@ export default async function LlmHubPage() {
 
   return (
     <div className="min-h-screen bg-[#0a0a0b] text-white">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(itemListJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(faqJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(breadcrumbJsonLd) }} />
 
       <div className="pointer-events-none fixed inset-0 overflow-hidden">
         <div className="absolute inset-0 bg-[#0a0a0b]" />

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,6 +4,8 @@ import path from 'path'
 import matter from 'gray-matter'
 import { researchDomains } from '@/lib/research/domains'
 import { listPartners } from '@/content/partnerships'
+import { getAllModels } from '@/lib/llm-hub/registry'
+import { COMPARISONS } from '@/lib/llm-hub/comparisons'
 // Pre-baked at build time by scripts/build-route-index.mjs (which uses
 // lib/route-enumeration.mjs). Importing the JSON keeps the sitemap lambda
 // small — calling enumerateRoutes() at request time forces Turbopack to
@@ -599,6 +601,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${BASE_URL}/guides/${slug}`,
       lastModified: currentDate,
       changeFrequency: 'monthly',
+      priority: 0.7,
+    })
+  })
+
+  // LLM Hub — per-model pages (dynamic, keyed by registry slug)
+  getAllModels().forEach((m) => {
+    entries.push({
+      url: `${BASE_URL}/llm-hub/${m.id}`,
+      lastModified: currentDate,
+      changeFrequency: 'weekly',
+      priority: 0.75,
+    })
+  })
+
+  // LLM Hub — head-to-head comparison pages (dynamic)
+  COMPARISONS.forEach((c) => {
+    entries.push({
+      url: `${BASE_URL}/llm-hub/compare/${c.slug}`,
+      lastModified: currentDate,
+      changeFrequency: 'weekly',
       priority: 0.7,
     })
   })

--- a/content/blog/faceless-youtube-ai-tools-2026.mdx
+++ b/content/blog/faceless-youtube-ai-tools-2026.mdx
@@ -113,7 +113,7 @@ This is the multiplier. One long upload becomes 5–10 vertical clips for Shorts
 
 Three configurations, all verified at June-2026 prices. Pick the row that matches your stage.
 
-| Station | Lean ($0–5) | Recommended (<$60) | Tool |
+| Station | Lean ($0–5) | Recommended (under $60) | Tool |
 |---|---|---|---|
 | Script | Free | $0 (Claude free) | Claude / ChatGPT |
 | Voice | $5 | $5 | ElevenLabs Starter |

--- a/lib/llm-hub/articles.ts
+++ b/lib/llm-hub/articles.ts
@@ -1,0 +1,27 @@
+/**
+ * Maps a registry model key to its FrankX deep-dive analysis article slug
+ * (under /blog/[slug]). Single source of truth for model ↔ article interlinking,
+ * consumed by the LLM Hub model pages and the sitemap.
+ *
+ * Keyed by registry KEY (the canonical id after normaliseModel), so callers pass
+ * the same identifier used for /llm-hub/[slug] routing.
+ */
+export const MODEL_ARTICLES: Record<string, string> = {
+  'claude-opus-4-8': 'claude-opus-4-8-analysis-2026',
+  'gpt-5-5': 'gpt-5-5-analysis-2026',
+  'gemini-3-5-pro': 'gemini-3-5-pro-analysis-2026',
+  'grok-4-3': 'grok-4-3-analysis-2026',
+  'deepseek-v4': 'deepseek-v4-analysis-2026',
+  'qwen3-7-max': 'qwen3-max-analysis-2026',
+  'kimi-k2-6': 'kimi-k2-analysis-2026',
+  'gemma-4': 'gemma-3-analysis-2026',
+  'llama-4-maverick': 'llama-4-analysis-2026',
+  'mistral-large-3': 'mistral-large-3-analysis-2026',
+  'gpt-oss': 'gpt-oss-analysis-2026',
+  'phi-4': 'phi-analysis-2026',
+}
+
+/** Returns the deep-dive article slug for a model key, if one exists. */
+export function articleForModel(key?: string): string | undefined {
+  return key ? MODEL_ARTICLES[key] : undefined
+}

--- a/lib/llm-hub/articles.ts
+++ b/lib/llm-hub/articles.ts
@@ -19,6 +19,10 @@ export const MODEL_ARTICLES: Record<string, string> = {
   'mistral-large-3': 'mistral-large-3-analysis-2026',
   'gpt-oss': 'gpt-oss-analysis-2026',
   'phi-4': 'phi-analysis-2026',
+  // Microsoft MAI models share the in-house-family deep-dive.
+  'mai-thinking-1': 'microsoft-mai-frontier-models-2026',
+  'mai-image-2-5': 'microsoft-mai-frontier-models-2026',
+  'mai-code-1-flash': 'microsoft-mai-frontier-models-2026',
 }
 
 /** Returns the deep-dive article slug for a model key, if one exists. */

--- a/lib/seo/jsonld.ts
+++ b/lib/seo/jsonld.ts
@@ -6,12 +6,25 @@
  * (a stored-XSS vector if data ever includes attacker-influenced text). Escaping
  * `<`, `>`, `&`, and the JS line separators to their \uXXXX forms keeps the JSON
  * semantically identical while making it impossible to close the script tag.
+ *
+ * Single-pass replacement; returns "" if the value cannot be serialized so a
+ * malformed payload yields an empty (harmless) script rather than crashing render.
  */
+const ESCAPE_MAP: Record<string, string> = {
+  "<": "\\u003c",
+  ">": "\\u003e",
+  "&": "\\u0026",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+}
+
 export function ldJson(data: unknown): string {
-  return JSON.stringify(data)
-    .replace(/</g, "\\u003c")
-    .replace(/>/g, "\\u003e")
-    .replace(/&/g, "\\u0026")
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029")
+  try {
+    const json = JSON.stringify(data)
+    if (typeof json !== "string") return ""
+    return json.replace(/[<>&\u2028\u2029]/g, (m) => ESCAPE_MAP[m] ?? m)
+  } catch (error) {
+    console.error("[ldJson] Serialization failed:", error)
+    return ""
+  }
 }

--- a/lib/seo/jsonld.ts
+++ b/lib/seo/jsonld.ts
@@ -1,0 +1,17 @@
+/**
+ * Safe JSON-LD serialization for inline <script type="application/ld+json">.
+ *
+ * JSON.stringify alone is unsafe inside a <script> element: a literal "</script>"
+ * (or U+2028/U+2029) inside any string value can break out of the script context
+ * (a stored-XSS vector if data ever includes attacker-influenced text). Escaping
+ * `<`, `>`, `&`, and the JS line separators to their \uXXXX forms keeps the JSON
+ * semantically identical while making it impossible to close the script tag.
+ */
+export function ldJson(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+}


### PR DESCRIPTION
## What & why

A polish pass over the June 2026 model surface (#155–#158) for interlinking, SEO completeness, and security — the "everything connected and top-notch" follow-through.

## Interlinking — the connected graph
- **New single source of truth** `lib/llm-hub/articles.ts` maps each model key → its deep-dive article slug.
- **Hub model pages → deep-dives**: each `/llm-hub/[model]` now renders a prominent "Read the full **<model>** analysis" CTA.
- **Arena → both**: every frontier card gains **Deep dive** (→ article) and **Specs & verdict** (→ `/llm-hub/[key]`) links; the hero gains an **Explore the LLM Hub** CTA. (The Open & Local cards already deep-link.)
- Result: arena ↔ articles ↔ hub are now mutually reachable. All link targets validated against real blog slugs and registry keys.

## SEO completeness
- `sitemap.ts` now enumerates **all 24 per-model hub pages** (`/llm-hub/[key]`) and **all head-to-head comparison pages** (`/llm-hub/compare/[slug]`) — previously only the two static hub index URLs were listed.

## Security hardening (defense-in-depth)
- New `lib/seo/jsonld.ts` `ldJson()` escapes `<`, `>`, `&`, and U+2028/U+2029 so inline JSON-LD can't break out of its `<script>` (a stored-XSS vector if model/editorial data ever contained `</script>`). Applied to **all 7 JSON-LD blocks** across the hub model, hub index, and compare pages. Unit-tested: `</script>` and angle brackets are neutralized.

## Verification
- Full-project `tsc --noEmit` clean · `eslint` clean on all touched files.
- Audit scripts confirm: every internal blog link, every frontmatter hero image, all registry org/routing refs, and the **three new interlink maps** resolve to real targets.
- `route-index` builds. (Local `next build` is blocked only by the sandbox Google-Fonts firewall — unrelated to these changes; Vercel builds authoritatively.)

No URL renames or deletions; no factual registry data touched.

https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvZ6pHNJ537n6kyDcbSWum)_