### PR TITLE
ci(resilience): fail-fast MDX build-safety guard (prevents the &lt;$60 prerender outage class)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "music:index": "node scripts/generate-music-index.mjs",
     "music:asset-registry": "node scripts/music/build-asset-registry.mjs",
     "sync-ais": "node scripts/sync-ais.mjs",
-    "prebuild": "npm run sync-ais && node scripts/prebuild-cache.mjs && node scripts/build-route-index.mjs",
+    "prebuild": "npm run sync-ais && node scripts/check-mdx-safety.mjs && node scripts/prebuild-cache.mjs && node scripts/build-route-index.mjs",
     "routes:build": "node scripts/build-route-index.mjs",
     "prebuild:force": "npm run gen:html && npm run gen:search && npm run content:index && npm run vault:scan && npm run heroes:scan",
     "roadmap:check": "node scripts/daily-roadmap-check.js",
@@ -87,7 +87,8 @@
     "sync:fix": "bash scripts/pre-deploy-sync-check.sh --sync",
     "sync:diff": "bash scripts/pre-deploy-sync-check.sh --diff",
     "predeploy": "npm run merge:gate && npm run sync:check",
-    "observatory:catalog": "node scripts/sync-observatory-catalog.mjs"
+    "observatory:catalog": "node scripts/sync-observatory-catalog.mjs",
+    "check:mdx": "node scripts/check-mdx-safety.mjs"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/scripts/check-mdx-safety.mjs
+++ b/scripts/check-mdx-safety.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * MDX build-safety guard.
+ *
+ * Catches the class of content bug that silently broke production for days:
+ * a `<` immediately followed by a digit or `$` in MDX prose/tables (e.g.
+ * `Recommended (<$60)`), which the MDX compiler parses as the start of a JSX
+ * tag and then fails to prerender ("Unexpected character ... in name").
+ *
+ * This runs in `prebuild`, so it fails in ~1s with a precise file:line BEFORE
+ * the expensive `next build` prerender, instead of a cryptic error 1,300 pages in.
+ *
+ * Precision over recall: we only flag the proven-breaking pattern `<[0-9$]`
+ * OUTSIDE fenced code blocks (``` / ~~~), inline code spans (`...`), and
+ * frontmatter. Code samples that legitimately contain `<500 lines` or `< 2.5s`
+ * are not flagged.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+// Only scan content directories that are COMPILED TO PAGES (MDX/JSX prerender).
+// Internal docs (content/strategy, content/newsletters, …) are never compiled,
+// so a `<` there can't break the build and must not fail CI.
+// Render roots confirmed via lib/blog.ts, lib/guides.ts, app/sitemap.ts.
+const RENDERED_DIRS = ['content/blog', 'content/guides'];
+
+const { readdirSync, statSync, existsSync } = await import('node:fs');
+let files = [];
+const walk = (dir) => {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    const s = statSync(p);
+    if (s.isDirectory()) walk(p);
+    else if (/\.(mdx|md)$/.test(e)) files.push(p);
+  }
+};
+for (const rel of RENDERED_DIRS) {
+  const abs = join(ROOT, rel);
+  if (existsSync(abs)) walk(abs);
+}
+
+const DANGER = /<[0-9$]/; // `<` directly followed by a digit or `$` — breaks MDX/JSX parsing
+const violations = [];
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const lines = text.split('\n');
+  let inFence = false;
+  let inFrontmatter = false;
+  let frontmatterDone = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    // YAML frontmatter (leading --- ... ---)
+    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
+    if (inFrontmatter) { if (line.trim() === '---') { inFrontmatter = false; frontmatterDone = true; } continue; }
+
+    // Fenced code blocks
+    if (/^\s*(```|~~~)/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+
+    // Strip inline code spans so `<$60` inside `...` is ignored
+    const stripped = line.replace(/`[^`]*`/g, '');
+
+    if (DANGER.test(stripped)) {
+      const col = stripped.search(DANGER) + 1;
+      violations.push({ file: file.replace(ROOT + '/', ''), line: i + 1, col, text: line.trim().slice(0, 120) });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('\n[31m✗ MDX build-safety check failed[0m — these will break `next build` prerender:\n');
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}:${v.col}`);
+    console.error(`    ${v.text}`);
+    console.error(`    → "<" directly followed by a digit/$ is parsed as a JSX tag. Reword (e.g. "(<$60)" → "(under $60)") or wrap in \`backticks\`.\n`);
+  }
+  console.error(`${violations.length} issue(s) found across ${files.length} content file(s). Fix before build.\n`);
+  process.exit(1);
+}
+
+console.log(`✓ MDX build-safety check passed (${files.length} content files, no unsafe '<' in prose/tables).`);

--- a/scripts/check-mdx-safety.mjs
+++ b/scripts/check-mdx-safety.mjs
@@ -15,7 +15,7 @@
  * frontmatter. Code samples that legitimately contain `<500 lines` or `< 2.5s`
  * are not flagged.
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = process.cwd();
@@ -26,8 +26,7 @@ const ROOT = process.cwd();
 // Render roots confirmed via lib/blog.ts, lib/guides.ts, app/sitemap.ts.
 const RENDERED_DIRS = ['content/blog', 'content/guides'];
 
-const { readdirSync, statSync, existsSync } = await import('node:fs');
-let files = [];
+const files = [];
 const walk = (dir) => {
   for (const e of readdirSync(dir)) {
     const p = join(dir, e);
@@ -49,14 +48,13 @@ for (const file of files) {
   const lines = text.split('\n');
   let inFence = false;
   let inFrontmatter = false;
-  let frontmatterDone = false;
 
   for (let i = 0; i < lines.length; i++) {
-    let line = lines[i];
+    const line = lines[i];
 
     // YAML frontmatter (leading --- ... ---)
     if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
-    if (inFrontmatter) { if (line.trim() === '---') { inFrontmatter = false; frontmatterDone = true; } continue; }
+    if (inFrontmatter) { if (line.trim() === '---') inFrontmatter = false; continue; }
 
     // Fenced code blocks
     if (/^\s*(```|~~~)/.test(line)) { inFence = !inFence; continue; }
@@ -73,14 +71,14 @@ for (const file of files) {
 }
 
 if (violations.length > 0) {
-  console.error('\n[31m✗ MDX build-safety check failed[0m — these will break `next build` prerender:\n');
+  console.error('\nMDX build-safety check FAILED — these will break `next build` prerender:\n');
   for (const v of violations) {
     console.error(`  ${v.file}:${v.line}:${v.col}`);
     console.error(`    ${v.text}`);
-    console.error(`    → "<" directly followed by a digit/$ is parsed as a JSX tag. Reword (e.g. "(<$60)" → "(under $60)") or wrap in \`backticks\`.\n`);
+    console.error(`    -> "<" directly followed by a digit/$ is parsed as a JSX tag. Reword (e.g. "(<$60)" -> "(under $60)") or wrap in \`backticks\`.\n`);
   }
   console.error(`${violations.length} issue(s) found across ${files.length} content file(s). Fix before build.\n`);
   process.exit(1);
 }
 
-console.log(`✓ MDX build-safety check passed (${files.length} content files, no unsafe '<' in prose/tables).`);
+console.log(`MDX build-safety check passed (${files.length} content files, no unsafe '<' in prose/tables).`);


### PR DESCRIPTION
## Why
A `<` directly followed by a digit/`$` in MDX prose (e.g. `Recommended (<$60)` in a table) is parsed as a JSX tag and **fails `next build` prerender** — this silently broke production for days (fixed in #160). There was no fast guard; the only gate was the full build, which fails late and cryptically.

## What
- **`scripts/check-mdx-safety.mjs`** — fence/inline-code/frontmatter-aware scanner. Flags only the proven-breaking pattern `<[0-9$]` outside code, so it can't false-fail on code samples (`<500 lines`, `< 2.5s`).
- Wired into **`prebuild`** (runs before `next build` locally + on Vercel + in CI Build) → fails in ~1s with a precise `file:line` and a fix hint, instead of an error 1,300 pages into prerender. Also added `npm run check:mdx`.
- **Scoped to dirs compiled to pages** (`content/blog`, `content/guides` per `lib/blog.ts`/`lib/guides.ts`/`sitemap.ts`), so internal docs (`content/strategy`, …) never fail a build.

## Verification
- Passes clean on current `main` (212 rendered content files).
- Confirmed it catches a reintroduced `(<$60)` with exact line/col, and correctly ignores the same pattern inside ``` fences and `inline code`.

CTO/resilience item from today's audit. Net-new script + 2 lines in package.json — no app/runtime changes.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_