### PR TITLE
fix(accuracy): Llama 4 Maverick needs 8×H100, not a single H100 (tracker card)

### DIFF
--- a/app/ai-ops/models-2026/page.tsx
+++ b/app/ai-ops/models-2026/page.tsx
@@ -183,7 +183,7 @@ const frontierModels = [
     links: {
       docs: 'https://llama.meta.com/',
     },
-    notes: 'Open-weight. 400B total, 17B active per token. Runs on a single H100. Self-host / fine-tune base.',
+    notes: 'Open-weight. 400B total, 17B active per token. Needs an 8×H100 node (the Scout sibling self-hosts on one H100). Self-host / fine-tune base.',
   },
   {
     name: 'MAI-Thinking-1',


### PR DESCRIPTION
## What
Corrects a factual error on the frontier-models tracker card for **Llama 4 Maverick** (`app/ai-ops/models-2026/page.tsx:186`):

> "Open-weight. 400B total, 17B active per token. ~~Runs on a single H100.~~ Self-host / fine-tune base."
→ "…**Needs an 8×H100 node (the Scout sibling self-hosts on one H100).**…"

## Why
Maverick (400B total / 17B active, ~600 GB in FP8) needs an 8×H100 node; **Scout** (109B/17B) is the single-H100 model. The claim also **contradicted the same page** (line 274: `8×H100 (Maverick) · 1×H100 (Scout)`) and `data/model-registry.json`. Second instance of the same H100 error class (the MoE-section copy was fixed in #161) — surfaced by the content-accuracy audit. Copy-only, one line.

https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmSdvkq2xghcJAaHrQwJ9R)_