### PR TITLE
feat(foundry): FrankX Foundry hub — the service layer of the Agentic OS family

### DIFF
--- a/app/api/foundry/apply/route.ts
+++ b/app/api/foundry/apply/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { appendFile, mkdir } from 'fs/promises'
+import path from 'path'
+import {
+  foundryApplicationReceivedEmail,
+  foundryApplicationNotifyEmail,
+  type FoundryApplicationInput,
+} from '@/lib/email-templates-foundry'
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY
+const AUDIENCE_ID = '4d2e913e-6903-4dd4-8749-c02cdb844331'
+
+const VALID_STAGES = ['idea', 'pre-launch', 'revenue', 'scaling'] as const
+
+/**
+ * Foundry application intake.
+ * Mirrors the 404-log storage pattern: private/ locally (gitignored),
+ * /tmp on Vercel. Applications also land in Frank's inbox via Resend,
+ * so the JSONL is a backstop, not the system of record.
+ */
+function applicationsPath() {
+  const dir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'private')
+  return { dir, file: path.join(dir, 'foundry-applications.jsonl') }
+}
+
+async function sendEmails(input: FoundryApplicationInput) {
+  if (!RESEND_API_KEY) return
+
+  const send = (to: string, subject: string, text: string) =>
+    fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from: 'Frank <frank@mail.frankx.ai>', to, subject, text }),
+    })
+
+  const confirmation = foundryApplicationReceivedEmail(input)
+  const notification = foundryApplicationNotifyEmail(input)
+
+  await Promise.allSettled([
+    send(input.email, confirmation.subject, confirmation.plainText),
+    send('frank@frankx.ai', notification.subject, notification.plainText),
+  ])
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const input: FoundryApplicationInput = {
+      name: String(body.name ?? '').slice(0, 200).trim(),
+      email: String(body.email ?? '').slice(0, 200).trim(),
+      company: String(body.company ?? '').slice(0, 200).trim(),
+      building: String(body.building ?? '').slice(0, 2000).trim(),
+      why: String(body.why ?? '').slice(0, 2000).trim(),
+      stage: String(body.stage ?? '').slice(0, 50).trim(),
+      link: body.link ? String(body.link).slice(0, 500).trim() : undefined,
+    }
+
+    if (!input.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
+      return NextResponse.json({ error: 'Please enter a valid email address' }, { status: 400 })
+    }
+    if (!input.name || !input.company || !input.building || !input.why) {
+      return NextResponse.json(
+        { error: 'Name, company, what you are building, and why it matters are required' },
+        { status: 400 }
+      )
+    }
+    if (!VALID_STAGES.includes(input.stage as (typeof VALID_STAGES)[number])) {
+      return NextResponse.json({ error: 'Please select a stage' }, { status: 400 })
+    }
+
+    // Backstop log (gitignored locally, ephemeral on Vercel)
+    try {
+      const { dir, file } = applicationsPath()
+      await mkdir(dir, { recursive: true })
+      await appendFile(
+        file,
+        JSON.stringify({ ...input, receivedAt: new Date().toISOString() }) + '\n'
+      )
+    } catch (err) {
+      console.error('Foundry application log write failed:', err)
+    }
+
+    // Add to Resend audience so the applicant exists as a contact (idempotent-ish:
+    // a 409 just means they already exist — not an error for an application).
+    if (RESEND_API_KEY) {
+      const res = await fetch(`https://api.resend.com/audiences/${AUDIENCE_ID}/contacts`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: input.email,
+          first_name: input.name || undefined,
+          unsubscribed: false,
+        }),
+      })
+      if (!res.ok && res.status !== 409) {
+        console.error('Resend contact creation failed for foundry application:', await res.text())
+      }
+    } else {
+      console.error('RESEND_API_KEY not configured — foundry application stored to log only')
+    }
+
+    // Confirmation + internal notification (non-blocking for the response)
+    sendEmails(input).catch((err) => console.error('Foundry application email error:', err))
+
+    return NextResponse.json({
+      success: true,
+      message: 'Application received. Frank reads every one personally.',
+    })
+  } catch (error) {
+    console.error('Foundry application error:', error)
+    return NextResponse.json(
+      { error: 'An unexpected error occurred. Please try again.' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/foundry/guide/page.tsx
+++ b/app/foundry/guide/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'The Operating Guide — FrankX Foundry',
+  description:
+    'How to operate an installed business OS: day-1 onboarding, the 30-minute weekly rhythm, the quality gates, and how harness updates arrive. Written for founders, no AI background assumed.',
+  alternates: { canonical: 'https://frankx.ai/foundry/guide' },
+}
+
+/** Long-form reading surface — narrow measure, slow cadence, no funnel. */
+export default function FoundryGuidePage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/70">
+      <article className="mx-auto max-w-3xl px-6 pb-32 pt-28 lg:pt-36">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+          Foundry · The Operating Guide
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight text-white md:text-5xl">
+          How to run a business on an operating system.
+        </h1>
+        <p className="mt-6 text-lg leading-relaxed text-white/60">
+          For founders who just got an OS installed — or instantiated the open-source template
+          themselves. No AI background assumed. Ten minutes to read; thirty minutes a week to
+          operate.
+        </p>
+
+        <div className="mt-16 space-y-14 text-base leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-white">What you actually have</h2>
+            <p className="mt-4">
+              Most companies use AI as a chatbot: blank window, blank context, generic output. You
+              have something different — a repository that teaches the AI who you are. Five
+              contract files do the teaching:
+            </p>
+            <ul className="mt-4 space-y-3">
+              <li>
+                <span className="font-mono text-sm text-emerald-400/80">CLAUDE.md</span> — the
+                doctrine. The company handbook, read automatically by every AI session.
+              </li>
+              <li>
+                <span className="font-mono text-sm text-emerald-400/80">AGENTS.md</span> — the same
+                rules on one page, readable by any AI tool.
+              </li>
+              <li>
+                <span className="font-mono text-sm text-emerald-400/80">SKILL.md</span> — what to
+                load before each kind of work, and when the AI should refuse.
+              </li>
+              <li>
+                <span className="font-mono text-sm text-emerald-400/80">design.md</span> — every
+                color, font, and spacing value your site is allowed to use.
+              </li>
+              <li>
+                <span className="font-mono text-sm text-emerald-400/80">taste.md</span> — the
+                judgment tokens can&apos;t capture: references, refusals, the polish pass.
+              </li>
+            </ul>
+            <p className="mt-4">
+              Edit these files and every future AI session changes behavior. That&apos;s the whole
+              trick — the configuration is the company knowledge, and it compounds.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">Day 1 — one evening</h2>
+            <ol className="mt-4 list-decimal space-y-3 pl-5">
+              <li>
+                Install{' '}
+                <a
+                  href="https://claude.com/claude-code"
+                  rel="noopener"
+                  className="text-emerald-400 hover:underline"
+                >
+                  Claude Code
+                </a>{' '}
+                (or use Cursor or Codex — the contract files cover them too).
+              </li>
+              <li>
+                Open a terminal in your repo and just talk. Try:{' '}
+                <em>&ldquo;What are the rules of this repo?&rdquo;</em> The agent recites your
+                doctrine back — that&apos;s how you know the harness is live.
+              </li>
+              <li>
+                Read your own <span className="font-mono text-sm">CLAUDE.md</span>. It&apos;s the
+                best summary of how everything fits.
+              </li>
+            </ol>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              The weekly rhythm — the whole operation
+            </h2>
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 text-left text-white/40">
+                    <th className="py-2 pr-4 font-medium">When</th>
+                    <th className="py-2 pr-4 font-medium">Command</th>
+                    <th className="py-2 pr-4 font-medium">What happens</th>
+                    <th className="py-2 font-medium">Time</th>
+                  </tr>
+                </thead>
+                <tbody className="text-white/70">
+                  <tr className="border-b border-white/5">
+                    <td className="py-3 pr-4">Monday</td>
+                    <td className="py-3 pr-4 font-mono text-xs">/weekly-content</td>
+                    <td className="py-3 pr-4">
+                      Plans the week: one post, one distribution action, one ops task. Three items
+                      max — sized for founders with day jobs.
+                    </td>
+                    <td className="py-3">10 min</td>
+                  </tr>
+                  <tr className="border-b border-white/5">
+                    <td className="py-3 pr-4">Midweek</td>
+                    <td className="py-3 pr-4 font-mono text-xs">/blog-post</td>
+                    <td className="py-3 pr-4">
+                      Drafts, polishes, gates, and build-verifies a piece of content.
+                    </td>
+                    <td className="py-3">1–2 h</td>
+                  </tr>
+                  <tr>
+                    <td className="py-3 pr-4">Friday</td>
+                    <td className="py-3 pr-4 font-mono text-xs">/weekly-review</td>
+                    <td className="py-3 pr-4">
+                      Asks you three questions, closes the week, updates the business memory.
+                    </td>
+                    <td className="py-3">15 min</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-4">
+              The Friday step is the one people skip and shouldn&apos;t. The plan is disposable;
+              the review is the asset — it writes to{' '}
+              <span className="font-mono text-sm">docs/intelligence/</span>, the memory that makes
+              week 30 smarter than week 1. The operating discipline in one line:{' '}
+              <strong className="text-white">check memory first, update memory after.</strong>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              The gates — why your output won&apos;t look AI-generated
+            </h2>
+            <p className="mt-4">Nothing publishes without passing:</p>
+            <ul className="mt-4 space-y-3">
+              <li>
+                <strong className="text-white">@claims-guard</strong> — blocks regulated claim
+                language, uncited assertions, banned phrases, and AI-tone. A FAIL is final until a
+                human rewrites. This is the agent that keeps you out of regulatory trouble and out
+                of the &ldquo;obviously a chatbot wrote this&rdquo; zone.
+              </li>
+              <li>
+                <strong className="text-white">/ship</strong> — typecheck, build, claims, and SEO
+                before any deploy. A human always presses the deploy button.
+              </li>
+              <li>
+                <strong className="text-white">The polish pass</strong> — seven manual checks in{' '}
+                <span className="font-mono text-sm">taste.md</span> before any visual ships.
+              </li>
+            </ul>
+            <p className="mt-4">
+              The standing rule:{' '}
+              <strong className="text-white">
+                agents draft, gate, and commit; humans deploy, post, and send.
+              </strong>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">When the harness improves upstream</h2>
+            <p className="mt-4">
+              Your repo descends from{' '}
+              <a
+                href="https://github.com/frankxai/agentic-business-os"
+                rel="noopener"
+                className="text-emerald-400 hover:underline"
+              >
+                agentic-business-os
+              </a>
+              . When the upstream harness improves, you receive a pull request with a
+              plain-language changelog. You read the diff — it&apos;s markdown, readable in the
+              GitHub interface — and merge or decline per file. Nothing ever auto-merges, and your
+              brand files are never touched. The full contract is one page:{' '}
+              <a
+                href="https://github.com/frankxai/agentic-business-os/blob/main/HARNESS.md"
+                rel="noopener"
+                className="text-emerald-400 hover:underline"
+              >
+                HARNESS.md
+              </a>
+              . The principle it encodes:{' '}
+              <strong className="text-white">brand is yours, machinery is shared.</strong>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">Where to get help</h2>
+            <ul className="mt-4 space-y-3">
+              <li>
+                The template and skill packs are MIT-licensed — community help via{' '}
+                <a
+                  href="https://github.com/frankxai/agentic-business-os/issues"
+                  rel="noopener"
+                  className="text-emerald-400 hover:underline"
+                >
+                  GitHub issues
+                </a>
+                .
+              </li>
+              <li>Installed by the Foundry? You have a direct channel — use it.</li>
+              <li>
+                Considering an install?{' '}
+                <Link href="/foundry#apply" className="text-emerald-400 hover:underline">
+                  Apply here
+                </Link>
+                .
+              </li>
+            </ul>
+          </section>
+        </div>
+      </article>
+    </main>
+  )
+}

--- a/app/foundry/page.tsx
+++ b/app/foundry/page.tsx
@@ -1,0 +1,460 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { GlowCard } from '@/components/ui/glow-card'
+import { FoundryApplicationForm } from '@/components/foundry/FoundryApplicationForm'
+import { FOUNDRY_FAQS } from '@/lib/foundry-faqs'
+
+export const metadata: Metadata = {
+  title: 'FrankX Foundry — Operating Systems for Businesses We Believe In',
+  description:
+    'The Foundry installs complete AI operating systems into businesses: website, agent harness, quality gates, compounding memory. Evaluated applications only. Priority for sustainable, healthcare, and meaningful products.',
+  alternates: { canonical: 'https://frankx.ai/foundry' },
+  openGraph: {
+    title: 'FrankX Foundry',
+    description:
+      'Complete AI operating systems, installed into businesses we believe in. Application-only.',
+    url: 'https://frankx.ai/foundry',
+  },
+}
+
+// ── The Agentic OS family — every box links to a real public repo ──
+const osFamily = [
+  {
+    name: 'agentic-creator-os',
+    audience: 'For creators',
+    status: 'live' as const,
+    href: 'https://github.com/frankxai/agentic-creator-os',
+    note: 'The original — content engine, music, publishing pipelines.',
+  },
+  {
+    name: 'agentic-business-os',
+    audience: 'For businesses',
+    status: 'live' as const,
+    href: 'https://github.com/frankxai/agentic-business-os',
+    note: 'Site + harness + claims gate + business memory. What the Foundry installs.',
+  },
+  {
+    name: 'agentic-family-os',
+    audience: 'For families',
+    status: 'in development' as const,
+    note: 'Heritage, memory, and family knowledge systems.',
+  },
+  {
+    name: 'agentic-health-os',
+    audience: 'For health',
+    status: 'in development' as const,
+    note: 'Training, nutrition, and recovery operating loops.',
+  },
+  {
+    name: 'agentic-investor-os',
+    audience: 'For wealth',
+    status: 'in development' as const,
+    note: 'Portfolio intelligence and decision memory.',
+  },
+]
+
+// ── What gets installed — the five contract files, explained ──
+const contracts = [
+  {
+    file: 'CLAUDE.md',
+    name: 'The doctrine',
+    body: 'The company handbook, read automatically by every AI session. Identity, rules, gates. Edit it, and every future session changes behavior.',
+  },
+  {
+    file: 'design.md + taste.md',
+    name: 'The design contract',
+    body: 'Every visual value the site may use, plus the judgment tokens cannot capture. Your brand stops drifting the day these exist.',
+  },
+  {
+    file: '@claims-guard',
+    name: 'The gate',
+    body: 'A zero-tolerance pre-publish audit for regulated claim language, uncited assertions, and AI-tone. A FAIL blocks publish until a human rewrites.',
+  },
+  {
+    file: 'docs/intelligence/',
+    name: 'The memory',
+    body: 'Decision records, market notes, weekly reviews. Sessions check it first and update it after — week 30 is smarter than week 1.',
+  },
+  {
+    file: 'The weekly rhythm',
+    name: 'The operation',
+    body: 'Monday plan, ten minutes. Friday review, fifteen. Sized for founders with day jobs; everything else is production.',
+  },
+]
+
+// ── Evaluation criteria — published, not implied ──
+const criteria = [
+  {
+    title: 'Meaningful product',
+    body: 'Priority goes to sustainable, healthcare, and genuinely useful businesses. We install systems into things we want to exist.',
+  },
+  {
+    title: 'A founder who will operate it',
+    body: 'The system compounds through the weekly rhythm. If nobody runs the Friday review, the install is shelf-ware — we decline rather than ship that.',
+  },
+  {
+    title: 'Honest category',
+    body: 'If your market rewards overstatement, our claims gate will frustrate you. We take businesses that win by being right, not loud.',
+  },
+]
+
+const steps = [
+  {
+    n: '01',
+    title: 'Apply',
+    body: 'Six questions. Frank reads every application personally — no form-letter pipeline.',
+  },
+  {
+    n: '02',
+    title: 'Evaluate',
+    body: 'Fit call if the application lands: the business, the stage, the regulated territory, the operating capacity. Pricing follows this conversation.',
+  },
+  {
+    n: '03',
+    title: 'Forge',
+    body: 'The install: brand derivation interview, design contract, voice file, doctrine, gates, site — build-verified and deploy-ready.',
+  },
+  {
+    n: '04',
+    title: 'Stay connected',
+    body: 'Your repo is registered downstream. Harness improvements arrive as readable pull requests. Nothing auto-merges; your brand files are never touched.',
+  },
+]
+
+export default function FoundryPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://frankx.ai' },
+          { '@type': 'ListItem', position: 2, name: 'Foundry', item: 'https://frankx.ai/foundry' },
+        ],
+      },
+      {
+        '@type': 'Service',
+        name: 'FrankX Foundry',
+        url: 'https://frankx.ai/foundry',
+        provider: { '@type': 'Person', name: 'Frank', url: 'https://frankx.ai' },
+        description:
+          'Evaluated installs of the Agentic Business OS: website, AI-agent harness, quality gates, and compounding business memory.',
+        areaServed: 'Worldwide',
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: FOUNDRY_FAQS.map((f) => ({
+          '@type': 'Question',
+          name: f.question,
+          acceptedAnswer: { '@type': 'Answer', text: f.answer },
+        })),
+      },
+    ],
+  }
+
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/80">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      {/* Hero */}
+      <section className="mx-auto max-w-6xl px-6 pb-24 pt-28 lg:pt-36">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+          FrankX Foundry
+        </p>
+        <h1 className="max-w-3xl text-4xl font-bold tracking-tight text-white md:text-6xl">
+          We install operating systems into businesses we believe in.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-white/60">
+          A website, an AI-agent harness, pre-publish quality gates, and a business memory that
+          compounds — the same architecture that runs frankx.ai, derived for your brand and owned
+          by you. Installed in days, operated in thirty minutes a week, connected for the long run.
+        </p>
+        <div className="mt-10 flex flex-wrap items-center gap-4">
+          <Link
+            href="#apply"
+            className="rounded-full bg-white px-8 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+          >
+            Apply for an Install
+          </Link>
+          <Link
+            href="/foundry/guide"
+            className="px-2 py-3.5 text-sm font-semibold text-white/60 transition-colors hover:text-white"
+          >
+            Read the operating guide
+          </Link>
+        </div>
+        <p className="mt-8 font-mono text-xs text-white/40">
+          Founding cohort forming · limited installs per quarter · priority: sustainable, healthcare,
+          meaningful
+        </p>
+      </section>
+
+      {/* The architecture — three layers, all inspectable */}
+      <section className="border-t border-white/5 py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+            The Architecture
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Three layers. Every one of them public.
+          </h2>
+          <p className="mt-3 max-w-xl text-base text-white/60">
+            The claim is substance, not marketing: the substrate, the operating systems, and the
+            first installs are open repositories. Verify rather than trust.
+          </p>
+
+          <div className="mt-12 space-y-4">
+            <GlowCard color="cyan" className="p-7">
+              <p className="font-mono text-xs text-cyan-400/70">LAYER 0 — SUBSTRATE</p>
+              <h3 className="mt-2 text-lg font-semibold text-white">
+                Starlight Intelligence System
+              </h3>
+              <p className="mt-2 max-w-2xl text-sm text-white/60">
+                The protocol layer: memory architecture, decision records, the operating-skill
+                pattern. Open source at{' '}
+                <a
+                  href="https://github.com/frankxai/Starlight-Intelligence-System"
+                  className="text-cyan-400 hover:underline"
+                  rel="noopener"
+                >
+                  frankxai/Starlight-Intelligence-System
+                </a>
+                .
+              </p>
+            </GlowCard>
+
+            <GlowCard color="emerald" className="p-7">
+              <p className="font-mono text-xs text-emerald-400/70">LAYER 1 — THE AGENTIC OS FAMILY</p>
+              <h3 className="mt-2 text-lg font-semibold text-white">
+                One architecture, specialized per domain
+              </h3>
+              <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                {osFamily.map((os) => (
+                  <div
+                    key={os.name}
+                    className="rounded-xl border border-white/5 bg-white/[0.03] p-4"
+                  >
+                    <p className="font-mono text-[11px] text-white/80">{os.name}</p>
+                    <p className="mt-1 text-xs text-white/50">{os.audience}</p>
+                    <p
+                      className={`mt-2 inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                        os.status === 'live'
+                          ? 'bg-emerald-500/15 text-emerald-400'
+                          : 'bg-white/5 text-white/40'
+                      }`}
+                    >
+                      {os.status}
+                    </p>
+                    <p className="mt-2 text-[11px] leading-relaxed text-white/40">{os.note}</p>
+                    {os.href ? (
+                      <a
+                        href={os.href}
+                        rel="noopener"
+                        className="mt-2 block text-[11px] text-emerald-400/80 hover:text-emerald-300"
+                      >
+                        View repo →
+                      </a>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </GlowCard>
+
+            <GlowCard color="white" className="p-7">
+              <p className="font-mono text-xs text-white/50">LAYER 2 — THE SERVICE</p>
+              <h3 className="mt-2 text-lg font-semibold text-white">The Foundry — this page</h3>
+              <p className="mt-2 max-w-2xl text-sm text-white/60">
+                The human layer: evaluate, forge, stay connected. The templates are free and
+                MIT-licensed; the Foundry prices the install, the brand derivation, and the
+                connected relationship.
+              </p>
+            </GlowCard>
+          </div>
+        </div>
+      </section>
+
+      {/* What gets installed */}
+      <section className="border-t border-white/5 py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+            What Gets Installed
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Five contracts that teach AI your business.
+          </h2>
+          <p className="mt-3 max-w-xl text-base text-white/60">
+            Most companies use AI as a blank chatbot. An installed OS is a repository that teaches
+            the AI who you are — so every session works like a trained team member.
+          </p>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {contracts.map((c) => (
+              <GlowCard key={c.file} color="emerald" className="p-6">
+                <p className="font-mono text-xs text-emerald-400/70">{c.file}</p>
+                <h3 className="mt-2 text-base font-semibold text-white">{c.name}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{c.body}</p>
+              </GlowCard>
+            ))}
+            <GlowCard color="white" href="/foundry/guide" className="p-6">
+              <p className="font-mono text-xs text-white/50">GUIDE.md</p>
+              <h3 className="mt-2 text-base font-semibold text-white">The operating guide</h3>
+              <p className="mt-2 text-sm leading-relaxed text-white/60">
+                Day-1 onboarding, the weekly rhythm, the gates — written for founders, no AI
+                background assumed. Read it now →
+              </p>
+            </GlowCard>
+          </div>
+        </div>
+      </section>
+
+      {/* Proof */}
+      <section className="border-t border-white/5 py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+            Proof
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            The receipts, not the pitch.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 lg:grid-cols-3">
+            <GlowCard color="emerald" className="p-7">
+              <p className="font-mono text-xs text-white/40">INSTALL №1</p>
+              <h3 className="mt-2 text-base font-semibold text-white">
+                A European consumer-goods launch
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-white/60">
+                Zero to a build-verified operating system in one day: site, claims gate tuned to EU
+                regulated-claim territory, business memory, weekly rhythm. Now a registered
+                downstream instance — it merged its first harness-sync pull request the same week.
+              </p>
+            </GlowCard>
+            <GlowCard color="cyan" className="p-7">
+              <p className="font-mono text-xs text-white/40">THE UPDATE CHANNEL</p>
+              <h3 className="mt-2 text-base font-semibold text-white">Sync you can read</h3>
+              <p className="mt-2 text-sm leading-relaxed text-white/60">
+                Harness improvements arrive as pull requests with plain-language changelogs —
+                markdown diffs readable in the GitHub UI. Nothing auto-merges. The contract is
+                public:{' '}
+                <a
+                  href="https://github.com/frankxai/agentic-business-os/blob/main/HARNESS.md"
+                  rel="noopener"
+                  className="text-cyan-400 hover:underline"
+                >
+                  HARNESS.md
+                </a>
+                .
+              </p>
+            </GlowCard>
+            <GlowCard color="white" className="p-7">
+              <p className="font-mono text-xs text-white/40">THE REFERENCE</p>
+              <h3 className="mt-2 text-base font-semibold text-white">frankx.ai itself</h3>
+              <p className="mt-2 text-sm leading-relaxed text-white/60">
+                This site runs the same architecture in production: 500+ routes, automated
+                pre-publish gates, a public agent catalog at{' '}
+                <Link href="/acos/agents" className="text-white hover:underline">
+                  /acos/agents
+                </Link>
+                , and the operating loop documented at{' '}
+                <Link href="/os" className="text-white hover:underline">
+                  /os
+                </Link>
+                .
+              </p>
+            </GlowCard>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works + evaluation */}
+      <section className="border-t border-white/5 py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+            The Process
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Evaluated, not transactional.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {steps.map((s) => (
+              <div key={s.n} className="rounded-2xl border border-white/5 bg-white/[0.03] p-6">
+                <p className="font-mono text-xs text-emerald-400/60">{s.n}</p>
+                <h3 className="mt-2 text-base font-semibold text-white">{s.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{s.body}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-16">
+            <h3 className="text-xl font-semibold text-white">What we evaluate for</h3>
+            <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-3">
+              {criteria.map((c) => (
+                <div key={c.title} className="border-l-2 border-emerald-500/40 pl-5">
+                  <p className="text-sm font-semibold text-white">{c.title}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-white/60">{c.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Application */}
+      <section id="apply" className="border-t border-white/5 py-24 lg:py-32">
+        <div className="mx-auto max-w-3xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+            Apply
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Tell us what you&apos;re building.
+          </h2>
+          <p className="mt-3 max-w-xl text-base text-white/60">
+            Six questions, read personally. Pricing follows evaluation — the founding cohort is
+            forming now.
+          </p>
+          <div className="mt-10">
+            <FoundryApplicationForm />
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="border-t border-white/5 py-24 lg:py-32">
+        <div className="mx-auto max-w-3xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+            FAQ
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Straight answers.
+          </h2>
+          <div className="mt-12 space-y-10">
+            {FOUNDRY_FAQS.map((f) => (
+              <div key={f.question}>
+                <h3 className="text-base font-semibold text-white">{f.question}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{f.answer}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-16 border-t border-white/5 pt-10">
+            <p className="text-sm text-white/60">
+              Not ready to apply? The template is open source —{' '}
+              <a
+                href="https://github.com/frankxai/agentic-business-os"
+                rel="noopener"
+                className="text-emerald-400 hover:underline"
+              >
+                take it, it&apos;s yours
+              </a>
+              . Or start with the{' '}
+              <Link href="/foundry/guide" className="text-emerald-400 hover:underline">
+                operating guide
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -130,6 +130,7 @@ export default function Footer() {
           <nav aria-label="Connect">
             <h3 className="text-xs sm:text-sm font-semibold uppercase tracking-wider sm:tracking-widest text-white/60 mb-3 sm:mb-4">Connect</h3>
             <ul className="space-y-2 sm:space-y-3 text-xs sm:text-sm text-white/40">
+              <li><Link href="/foundry" className="text-emerald-400/70 hover:text-emerald-300 transition-colors">Foundry</Link></li>
               <li><Link href="/start" className="hover:text-white transition-colors">Start here</Link></li>
               <li><Link href="/newsletter" className="hover:text-white transition-colors">Newsletter</Link></li>
               <li><Link href="/inner-circle" className="hover:text-white transition-colors">Inner Circle</Link></li>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -89,6 +89,15 @@ const navItems: NavItem[] = [
       { name: 'Methodology', href: '/research/methodology' },
     ],
   },
+  {
+    name: 'Foundry',
+    href: '/foundry',
+    subItems: [
+      { name: 'The Foundry', href: '/foundry' },
+      { name: 'Operating Guide', href: '/foundry/guide' },
+      { name: 'Apply', href: '/foundry#apply' },
+    ],
+  },
   { name: 'Blog', href: '/blog' },
   { name: 'About', href: '/about' },
 ]

--- a/components/foundry/FoundryApplicationForm.tsx
+++ b/components/foundry/FoundryApplicationForm.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+
+const STAGES = [
+  { value: 'idea', label: 'Idea — validating' },
+  { value: 'pre-launch', label: 'Pre-launch — building' },
+  { value: 'revenue', label: 'Revenue — selling' },
+  { value: 'scaling', label: 'Scaling — growing' },
+] as const
+
+const inputClass =
+  'w-full px-4 py-3 bg-white/[0.04] border border-white/10 rounded-xl text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-emerald-500/60 focus:border-transparent disabled:opacity-50 transition-all'
+
+export function FoundryApplicationForm() {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    company: '',
+    link: '',
+    building: '',
+    why: '',
+    stage: '',
+  })
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const set = (key: keyof typeof form) => (e: { target: { value: string } }) =>
+    setForm((f) => ({ ...f, [key]: e.target.value }))
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setStatus('loading')
+    setErrorMessage('')
+    try {
+      const res = await fetch('/api/foundry/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Something went wrong')
+      setStatus('success')
+    } catch (err) {
+      setStatus('error')
+      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-8 text-center">
+        <p className="text-lg font-semibold text-white">Application received.</p>
+        <p className="mt-2 text-sm text-white/60">
+          Frank reads every one personally — you&apos;ll hear back within a few days, and a
+          confirmation is on its way to your inbox. No drip campaign follows.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="foundry-name" className="mb-2 block text-sm font-medium text-white/70">
+            Name
+          </label>
+          <input
+            id="foundry-name"
+            type="text"
+            required
+            value={form.name}
+            onChange={set('name')}
+            disabled={status === 'loading'}
+            className={inputClass}
+            placeholder="Your name"
+          />
+        </div>
+        <div>
+          <label htmlFor="foundry-email" className="mb-2 block text-sm font-medium text-white/70">
+            Email
+          </label>
+          <input
+            id="foundry-email"
+            type="email"
+            required
+            value={form.email}
+            onChange={set('email')}
+            disabled={status === 'loading'}
+            className={inputClass}
+            placeholder="you@company.com"
+          />
+        </div>
+        <div>
+          <label htmlFor="foundry-company" className="mb-2 block text-sm font-medium text-white/70">
+            Business / brand
+          </label>
+          <input
+            id="foundry-company"
+            type="text"
+            required
+            value={form.company}
+            onChange={set('company')}
+            disabled={status === 'loading'}
+            className={inputClass}
+            placeholder="Company or working name"
+          />
+        </div>
+        <div>
+          <label htmlFor="foundry-link" className="mb-2 block text-sm font-medium text-white/70">
+            Link <span className="text-white/40">(optional)</span>
+          </label>
+          <input
+            id="foundry-link"
+            type="url"
+            value={form.link}
+            onChange={set('link')}
+            disabled={status === 'loading'}
+            className={inputClass}
+            placeholder="https://"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="foundry-building" className="mb-2 block text-sm font-medium text-white/70">
+          What are you building?
+        </label>
+        <textarea
+          id="foundry-building"
+          required
+          rows={3}
+          value={form.building}
+          onChange={set('building')}
+          disabled={status === 'loading'}
+          className={inputClass}
+          placeholder="The product, the customer, the honest one-paragraph version."
+        />
+      </div>
+
+      <div>
+        <label htmlFor="foundry-why" className="mb-2 block text-sm font-medium text-white/70">
+          Why does it matter?
+        </label>
+        <textarea
+          id="foundry-why"
+          required
+          rows={3}
+          value={form.why}
+          onChange={set('why')}
+          disabled={status === 'loading'}
+          className={inputClass}
+          placeholder="Sustainable, healthcare, and meaningful businesses get priority — tell us where yours stands."
+        />
+      </div>
+
+      <div>
+        <label htmlFor="foundry-stage" className="mb-2 block text-sm font-medium text-white/70">
+          Stage
+        </label>
+        <select
+          id="foundry-stage"
+          required
+          value={form.stage}
+          onChange={set('stage')}
+          disabled={status === 'loading'}
+          className={inputClass}
+        >
+          <option value="" disabled>
+            Select a stage
+          </option>
+          {STAGES.map((s) => (
+            <option key={s.value} value={s.value} className="bg-[#111113]">
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        disabled={status === 'loading'}
+        className="w-full rounded-full bg-white px-6 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:px-10"
+      >
+        {status === 'loading' ? 'Submitting…' : 'Submit Application'}
+      </button>
+
+      {status === 'error' && errorMessage && (
+        <p className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-400">
+          {errorMessage}
+        </p>
+      )}
+
+      <p className="text-xs text-white/40">
+        Applications are read personally. You get one confirmation email and a decision — nothing
+        else lands in your inbox.
+      </p>
+    </form>
+  )
+}

--- a/content/blog/agentic-os-family-foundry-launch.mdx
+++ b/content/blog/agentic-os-family-foundry-launch.mdx
@@ -1,0 +1,61 @@
+---
+title: "The Agentic OS Family: One Architecture, Installed Into Real Businesses"
+description: "How a one-day install for a friend's company became agentic-business-os, a public template with a sync channel — and the Foundry, an application-only install service with priority for sustainable, healthcare, and meaningful businesses."
+date: "2026-06-11"
+lastUpdated: "2026-06-11"
+author: "Frank"
+category: "Intelligence Dispatches"
+tags:
+  - agentic-os
+  - business-os
+  - foundry
+  - claude-code
+  - ai-architecture
+  - open-source
+keywords:
+  - agentic business os
+  - ai operating system for business
+  - frankx foundry
+  - claude code business setup
+  - ai agent harness template
+  - business ai operating system install
+image: "/images/blog/agentic-os-family-hero.svg"
+featured: true
+schema: ["Article"]
+---
+
+**TL;DR:** I installed a complete AI operating system into a friend's consumer-goods startup in one day: website, agent harness, a zero-tolerance claims gate, and a business memory that compounds weekly. Then I extracted the generic machinery into [agentic-business-os](https://github.com/frankxai/agentic-business-os), a public MIT template with an update channel that ships harness improvements to every instance as readable pull requests. The install service around it is the [FrankX Foundry](/foundry) — application-only, evaluated, with priority for sustainable, healthcare, and meaningful businesses.
+
+## What happened this week
+
+Friends of mine are launching a physical product in a category where one careless sentence of marketing copy is a regulatory problem. They asked what my stack could do for them.
+
+The answer turned out to be: everything, in a day. Not because the day was heroic, but because the architecture already existed. frankx.ai runs on a layered system: a memory substrate ([Starlight Intelligence System](https://github.com/frankxai/Starlight-Intelligence-System)), an agent harness ([Agentic Creator OS](https://github.com/frankxai/agentic-creator-os)), a two-file design contract, and pre-publish quality gates. Installing it for a business meant deriving those layers for one brand instead of inventing anything new.
+
+## What an installed OS actually is
+
+Five contract files in a repository, read automatically by any coding agent:
+
+- **The doctrine** (`CLAUDE.md`): the company handbook, enforced by software
+- **The design contract** (`design.md` + `taste.md`): every visual value the site may use, plus the judgment tokens can't capture
+- **The voice file**: banned phrases, blocked claim patterns, approved framing
+- **The gate** (`@claims-guard`): a pre-publish audit that blocks regulated claim language outright. A FAIL is final until a human rewrites
+- **The memory** (`docs/intelligence/`): decision records, market notes, weekly reviews
+
+The operating cost once it runs: a ten-minute Monday plan and a fifteen-minute Friday review. The agents do production; the gates hold the floor; the memory makes week 30 smarter than week 1.
+
+## The part that makes it a system, not a setup
+
+A setup decays the day it ships. This doesn't, because of one design decision: **brand is yours, machinery is shared.**
+
+The brand files above are instance-owned — never touched by anyone. The generic machinery (the agents, the command pipelines, the gate logic) is upstream-managed. When it improves in the public template, every registered instance receives a pull request with a plain-language changelog. The founder reads the diff in the GitHub UI and merges or declines. Nothing auto-merges, ever. The contract is one page: [HARNESS.md](https://github.com/frankxai/agentic-business-os/blob/main/HARNESS.md).
+
+The loop is already proven, not promised: the first instance merged its first harness-sync pull request the same week it was installed.
+
+## Take the template, or apply for an install
+
+The template and four standalone skill packs (the claims gate, the business memory, the design-contract authoring session, the weekly rhythm) are MIT-licensed at [frankxai/agentic-business-os](https://github.com/frankxai/agentic-business-os). They work in Claude Code, Cursor, and Codex, and the packs import into a Claude.ai project as plain folders.
+
+If you want it installed, derived for your brand, and connected for the long run: the [Foundry](/foundry) takes a small number of installs per quarter, by application, with priority for sustainable, healthcare, and genuinely meaningful products. Pricing follows evaluation; the founding cohort is forming now.
+
+The repos are public on purpose. Verify rather than trust.

--- a/content/blog/ai-model-routing-guide.mdx
+++ b/content/blog/ai-model-routing-guide.mdx
@@ -82,7 +82,7 @@ Our blind style verdicts flipped between rounds — Opus won Round 1, Fable won 
 
 ## What Changed This Quarter?
 
-**Q2 2026 (this edition):** Fable 5 arrived (June 9) and took the agentic-coding row from the Opus/GPT split; Opus 4.8 consolidated the judgment row on measured behavior, not just price; Qwen3.7-Max went closed and earned the mid-tier row; Gemini 3.5 Pro remains preview-only and holds no row — [the honest state here](/llm-hub/compare/claude-fable-5-vs-gemini-3-5-pro). Watch for next edition: Gemini 3.5 Pro GA, a cross-lab Fable-vs-GPT arena round, and whether Fable 5's vendor-claimed benchmarks survive independent reproduction.
+**Q2 2026 (this edition):** Fable 5 arrived (June 9) and took the agentic-coding row from the Opus/GPT split; Opus 4.8 consolidated the judgment row on measured behavior, not just price; Qwen3.7-Max went closed and earned the mid-tier row; Gemini 3.5 Pro remains preview-only and holds no row — [the honest state here](/llm-hub/gemini-3-5-pro). Watch for next edition: Gemini 3.5 Pro GA, a cross-lab Fable-vs-GPT arena round, and whether Fable 5's vendor-claimed benchmarks survive independent reproduction.
 
 ## How Does This Fit Your AI Center of Excellence?
 

--- a/content/blog/claude-fable-5-prompting-guide.mdx
+++ b/content/blog/claude-fable-5-prompting-guide.mdx
@@ -103,7 +103,7 @@ Five lines of structure encode rules 1–5. Rules 6–7 are routing and architec
 
 ## When Should You Not Use Fable 5 at All?
 
-Prompting can't fix a routing mistake. Judgment-heavy review, ambiguous specs, and human-read prose route better to [Opus 4.8 at half the price](/llm-hub/compare/claude-fable-5-vs-claude-opus-4-8); bulk fan-out belongs on Haiku-tier; the full persona-by-persona picture is in the [comparison hub](/llm-hub) and the [routing guide](/blog/ai-model-routing-guide).
+Prompting can't fix a routing mistake. Judgment-heavy review, ambiguous specs, and human-read prose route better to [Opus 4.8 at half the price](/llm-hub/claude-opus-4-8); bulk fan-out belongs on Haiku-tier; the full persona-by-persona picture is in the [comparison hub](/llm-hub) and the [routing guide](/blog/ai-model-routing-guide).
 
 ## FAQ
 

--- a/data/os-modules.ts
+++ b/data/os-modules.ts
@@ -198,6 +198,29 @@ export const osModules: OSModule[] = [
         'LinkedIn (AI Architect), YouTube long-form (the Builder), Shorts + TikTok (the Creator), Instagram (the Aesthete), X (the Thinker), Threads (Conversation-starter), Bluesky (Live-thinker), Spotify (the Producer). One persona per profile.',
     },
   },
+  {
+    id: 'foundry',
+    name: 'FrankX Foundry',
+    slug: 'foundry',
+    route: '/foundry',
+    status: 'live',
+    color: 'emerald',
+    iconName: 'Hammer',
+    shipped: '2026-06-11',
+    oneLine: 'Operating-system installs for businesses we believe in.',
+    description:
+      'The service layer of the Agentic OS family. Evaluated installs of agentic-business-os — site, agent harness, claims gate, business memory — derived per brand, owned by the founder, connected via harness-sync PRs. Application-only; priority for sustainable, healthcare, and meaningful businesses.',
+    phases: ['funnel', 'cross-cutting'],
+    connectsTo: ['acos', 'coe-hub'],
+    artifacts: ['OS installs', 'Brand derivations', 'Harness-sync PRs', 'Skill packs'],
+    commands: ['/os-spawn'],
+    deepDive: {
+      route: '/foundry/guide',
+      label: 'Read the operating guide',
+      description:
+        'How a founder runs an installed OS: day-1 onboarding, the 30-minute weekly rhythm, the gates, and how harness updates arrive.',
+    },
+  },
 ]
 
 export const osCRM = {

--- a/lib/email-templates-foundry.ts
+++ b/lib/email-templates-foundry.ts
@@ -1,0 +1,57 @@
+/**
+ * Foundry application emails — plain text, no marketing chrome.
+ * Matches the Inner Circle waitlist aesthetic: a person wrote this.
+ */
+
+export interface FoundryApplicationInput {
+  name: string
+  email: string
+  company: string
+  building: string
+  why: string
+  stage: string
+  link?: string
+}
+
+/** Confirmation to the applicant. Plain text by design. */
+export function foundryApplicationReceivedEmail(input: FoundryApplicationInput) {
+  return {
+    subject: 'Your Foundry application is in',
+    plainText: `${input.name ? `${input.name} —` : 'Hey —'}
+
+Your application for a Foundry install is in. I read every one personally — usually within a few days, sometimes faster.
+
+What happens next:
+
+1. I evaluate fit: the business, the stage, and whether the operating system genuinely compounds for what you're building. Priority goes to sustainable, healthcare, and meaningful products.
+2. If it's a fit, you get a short call invite to scope the install.
+3. If it's not a fit right now, I'll tell you straight — and the open-source template is yours either way: https://github.com/frankxai/agentic-business-os
+
+No drip campaign follows this email. You'll hear from me about your application and nothing else.
+
+— Frank
+frankx.ai/foundry`,
+  }
+}
+
+/** Internal notification to Frank. */
+export function foundryApplicationNotifyEmail(input: FoundryApplicationInput) {
+  return {
+    subject: `Foundry application: ${input.company || input.name}`,
+    plainText: `New Foundry application
+
+Name:     ${input.name}
+Email:    ${input.email}
+Company:  ${input.company}
+Stage:    ${input.stage}
+Link:     ${input.link || '—'}
+
+What they're building:
+${input.building}
+
+Why it matters:
+${input.why}
+
+Review queue: private/foundry-applications.jsonl (local) · /tmp on Vercel`,
+  }
+}

--- a/lib/foundry-faqs.ts
+++ b/lib/foundry-faqs.ts
@@ -1,0 +1,55 @@
+/**
+ * Foundry FAQs — single source of truth.
+ * Consumed by:
+ *   - app/foundry/page.tsx (renders the FAQ UI + FAQPage JSON-LD)
+ *
+ * When updating FAQs, edit ONLY this file.
+ */
+
+export interface FoundryFAQ {
+  question: string
+  answer: string
+}
+
+export const FOUNDRY_FAQS: FoundryFAQ[] = [
+  {
+    question: 'What is the FrankX Foundry?',
+    answer:
+      'The Foundry installs complete operating systems into businesses: a website, an AI-agent harness, pre-publish quality gates, and a compounding business memory — the same architecture that runs frankx.ai, adapted to your brand in a guided derivation. You walk out owning the whole repo.',
+  },
+  {
+    question: 'What exactly gets installed?',
+    answer:
+      'An instance of the Agentic Business OS: a Next.js site, five contract files that teach any AI agent your brand (doctrine, design tokens, taste, voice, operating skill), specialist agents including a zero-tolerance claims gate, six operating commands, and a file-based business memory. The template is open source — you can inspect every part before applying.',
+  },
+  {
+    question: 'Why is it application-only?',
+    answer:
+      'Install capacity is limited to a small number per quarter, and the system only compounds for founders who actually operate it weekly. The evaluation protects both sides: we take businesses where the architecture genuinely fits, with priority for sustainable, healthcare, and meaningful products.',
+  },
+  {
+    question: 'What does it cost?',
+    answer:
+      'Pricing follows evaluation — the founding cohort is forming now and applications are open. The underlying template is MIT-licensed and free forever; what the Foundry prices is the install, the brand derivation, and the connected relationship.',
+  },
+  {
+    question: 'What does "staying connected" mean?',
+    answer:
+      'Your repo is registered as a downstream instance. When the upstream harness improves — a sharper gate, a new agent — you receive a pull request with a plain-language changelog. You read the diff and merge or decline; nothing ever auto-merges, and your brand files are never touched. The first instance has already merged its first sync.',
+  },
+  {
+    question: 'Do I need to know how to code?',
+    answer:
+      'No. The operating layer is plain language: you talk to a coding agent in your repo and it behaves like a trained team member, because the contract files teach it your business. The weekly rhythm is about 30 minutes of structure — a Monday plan and a Friday review.',
+  },
+  {
+    question: 'How does this relate to the Inner Circle and Alliance?',
+    answer:
+      'The Inner Circle is the FrankX community and vault. Alliance is custom-scope partnership. The Foundry is narrower and deeper than both: one business, one operating system, installed and connected. Alliance conversations often include a Foundry install; an Inner Circle membership is neither required nor assumed.',
+  },
+  {
+    question: 'Is the system actually proven?',
+    answer:
+      'The architecture runs frankx.ai in production — 500+ routes, automated quality gates, a public agent catalog. The first external install (a European consumer-goods launch) went from zero to a build-verified, gated, deployed-ready operating system in one day, and is now a registered downstream instance receiving harness updates. The repos are public; verify rather than trust.',
+  },
+]

--- a/public/images/blog/agentic-os-family-hero.svg
+++ b/public/images/blog/agentic-os-family-hero.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="The Agentic OS family: substrate, operating systems, and the Foundry service layer">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="0%" r="80%">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#10b981" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#ffffff" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="#0a0a0b"/>
+  <rect width="1200" height="630" fill="url(#glow)"/>
+  <rect x="120" y="0" width="960" height="1" fill="url(#edge)"/>
+
+  <!-- Eyebrow -->
+  <text x="100" y="92" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="600" letter-spacing="6" fill="#10b981" opacity="0.75">THE AGENTIC OS FAMILY</text>
+
+  <!-- Title -->
+  <text x="100" y="150" font-family="Poppins, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff" letter-spacing="-0.5">One architecture. Installed into real businesses.</text>
+
+  <!-- Layer 2 — service -->
+  <rect x="100" y="200" width="1000" height="92" rx="20" fill="#111113" stroke="#ffffff" stroke-opacity="0.10"/>
+  <text x="130" y="238" font-family="JetBrains Mono, monospace" font-size="13" fill="#8a8a8c">LAYER 2 · SERVICE</text>
+  <text x="130" y="270" font-family="Poppins, Arial, sans-serif" font-size="24" font-weight="600" fill="#ffffff">FrankX Foundry</text>
+  <text x="1070" y="258" text-anchor="end" font-family="Inter, Arial, sans-serif" font-size="15" fill="#a9a9aa">evaluate · forge · stay connected</text>
+
+  <!-- Layer 1 — OS family -->
+  <rect x="100" y="312" width="1000" height="148" rx="20" fill="#111113" stroke="#10b981" stroke-opacity="0.35"/>
+  <text x="130" y="350" font-family="JetBrains Mono, monospace" font-size="13" fill="#34d399">LAYER 1 · OPERATING SYSTEMS</text>
+
+  <g font-family="JetBrains Mono, monospace" font-size="14">
+    <rect x="130" y="372" width="180" height="60" rx="12" fill="#1a1a1f" stroke="#10b981" stroke-opacity="0.5"/>
+    <text x="220" y="398" text-anchor="middle" fill="#ffffff">creator-os</text>
+    <text x="220" y="420" text-anchor="middle" font-size="11" fill="#34d399">live</text>
+
+    <rect x="322" y="372" width="190" height="60" rx="12" fill="#1a1a1f" stroke="#10b981" stroke-opacity="0.5"/>
+    <text x="417" y="398" text-anchor="middle" fill="#ffffff">business-os</text>
+    <text x="417" y="420" text-anchor="middle" font-size="11" fill="#34d399">live</text>
+
+    <rect x="524" y="372" width="170" height="60" rx="12" fill="#1a1a1f" stroke="#ffffff" stroke-opacity="0.10"/>
+    <text x="609" y="398" text-anchor="middle" fill="#a9a9aa">family-os</text>
+    <text x="609" y="420" text-anchor="middle" font-size="11" fill="#787878">in development</text>
+
+    <rect x="706" y="372" width="170" height="60" rx="12" fill="#1a1a1f" stroke="#ffffff" stroke-opacity="0.10"/>
+    <text x="791" y="398" text-anchor="middle" fill="#a9a9aa">health-os</text>
+    <text x="791" y="420" text-anchor="middle" font-size="11" fill="#787878">in development</text>
+
+    <rect x="888" y="372" width="182" height="60" rx="12" fill="#1a1a1f" stroke="#ffffff" stroke-opacity="0.10"/>
+    <text x="979" y="398" text-anchor="middle" fill="#a9a9aa">investor-os</text>
+    <text x="979" y="420" text-anchor="middle" font-size="11" fill="#787878">in development</text>
+  </g>
+
+  <!-- Layer 0 — substrate -->
+  <rect x="100" y="480" width="1000" height="92" rx="20" fill="#111113" stroke="#06b6d4" stroke-opacity="0.30"/>
+  <text x="130" y="518" font-family="JetBrains Mono, monospace" font-size="13" fill="#22d3ee" opacity="0.8">LAYER 0 · SUBSTRATE</text>
+  <text x="130" y="550" font-family="Poppins, Arial, sans-serif" font-size="22" font-weight="600" fill="#ffffff">Starlight Intelligence System</text>
+  <text x="1070" y="538" text-anchor="end" font-family="Inter, Arial, sans-serif" font-size="15" fill="#a9a9aa">memory · decisions · protocol</text>
+
+  <!-- Footer mark -->
+  <text x="1100" y="608" text-anchor="end" font-family="Inter, Arial, sans-serif" font-size="14" fill="#535354">frankx.ai/foundry</text>
+</svg>


### PR DESCRIPTION
## FrankX Foundry — /foundry

The premium service surface for the Agentic OS family. Mirrors FrankX `d5c07db4`.

**New routes**
- `/foundry` — 3-layer architecture showcase (SIS → agentic-*-os family → Foundry), 5-contract explainer, proof receipts (install #1, the harness-sync loop, frankx.ai as reference), published evaluation criteria, application form, 8 FAQs + FAQPage/Service/Breadcrumb JSON-LD
- `/foundry/guide` — founder-facing operating guide (long-form, reading measure)
- `POST /api/foundry/apply` — validated intake → JSONL backstop (/tmp on Vercel) + Resend contact + plain-text confirmation + internal notification to frank@frankx.ai

**Wiring** (anchored patches on this repo's own file versions, not dev overwrites)
- Navigation: Foundry top-level item · Footer: Work-with-me section · data/os-modules.ts: foundry module with /foundry/guide deepDive
- fix: 2 broken `/llm-hub/compare/*` blog links → existing model pages

**Deliberately absent:** pricing (BV-gated — application-only until further notice).

Upstream repos this page links: [agentic-business-os](https://github.com/frankxai/agentic-business-os) (v0.1.1, template + packs + sync) · [Starlight-Intelligence-System](https://github.com/frankxai/Starlight-Intelligence-System) · [agentic-creator-os](https://github.com/frankxai/agentic-creator-os).

Verification: tsc clean for all new files on FrankX; links:check:static green; Vercel preview on this PR is the authoritative build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)