### PR TITLE
security: remove hardcoded admin secret + lock down open write endpoints

### DIFF
--- a/app/api/admin/upload/route.ts
+++ b/app/api/admin/upload/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { put } from '@vercel/blob'
+import { requireAdmin } from '@/lib/admin-auth'
 
 /**
  * Admin Upload API
@@ -9,18 +10,13 @@ import { put } from '@vercel/blob'
  *   - file: the file to upload
  *   - path: blob storage path (e.g., "products/soulbook/soulbook-7-pillars.pdf")
  *
- * Protected by ADMIN_SECRET header check.
+ * Protected by ADMIN_SECRET header check (fail-closed; no hardcoded fallback).
  * Only works in production (needs BLOB_READ_WRITE_TOKEN).
  */
 
-const ADMIN_SECRET = process.env.ADMIN_SECRET ?? 'frankx-admin-2026'
-
 export async function POST(request: NextRequest) {
-  // Simple auth check
-  const authHeader = request.headers.get('x-admin-secret')
-  if (authHeader !== ADMIN_SECRET) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const denied = requireAdmin(request)
+  if (denied) return denied
 
   const formData = await request.formData()
   const file = formData.get('file') as File | null

--- a/app/api/admin/verify/route.ts
+++ b/app/api/admin/verify/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { getAdminSecret } from '@/lib/admin-auth'
+import { getAdminSecret, safeEqual } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
 
     // The admin supplied this password; returning it as the session token is the
     // existing contract (command-center stores it and replays it as x-admin-secret).
-    if (typeof password === 'string' && password === secret) {
+    if (typeof password === 'string' && safeEqual(password, secret)) {
       return NextResponse.json({ success: true, token: secret })
     }
 

--- a/app/api/admin/verify/route.ts
+++ b/app/api/admin/verify/route.ts
@@ -1,13 +1,22 @@
 import { type NextRequest, NextResponse } from 'next/server'
-
-const ADMIN_SECRET = process.env.ADMIN_SECRET ?? 'frankx-admin-2026'
+import { getAdminSecret } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
   try {
+    const secret = getAdminSecret()
+    if (!secret) {
+      return NextResponse.json(
+        { error: 'Admin access is not configured (ADMIN_SECRET unset).' },
+        { status: 503 }
+      )
+    }
+
     const { password } = await request.json()
 
-    if (password === ADMIN_SECRET) {
-      return NextResponse.json({ success: true, token: ADMIN_SECRET })
+    // The admin supplied this password; returning it as the session token is the
+    // existing contract (command-center stores it and replays it as x-admin-secret).
+    if (typeof password === 'string' && password === secret) {
+      return NextResponse.json({ success: true, token: secret })
     }
 
     return NextResponse.json({ error: 'Invalid password' }, { status: 401 })

--- a/app/api/content-studio/trigger/route.ts
+++ b/app/api/content-studio/trigger/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
+import { requireAdmin } from '@/lib/admin-auth';
 
 const QUEUE_DIR = join(process.cwd(), 'data', 'content-queue');
 const QUEUE_FILE = join(QUEUE_DIR, 'queue.json');
@@ -36,14 +37,33 @@ function saveQueue(queue: ContentQueue) {
 
 export async function POST(request: NextRequest) {
   try {
+    // Auth: this enqueues tasks an automated watcher later executes, so it must
+    // not be open to anonymous callers (prompt-injection / queue-poisoning risk).
+    const denied = requireAdmin(request);
+    if (denied) return denied;
+
     const body = await request.json();
     const { action, params = {} } = body;
 
-    if (!action) {
-      return NextResponse.json({ error: 'Action required' }, { status: 400 });
+    // Validate action: short, safe identifier only.
+    if (typeof action !== 'string' || !/^[a-z0-9:_-]{1,64}$/i.test(action)) {
+      return NextResponse.json({ error: 'Invalid or missing action' }, { status: 400 });
+    }
+
+    // Validate params: plain object, bounded size (no unbounded payloads).
+    if (params === null || typeof params !== 'object' || Array.isArray(params)) {
+      return NextResponse.json({ error: 'params must be an object' }, { status: 400 });
+    }
+    if (JSON.stringify(params).length > 4000) {
+      return NextResponse.json({ error: 'params too large' }, { status: 413 });
     }
 
     const queue = loadQueue();
+
+    // Cap queue growth to prevent unbounded disk/queue flooding.
+    if (queue.pending.length >= 500) {
+      return NextResponse.json({ error: 'Queue is full; try again later' }, { status: 429 });
+    }
 
     // Create new task
     const task: QueueTask = {

--- a/app/api/content-studio/trigger/route.ts
+++ b/app/api/content-studio/trigger/route.ts
@@ -42,7 +42,11 @@ export async function POST(request: NextRequest) {
     const denied = requireAdmin(request);
     if (denied) return denied;
 
-    const body = await request.json();
+    // Safe parse: bad/empty/non-object bodies return 400, not a 500.
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: 'Invalid JSON or request body' }, { status: 400 });
+    }
     const { action, params = {} } = body;
 
     // Validate action: short, safe identifier only.
@@ -50,9 +54,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid or missing action' }, { status: 400 });
     }
 
-    // Validate params: plain object, bounded size (no unbounded payloads).
+    // Validate params: plain object of string values (matches QueueTask), bounded size.
     if (params === null || typeof params !== 'object' || Array.isArray(params)) {
       return NextResponse.json({ error: 'params must be an object' }, { status: 400 });
+    }
+    for (const value of Object.values(params)) {
+      if (typeof value !== 'string') {
+        return NextResponse.json({ error: 'params values must be strings' }, { status: 400 });
+      }
     }
     if (JSON.stringify(params).length > 4000) {
       return NextResponse.json({ error: 'params too large' }, { status: 413 });

--- a/app/api/download/file/route.ts
+++ b/app/api/download/file/route.ts
@@ -20,7 +20,13 @@ export async function GET(request: NextRequest) {
     )
   }
 
+  // Validate the key: only safe blob-path characters, and no traversal or
+  // protocol/host injection (prevents redirecting to arbitrary URLs).
+  if (!/^[a-zA-Z0-9._/-]+$/.test(blobKey) || blobKey.includes('..')) {
+    return NextResponse.json({ error: 'Invalid file key' }, { status: 400 })
+  }
+
   // Redirect directly to your public blob storage
-  const blobUrl = `${BLOB_BASE_URL}/${blobKey}`
+  const blobUrl = `${BLOB_BASE_URL}/${blobKey.replace(/^\/+/, '')}`
   return NextResponse.redirect(blobUrl)
 }

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,36 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Shared admin auth for protected API routes.
+ *
+ * Fail-closed: the admin secret comes ONLY from `process.env.ADMIN_SECRET`.
+ * There is intentionally NO hardcoded fallback — if the env var is unset, every
+ * admin request is rejected (503) rather than falling back to a public,
+ * committed password.
+ */
+export function getAdminSecret(): string | null {
+  const secret = process.env.ADMIN_SECRET
+  return secret && secret.length > 0 ? secret : null
+}
+
+/**
+ * Returns a NextResponse to short-circuit with when the request is NOT
+ * authorized, or `null` when it is. Usage:
+ *
+ *   const denied = requireAdmin(request)
+ *   if (denied) return denied
+ */
+export function requireAdmin(request: NextRequest): NextResponse | null {
+  const secret = getAdminSecret()
+  if (!secret) {
+    return NextResponse.json(
+      { error: 'Admin access is not configured (ADMIN_SECRET unset).' },
+      { status: 503 }
+    )
+  }
+  const provided = request.headers.get('x-admin-secret')
+  if (!provided || provided !== secret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return null
+}

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import { timingSafeEqual } from 'crypto'
 
 /**
  * Shared admin auth for protected API routes.
@@ -11,6 +12,14 @@ import { type NextRequest, NextResponse } from 'next/server'
 export function getAdminSecret(): string | null {
   const secret = process.env.ADMIN_SECRET
   return secret && secret.length > 0 ? secret : null
+}
+
+/** Constant-time string comparison (avoids leaking the secret via timing). */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  if (ab.length !== bb.length) return false
+  return timingSafeEqual(ab, bb)
 }
 
 /**
@@ -29,7 +38,7 @@ export function requireAdmin(request: NextRequest): NextResponse | null {
     )
   }
   const provided = request.headers.get('x-admin-secret')
-  if (!provided || provided !== secret) {
+  if (!provided || !safeEqual(provided, secret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   return null


### PR DESCRIPTION
## Security hardening (from today's CTO audit)

### Fixed here
- **P0 — hardcoded admin password.** `/api/admin/upload` and `/api/admin/verify` used `process.env.ADMIN_SECRET ?? 'frankx-admin-2026'` — if the env var is ever unset, the committed password gates a working Vercel-Blob upload endpoint. New **`lib/admin-auth.ts`** is **fail-closed**: secret comes only from `process.env.ADMIN_SECRET`; unset → `503`, never a public fallback. `verify` still returns the token, so the `command-center` login flow is unchanged.
- **P1 — unauthenticated task queue.** `/api/content-studio/trigger` enqueues tasks an automated watcher later executes, with **no auth** (anonymous queue-poisoning / prompt-injection into the pipeline). Added admin auth, `action` whitelist (`^[a-z0-9:_-]{1,64}$`), params size cap (4 KB), and queue-length cap (500). No app caller exists, so locking it down breaks nothing.
- **P2 — `/api/download/file`** redirected `?key=` into a blob URL with no validation (path traversal / arbitrary-redirect). Now validated (safe charset, no `..`).

### ⚠️ Action required by Frank
- Ensure **`ADMIN_SECRET` is set in Vercel** (Production + Preview) — it must already be, for admin to be secure today. **Rotate it**, since the old value (`frankx-admin-2026`) is in git history.

### Deferred (documented, need a follow-up — not done here to avoid breaking flows / scope creep)
- `/api/admin/youtube` POST/DELETE are unauthenticated. Locking them needs `YouTubeAdminClient.tsx` to send the `x-admin-secret` header (client change). Note: writes target ephemeral FS (non-functional on Vercel), so prod exposure is mostly the GET read — still should be closed.
- `/api/byok/chat`: add per-IP rate limit + cap `messages` length/bytes (cost-abuse / open-relay).
- `/api/misinformation/analyze`: SSRF is mostly defended but bypassable via redirect-follow — set `redirect:'manual'` and re-validate each hop.
- `lib/rails/*` render `marked` output via `dangerouslySetInnerHTML` without DOMPurify (safe today — trusted build-time content — but inconsistent with the sanitized BookReader/PromptCard).
- CSP `script-src 'unsafe-eval'` in `next.config.mjs` — evaluate removing.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_