### PR TITLE
fix(claims+voice): #107 standard on lab/build pages + voice router + audit refresh

### DIFF
--- a/.claude-skills/VOICE_ROUTER.md
+++ b/.claude-skills/VOICE_ROUTER.md
@@ -36,8 +36,8 @@ when the audience is explicitly creators/musicians/spiritual-growth readers.
 - Numbers must be verifiable from a public repo or analytics: `90+ open-source
   AI skills`, `12,000+ Suno tracks`. No invented or rounded-up stats.
 - "Tested in production" only for things that ran in production. For lab
-  artifacts still maturing, say "drawn from live builds" or "refined as each
-  build ships."
+  artifacts still maturing, say "drawn from live builds" or "iterated as each
+  build progresses."
 - Builds with `status: wip` are described as in progress — no implied shipped
   outcomes.
 

--- a/.claude-skills/VOICE_ROUTER.md
+++ b/.claude-skills/VOICE_ROUTER.md
@@ -1,0 +1,49 @@
+# Voice Router — which register for which surface
+
+Two voice systems coexist in this codebase and they conflict. This file is the
+tiebreaker. Check it before writing copy for any page, skill output, or campaign.
+
+## The two registers
+
+| Register | Source of truth | Sound |
+|---|---|---|
+| **Technical authority** | `CLAUDE.md` → Voice Guidelines | Results first. Precise, understated, zero spiritual language, no exclamation marks. Reads like a strong PR description. |
+| **Studio / creator** | `.claude-skills/creative/frankx-brand/SKILL.md` | Cinematic, intimate, studio-session metaphors, soul + systems framing. |
+
+Both are intentional. Neither is "the real one." They serve different audiences.
+
+## Routing table
+
+| Surface | Register | Why |
+|---|---|---|
+| `/agentic-builder-lab`, `/agentic-builder-lab/[slug]` | **Technical authority** | Audience is builders/architects scanning for proof. Voice override formalized in `.claude-skills/projects/agentic-builder-lab/resources/voice-spec.md` (banned-words lint included). |
+| `/build`, `/build/template-pack` | **Technical authority** | B2B commercial surface. Claims must be receipt-backed (see Claims rules below). |
+| `/ai-architecture`, `/ai-coe`, `/agentic-ai-center`, `/developers`, `/llm-hub` | **Technical authority** | Enterprise/architect audience. |
+| Blog posts tagged `agentic-builder`, `architecture`, `engineering` | **Technical authority** | Continuation of the lab voice. |
+| `/music`, `/music-lab`, `/products/vibe-os`, Suno content | **Studio / creator** | Creator audience; studio metaphors are literal here, not decoration. |
+| `/soulbook`, lifebook skills, Arcanea | **Studio / creator** | The product *is* the soul + systems framing. |
+| `/gencreator`, creator-economy content | **Studio / creator**, hype-trimmed | Creator-first but grounded per CLAUDE.md "show don't tell." |
+| Newsletters | Match the stream: `agentic-builder-lab` list → technical; `music-lab`/`creation-chronicles` → studio. |
+| Homepage, `/about`, `/bio` | **Technical authority** with warmth | The front door defaults to the more conservative register. |
+
+**Default when unlisted:** technical authority. Escalate to studio register only
+when the audience is explicitly creators/musicians/spiritual-growth readers.
+
+## Claims rules (apply to BOTH registers — from PR #107's launch hardening)
+
+- Oracle: always past tense — `Ex-Oracle`, `Former AI Architect, Oracle`. Never
+  "at Oracle," never "built at Oracle" as product provenance.
+- Numbers must be verifiable from a public repo or analytics: `90+ open-source
+  AI skills`, `12,000+ Suno tracks`. No invented or rounded-up stats.
+- "Tested in production" only for things that ran in production. For lab
+  artifacts still maturing, say "drawn from live builds" or "refined as each
+  build ships."
+- Builds with `status: wip` are described as in progress — no implied shipped
+  outcomes.
+
+## When skills collide
+
+A skill's own `voice_override` (e.g. `agentic-builder-lab`) beats `frankx-brand`
+for that skill's outputs. If no override exists, this routing table decides by
+surface. If the surface is genuinely ambiguous, technical authority wins —
+it's cheaper to add warmth later than to retract hype.

--- a/BRANCH_AUDIT.md
+++ b/BRANCH_AUDIT.md
@@ -1,8 +1,37 @@
 # Branch Audit — frankx.ai-vercel-website
 
-**As of:** 2026-06-01
+**As of:** 2026-06-01 · **Updated:** 2026-06-10 (see Status update below)
 **Auditor:** Claude Code session ([claude.ai/code](https://claude.ai/code))
 **Purpose:** Inventory every non-`main` branch so deletions are zero-risk — the ideas live here.
+
+## Status update — 2026-06-10
+
+What changed since the original audit:
+
+- **Cleanup executed.** The 3 `SAFE_DELETE` branches were deleted via the
+  `branch-cleanup.yml` workflow (run logs confirm). The `KEEP_WIP` and
+  `KEEP_BACKUP` branches were renamed by Frank to the `archive/*` prefix —
+  same refs, clearer intent. Branch names below refer to their pre-archive
+  names; prepend `archive/` (with `/`→`-` in some cases) to find them now.
+- **Generative Model Hub (`archive/claude-build-llm-research-hub-75ba8`):
+  PARTIALLY SUPERSEDED.** Frank rebuilt `/llm-hub` on `main` from scratch
+  (registry, editorial, comparison pages, Model Arena research domain). The
+  archive branch's remaining unique idea is the **multimodal `/models` layer**
+  (image/video/audio/voice/embedding/world categories — 6 route trees). If a
+  multimodal decision layer is wanted, mine the archive for IA and data-shape
+  ideas rather than reviving the diff — `main` has moved too far for a clean
+  rebase.
+- **Newsletter DOI infra (`archive/feat-newsletter-launch-v1`): REVIVED.**
+  Being cherry-picked onto current `main` as a draft PR. Urgency upgraded:
+  the live `email-signup.tsx` success message now says "Check your inbox to
+  confirm" while no confirm route exists on `main` — the site promises a
+  double-opt-in flow it doesn't have. DOI + one-click unsubscribe are also
+  the legally conservative posture for EU sending.
+- **Multi-agent newsletter system (`archive/multi-agent-newsletter-system-anKSZ`):
+  still unique, still archived.** 6 newsletter agents + `lib/newsletter/` +
+  publish script. Revive when newsletter operations resume; depends on the
+  DOI infra landing first.
+
 
 If a branch is marked `SAFE_DELETE`, every meaningful change it contains is already in `main`. If marked `KEEP`, it has unmerged work worth reviving or finishing. `KEEP_BACKUP` is explicit save-points (recovery, staging). Revival is always `git checkout origin/<branch>` (deletion is reversible until GitHub garbage-collects the ref, typically weeks).
 

--- a/app/build/page.tsx
+++ b/app/build/page.tsx
@@ -105,7 +105,7 @@ const offers = [
 
 const trust = [
   { metric: '12,000+', label: 'AI tracks shipped (Suno)' },
-  { metric: 'Oracle', label: 'Enterprise AI background' },
+  { metric: 'Ex-Oracle', label: 'Enterprise AI architecture' },
   { metric: '8', label: 'Builds in public on the lab' },
   { metric: '5', label: 'Agentic tools in active production' },
 ]

--- a/app/build/template-pack/page.tsx
+++ b/app/build/template-pack/page.tsx
@@ -99,7 +99,7 @@ const faqs = [
   },
   {
     q: 'How is it different from a free GitHub gist?',
-    a: 'The pack is the result of shipping 8 production builds with these exact files — every artifact has been used, broken, and refined in real work. The eval harness alone saves a week of scaffolding.',
+    a: 'The pack grows out of the 8 builds running in the public lab — every artifact gets used, broken, and refined as those builds ship, with the failure notes documented. The eval harness alone saves a week of scaffolding.',
   },
   {
     q: 'Refund policy?',
@@ -203,11 +203,11 @@ export default function TemplatePackPage() {
               Inside the pack
             </p>
             <h2 className="mt-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight">
-              Five core artifacts. Each one tested in production.
+              Five core artifacts, drawn from live builds.
             </h2>
             <p className="mt-4 text-base leading-7 text-slate-400">
-              These are the exact files Frank uses on every build in the public lab. They have
-              shipped real product surfaces — not slideware.
+              These are the working files behind the builds in the public lab — refined as each
+              build ships, with the failure notes kept in.
             </p>
           </div>
 

--- a/app/build/template-pack/page.tsx
+++ b/app/build/template-pack/page.tsx
@@ -99,7 +99,7 @@ const faqs = [
   },
   {
     q: 'How is it different from a free GitHub gist?',
-    a: 'The pack grows out of the 8 builds running in the public lab — every artifact gets used, broken, and refined as those builds ship, with the failure notes documented. The eval harness alone saves a week of scaffolding.',
+    a: 'The pack grows out of the 8 builds running in the public lab — every artifact gets used, broken, and refined as those builds progress, with the failure notes documented. The eval harness alone saves a week of scaffolding.',
   },
   {
     q: 'Refund policy?',
@@ -206,8 +206,8 @@ export default function TemplatePackPage() {
               Five core artifacts, drawn from live builds.
             </h2>
             <p className="mt-4 text-base leading-7 text-slate-400">
-              These are the working files behind the builds in the public lab — refined as each
-              build ships, with the failure notes kept in.
+              These are the working files behind the builds in the public lab — iterated as each
+              build progresses, with the failure notes kept in.
             </p>
           </div>
 


### PR DESCRIPTION
## What

Exec-level hardening pass across the Agentic Builder Lab surfaces, applying the standard that merged in #107:

**Claims (legal/brand):**
- `/build` trust strip: `Oracle · Enterprise AI background` → `Ex-Oracle · Enterprise AI architecture` (#107's past-tense employment rule)
- `/build/template-pack`: "Each one tested in production" + "shipped real product surfaces — not slideware" → "drawn from live builds" framing. The pack is early-access and most lab builds are `status: wip`; the old copy claimed shipped outcomes the receipts don't back yet. Same fix in the gist-comparison FAQ.

**Voice governance:**
- New `.claude-skills/VOICE_ROUTER.md` — permanent tiebreaker between the two intentional registers (CLAUDE.md technical authority vs frankx-brand studio voice). Routing table by surface, #107 claims rules codified, precedence: skill `voice_override` > router > frankx-brand, technical authority wins ambiguity. Stops the register conflict recurring on every new page.

**Audit refresh:**
- `BRANCH_AUDIT.md` 2026-06-10 update: cleanup executed (workflow logs confirm), Model Hub **partially superseded** by the rebuilt `/llm-hub` (unique remainder: the multimodal `/models` layer — mine for ideas, don't rebase the 27k-line diff), newsletter DOI revived as draft PR, multi-agent newsletter system still archived pending DOI.

## Note

`/build` prices (€4,500 / €7,500–€25,000) untouched — current main state, your call.

## Verified

Text-only changes; no logic touched. Claims now consistent with the #107-merged sitewide standard.

---
_Generated by [Claude Code](https://claude.ai/code/session_012dr4zpf6FsJygEDzt5a83N)_