### PR TITLE
feat(foundry): excellence pass — icon fix, OG images, hero visual, rate limit, a11y, cross-links

### DIFF
--- a/app/api/foundry/apply/route.ts
+++ b/app/api/foundry/apply/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { appendFile, mkdir } from 'fs/promises'
 import path from 'path'
+import { leadRatelimit, getClientIdentifier } from '@/lib/ratelimit'
 import {
   foundryApplicationReceivedEmail,
   foundryApplicationNotifyEmail,
@@ -47,7 +48,28 @@ async function sendEmails(input: FoundryApplicationInput) {
 
 export async function POST(request: NextRequest) {
   try {
+    // Rate limit: 10 applications per hour per client. Fail-open — a KV
+    // outage must never block a legitimate application.
+    try {
+      const { success } = await leadRatelimit.limit(getClientIdentifier(request))
+      if (!success) {
+        return NextResponse.json(
+          { error: 'Too many submissions. Please try again later.' },
+          { status: 429 }
+        )
+      }
+    } catch (err) {
+      console.error('Foundry rate-limit check failed (continuing open):', err)
+    }
+
     const body = await request.json()
+
+    // Honeypot: real users never see or fill this field. Bots that fill it
+    // get a success response and silence — no signal that they were caught.
+    if (typeof body.website === 'string' && body.website.trim() !== '') {
+      return NextResponse.json({ success: true, message: 'Application received.' })
+    }
+
     const input: FoundryApplicationInput = {
       name: String(body.name ?? '').slice(0, 200).trim(),
       email: String(body.email ?? '').slice(0, 200).trim(),

--- a/app/foundry/guide/page.tsx
+++ b/app/foundry/guide/page.tsx
@@ -6,6 +6,20 @@ export const metadata: Metadata = {
   description:
     'How to operate an installed business OS: day-1 onboarding, the 30-minute weekly rhythm, the quality gates, and how harness updates arrive. Written for founders, no AI background assumed.',
   alternates: { canonical: 'https://frankx.ai/foundry/guide' },
+  openGraph: {
+    title: 'The Operating Guide — FrankX Foundry',
+    description:
+      'Day-1 onboarding, the 30-minute weekly rhythm, the quality gates, and how harness updates arrive.',
+    url: 'https://frankx.ai/foundry/guide',
+    images: [
+      {
+        url: '/images/blog/agentic-os-family-hero.png',
+        width: 1200,
+        height: 675,
+        alt: 'The Foundry — operating systems forged for businesses',
+      },
+    ],
+  },
 }
 
 /** Long-form reading surface — narrow measure, slow cadence, no funnel. */

--- a/app/foundry/page.tsx
+++ b/app/foundry/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import Image from 'next/image'
 import { GlowCard } from '@/components/ui/glow-card'
 import { FoundryApplicationForm } from '@/components/foundry/FoundryApplicationForm'
 import { FOUNDRY_FAQS } from '@/lib/foundry-faqs'
@@ -14,6 +15,20 @@ export const metadata: Metadata = {
     description:
       'Complete AI operating systems, installed into businesses we believe in. Application-only.',
     url: 'https://frankx.ai/foundry',
+    images: [
+      {
+        url: '/images/blog/agentic-os-family-hero.png',
+        width: 1200,
+        height: 675,
+        alt: 'Molten energy being forged into a three-layer glass architecture — the Foundry metaphor',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'FrankX Foundry',
+    description: 'Complete AI operating systems, installed into businesses we believe in.',
+    images: ['/images/blog/agentic-os-family-hero.png'],
   },
 }
 
@@ -161,35 +176,50 @@ export default function FoundryPage() {
 
       {/* Hero */}
       <section className="mx-auto max-w-6xl px-6 pb-24 pt-28 lg:pt-36">
-        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
-          FrankX Foundry
-        </p>
-        <h1 className="max-w-3xl text-4xl font-bold tracking-tight text-white md:text-6xl">
-          We install operating systems into businesses we believe in.
-        </h1>
-        <p className="mt-6 max-w-2xl text-lg text-white/60">
-          A website, an AI-agent harness, pre-publish quality gates, and a business memory that
-          compounds — the same architecture that runs frankx.ai, derived for your brand and owned
-          by you. Installed in days, operated in thirty minutes a week, connected for the long run.
-        </p>
-        <div className="mt-10 flex flex-wrap items-center gap-4">
-          <Link
-            href="#apply"
-            className="rounded-full bg-white px-8 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
-          >
-            Apply for an Install
-          </Link>
-          <Link
-            href="/foundry/guide"
-            className="px-2 py-3.5 text-sm font-semibold text-white/60 transition-colors hover:text-white"
-          >
-            Read the operating guide
-          </Link>
+        <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-[1fr,400px]">
+          <div>
+            <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+              FrankX Foundry
+            </p>
+            <h1 className="max-w-3xl text-4xl font-bold tracking-tight text-white md:text-6xl">
+              We install operating systems into businesses we believe in.
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg text-white/60">
+              A website, an AI-agent harness, pre-publish quality gates, and a business memory that
+              compounds — the same architecture that runs frankx.ai, derived for your brand and
+              owned by you. Installed in days, operated in thirty minutes a week, connected for the
+              long run.
+            </p>
+            <div className="mt-10 flex flex-wrap items-center gap-4">
+              <Link
+                href="#apply"
+                className="rounded-full bg-white px-8 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+              >
+                Apply for an Install
+              </Link>
+              <Link
+                href="/foundry/guide"
+                className="px-2 py-3.5 text-sm font-semibold text-white/60 transition-colors hover:text-white"
+              >
+                Read the operating guide
+              </Link>
+            </div>
+            <p className="mt-8 font-mono text-xs text-white/50">
+              Founding cohort forming · limited installs per quarter · priority: sustainable,
+              healthcare, meaningful
+            </p>
+          </div>
+          <div className="hidden lg:block">
+            <Image
+              src="/images/blog/agentic-os-family-hero.png"
+              alt="Molten emerald energy being forged into a precise three-layer glass architecture"
+              width={800}
+              height={450}
+              priority
+              className="rounded-3xl border border-white/10 shadow-[0_20px_60px_-12px_rgba(0,0,0,0.6)]"
+            />
+          </div>
         </div>
-        <p className="mt-8 font-mono text-xs text-white/40">
-          Founding cohort forming · limited installs per quarter · priority: sustainable, healthcare,
-          meaningful
-        </p>
       </section>
 
       {/* The architecture — three layers, all inspectable */}

--- a/app/os/page.tsx
+++ b/app/os/page.tsx
@@ -15,6 +15,7 @@ import {
   Zap,
   Layers,
   LineChart,
+  Hammer,
 } from 'lucide-react'
 import { FrankXOSHeader } from '@/components/os/FrankXOSHeader'
 import { osModules, osCRM, type OSModule, type ModuleColor, type ModulePhase } from '@/data/os-modules'
@@ -48,7 +49,7 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://frankx.ai/os' },
 }
 
-const ICON_MAP = { Video, Users, Film, Cpu, Building2, BookOpen, Zap, LineChart }
+const ICON_MAP = { Video, Users, Film, Cpu, Building2, BookOpen, Zap, LineChart, Hammer }
 
 const COLOR_TOKENS: Record<ModuleColor, { ring: string; text: string; bg: string; glow: string }> = {
   cyan: {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -120,6 +120,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: '/creators', priority: 0.8, changeFrequency: 'monthly' as const },
     { url: '/students', priority: 0.8, changeFrequency: 'monthly' as const },
     { url: '/music-lab', priority: 0.8, changeFrequency: 'weekly' as const },
+    { url: '/foundry', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/foundry/guide', priority: 0.7, changeFrequency: 'monthly' as const },
   ]
 
   // Tool pages

--- a/app/work-with-me/StudioClient.tsx
+++ b/app/work-with-me/StudioClient.tsx
@@ -276,6 +276,34 @@ function ServicesSection() {
   )
 }
 
+function FoundrySection() {
+  return (
+    <section className="border-t border-white/5 py-20 md:py-28">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl">
+          <p className="text-[11px] tracking-[0.25em] uppercase text-emerald-400/60 font-medium mb-3">
+            Beyond Advisory
+          </p>
+          <h2 className="text-3xl font-bold text-white tracking-tight mb-3">
+            Some businesses need an operating system, not a session.
+          </h2>
+          <p className="text-white/60 text-base mb-6">
+            The FrankX Foundry installs the full architecture — site, agent harness, quality
+            gates, compounding business memory — derived for your brand and owned by you.
+            Application-only, a small number of installs per quarter.
+          </p>
+          <Link
+            href="/foundry"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-400 hover:text-emerald-300 transition-colors"
+          >
+            Explore the Foundry <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 function IndustriesSection() {
   const shouldReduceMotion = useReducedMotion()
   return (
@@ -568,6 +596,7 @@ export default function StudioClient() {
       <main className="relative">
         <HeroSection />
         <ServicesSection />
+        <FoundrySection />
         <IndustriesSection />
         <MethodologySection />
         <ProofPointsSection />

--- a/components/foundry/FoundryApplicationForm.tsx
+++ b/components/foundry/FoundryApplicationForm.tsx
@@ -21,6 +21,7 @@ export function FoundryApplicationForm() {
     building: '',
     why: '',
     stage: '',
+    website: '', // honeypot — hidden from humans, bots fill it
   })
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState('')
@@ -49,7 +50,10 @@ export function FoundryApplicationForm() {
 
   if (status === 'success') {
     return (
-      <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-8 text-center">
+      <div
+        aria-live="polite"
+        className="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-8 text-center"
+      >
         <p className="text-lg font-semibold text-white">Application received.</p>
         <p className="mt-2 text-sm text-white/60">
           Frank reads every one personally — you&apos;ll hear back within a few days, and a
@@ -61,6 +65,18 @@ export function FoundryApplicationForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
+      {/* Honeypot — visually hidden and excluded from the tab order */}
+      <div aria-hidden="true" className="absolute -left-[9999px] top-auto h-px w-px overflow-hidden">
+        <label htmlFor="foundry-website">Website</label>
+        <input
+          id="foundry-website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={form.website}
+          onChange={set('website')}
+        />
+      </div>
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
         <div>
           <label htmlFor="foundry-name" className="mb-2 block text-sm font-medium text-white/70">
@@ -186,11 +202,13 @@ export function FoundryApplicationForm() {
         {status === 'loading' ? 'Submitting…' : 'Submit Application'}
       </button>
 
-      {status === 'error' && errorMessage && (
-        <p className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-400">
-          {errorMessage}
-        </p>
-      )}
+      <div aria-live="polite">
+        {status === 'error' && errorMessage && (
+          <p className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-400">
+            {errorMessage}
+          </p>
+        )}
+      </div>
 
       <p className="text-xs text-white/40">
         Applications are read personally. You get one confirmation email and a decision — nothing

--- a/components/inner-circle/InnerCircleShell.tsx
+++ b/components/inner-circle/InnerCircleShell.tsx
@@ -596,6 +596,28 @@ export default function InnerCircleShell() {
               <PricingCard key={tier.name} tier={tier} index={index} />
             ))}
           </div>
+
+          {/* Foundry cross-link — the install path for founders */}
+          <div className="mx-auto mb-12 max-w-3xl rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-6 sm:p-8">
+            <p className="text-[11px] tracking-[0.25em] uppercase text-emerald-400/60 font-medium mb-2">
+              Building a business?
+            </p>
+            <h3 className="text-xl font-bold text-white mb-2">
+              The Foundry installs an operating system instead.
+            </h3>
+            <p className="text-sm text-white/60 mb-4">
+              Alliance-grade depth for one company: a complete agentic business OS — site, harness,
+              gates, memory — derived for your brand and owned by your team. Evaluated
+              applications only.
+            </p>
+            <Link
+              href="/foundry"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-400 hover:text-emerald-300 transition-colors"
+            >
+              Learn about the Foundry <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+
         </div>
       </section>
 


### PR DESCRIPTION
Closes every Tier-1 finding from the two-agent excellence audit. Mirrors FrankX `70218574`.

- **fix:** `Hammer` icon registered in /os ICON_MAP (foundry module was falling back to Sparkles)
- **OG/twitter cards** on /foundry + /foundry/guide (NB Pro forge render, 1200×675)
- **Hero visual anchor** on /foundry — next/image, lg-only, priority
- **Rate limit** (leadRatelimit 10/h, fail-open on KV outage) + **silent honeypot** on the apply endpoint
- **a11y:** aria-live on form error/success
- **Sitemap:** explicit /foundry (0.9) + /foundry/guide (0.7)
- **Cross-links:** FoundrySection on /work-with-me · emerald callout under /inner-circle pricing
- Hero meta contrast /40 → /50

Gates on source: tsc fully clean, links:check:static green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Foundry landing page with responsive hero layout and imagery
  * Introduced Foundry application form for user submissions
  * Integrated Foundry cross-links in membership pathway and studio services sections
  * Added Foundry and guide pages to sitemap for search engine discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->