### PR TITLE
fix(dare/watch): verified video IDs + curated watch vault

### DIFF
--- a/app/dare/page.tsx
+++ b/app/dare/page.tsx
@@ -395,10 +395,17 @@ function DareVideo({
   const [isPlaying, setIsPlaying] = useState(false)
   // maxres doesn't exist for every video; fall back to hqdefault (always present)
   // on error so the thumbnail never renders broken.
-  const [thumb, setThumb] = useState(
-    `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
-  )
+  const maxres = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
+  const hqdefault = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`
+  const [thumb, setThumb] = useState(maxres)
   const watchUrl = `https://www.youtube.com/watch?v=${videoId}`
+
+  // Reset to the high-res thumbnail (and stop playback) if the video changes,
+  // since useState only seeds on mount.
+  useEffect(() => {
+    setThumb(`https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`)
+    setIsPlaying(false)
+  }, [videoId])
 
   return (
     <div className="rounded-xl overflow-hidden border border-white/10">
@@ -420,9 +427,10 @@ function DareVideo({
               sizes="(max-width: 768px) 100vw, 672px"
               className="object-cover"
               unoptimized
-              onError={() =>
-                setThumb(`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`)
-              }
+              onError={() => {
+                // Guard against an onError loop if hqdefault also 404s.
+                if (thumb !== hqdefault) setThumb(hqdefault)
+              }}
             />
             <button
               onClick={() => setIsPlaying(true)}

--- a/app/dare/page.tsx
+++ b/app/dare/page.tsx
@@ -393,13 +393,19 @@ function DareVideo({
   channel?: string
 }) {
   const [isPlaying, setIsPlaying] = useState(false)
+  // maxres doesn't exist for every video; fall back to hqdefault (always present)
+  // on error so the thumbnail never renders broken.
+  const [thumb, setThumb] = useState(
+    `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
+  )
+  const watchUrl = `https://www.youtube.com/watch?v=${videoId}`
 
   return (
     <div className="rounded-xl overflow-hidden border border-white/10">
       <div className="relative aspect-video bg-black/50">
         {isPlaying ? (
           <iframe
-            src={`https://www.youtube.com/embed/${videoId}?autoplay=1`}
+            src={`https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`}
             className="absolute inset-0 w-full h-full"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
@@ -408,11 +414,15 @@ function DareVideo({
         ) : (
           <>
             <Image
-              src={`https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`}
+              src={thumb}
               alt={title}
               fill
               sizes="(max-width: 768px) 100vw, 672px"
               className="object-cover"
+              unoptimized
+              onError={() =>
+                setThumb(`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`)
+              }
             />
             <button
               onClick={() => setIsPlaying(true)}
@@ -431,6 +441,19 @@ function DareVideo({
           </>
         )}
       </div>
+      {/* Always-present escape hatch: some videos disable embedding, and this
+          guarantees the dare's video is reachable even when the iframe can't load. */}
+      <a
+        href={watchUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between gap-2 px-3 py-2 bg-black/40 text-xs text-white/40 hover:text-white/70 transition-colors"
+      >
+        <span className="truncate">{title}</span>
+        <span className="inline-flex items-center gap-1 shrink-0">
+          Watch on YouTube <ArrowRight className="w-3 h-3" />
+        </span>
+      </a>
     </div>
   )
 }

--- a/data/daily-dares.ts
+++ b/data/daily-dares.ts
@@ -184,8 +184,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Learn anything with the Feynman loop',
       body: 'Pick the skill your aim requires. The Feynman technique — explain, find the gap, go back, simplify — is the fastest known loop for real understanding. It\'s also exactly how you should be using AI: as the student you teach.',
-      videoId: 'zdkGXDq1jqM',
-      videoTitle: 'How to Learn Anything (Feynman Technique)',
+      videoId: 'MlJdMr3O5J4',
+      videoTitle: 'How to Study Way More Effectively (Feynman Technique)',
       videoChannel: 'Freedom in Thought',
     },
     prompt: {
@@ -211,8 +211,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'The math of 1% better',
       body: 'One percent better every day is 37× better in a year — not motivation, arithmetic. James Clear walks the compounding logic that turns a definite aim into a daily unit of work.',
-      videoId: 'mNeXuCYiE0U',
-      videoTitle: '1% Better Every Day',
+      videoId: 'U_nzqnXWvSo',
+      videoTitle: 'Atomic Habits: How to Get 1% Better Every Day',
       videoChannel: 'James Clear',
     },
     prompt: {
@@ -268,7 +268,7 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'You are not done becoming',
       body: 'Psychologist Dan Gilbert\'s finding: people at every age believe they\'ve finished changing — and they\'re wrong every time. The "end of history illusion." Belief in a future self is not delusion; assuming you\'re finished is.',
-      videoId: 'Cqbleas1mmo',
+      videoId: 'XNbaR54Gpj4',
       videoTitle: 'The Psychology of Your Future Self',
       videoChannel: 'TED',
     },
@@ -405,8 +405,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Rick Rubin on the creative act',
       body: 'The most decorated producer alive can\'t play instruments and barely touches a mixing board. What he brings is trained imagination — taste, and the conviction to follow it. Watch what creation looks like when the instrument is the mind itself.',
-      videoId: 'n9iv24yI04nI',
-      videoTitle: 'Rick Rubin: The Creative Act',
+      videoId: 'sE1teB5bN-w',
+      videoTitle: 'Rick Rubin on the Creative Act',
       videoChannel: '60 Minutes',
     },
     prompt: {
@@ -433,7 +433,7 @@ export const dailyDares: DailyDare[] = [
       title: 'A model that dreams in video',
       body: 'Text in, moving world out. Whatever you think about generative video, sit with the fact that imagination — the prototyping of unreal scenes — is no longer exclusively biological. Your workshop just acquired power tools.',
       videoId: 'nbPbK1xYSNY',
-      videoTitle: 'OpenAI Sora: This is Insane!',
+      videoTitle: 'OpenAI Sora: The Age of AI Is Here!',
       videoChannel: 'Two Minute Papers',
     },
     prompt: {
@@ -459,9 +459,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Prompting as a visual language',
       body: 'Image models respond to the precision of your imagination: style, light, lens, mood. Learning to prompt well is learning to see what you\'re imagining clearly enough to describe it — which was always the hard part.',
-      videoId: '9WVZbitXbck',
-      videoTitle: 'Midjourney Complete Tutorial',
-      videoChannel: 'Midjourney Guide',
+      videoId: 'VUDjpOY3YeE',
+      videoTitle: "MidJourney Tutorial: Full Beginner's Guide",
     },
     prompt: {
       promptId: 'midjourney-abstract-art',
@@ -486,9 +485,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Writing songs with AI',
       body: 'Music is imagination you can hear. Watch how lyric and style prompts shape a generated song — then consider that focus, calm, and drive all have soundtracks, and you can now compose them.',
-      videoId: 'EIi5k9TJUvY',
-      videoTitle: 'Suno v4.5 Lyric Writing',
-      videoChannel: 'Suno AI',
+      videoId: 'sIx3LNV51bQ',
+      videoTitle: 'Suno V4.5: Complete AI Music Tutorial',
     },
     prompt: {
       promptId: 'suno-ambient-electronic',
@@ -569,8 +567,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Claude Code: instructions that become behavior',
       body: 'Developers write a file of standing instructions and the AI obeys it every session, automatically. Standing instructions that shape every future action — that\'s a system prompt, and you\'re running one too. Yours just isn\'t written down yet.',
-      videoId: 'Ta5g-OxjPO4',
-      videoTitle: 'Build Anything with Claude Code',
+      videoId: 'hq8J-nj_Sr0',
+      videoTitle: "Build Anything with Claude Code, Here's How",
       videoChannel: 'David Ondrej',
       learningPathSlug: 'claude-mastery',
     },
@@ -625,8 +623,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'The real secret of productivity',
       body: 'Ali Abdaal\'s honest take: the productive people aren\'t more disciplined, they\'ve built systems where the work mostly happens by default. Goals set the direction; the system does the carrying.',
-      videoId: 'H_lZr0BAWhM',
-      videoTitle: 'How I Think: The Real Secret of Productivity',
+      videoId: 'tQSKyvjsUuI',
+      videoTitle: 'My Complete Productivity System',
       videoChannel: 'Ali Abdaal',
     },
     prompt: {
@@ -762,9 +760,9 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Why you\'re actually tired',
       body: 'Most exhaustion isn\'t physical — it\'s decision fatigue, fragmented attention, and a nervous system that never downshifts. Understand the real causes and "I\'m too tired" loses most of its veto power.',
-      videoId: '1Edv43k15cY',
-      videoTitle: "The Real Reason You're Always Tired",
-      videoChannel: 'OptimalMind',
+      videoId: 'KyxYdicOzTg',
+      videoTitle: "Why You're Always Tired",
+      videoChannel: 'After Skool',
     },
     prompt: {
       promptId: 'health-fitness-ai-coe',
@@ -789,9 +787,9 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Finite and infinite games',
       body: 'Sinek\'s distinction changes what "failure" even means: in a finite game you lose; in an infinite game you only fall behind for a while. Your aim is an infinite game. Setbacks are scores, not verdicts.',
-      videoId: 'BSjQk-7j3X0',
-      videoTitle: 'The Infinite Game',
-      videoChannel: 'Simon Sinek',
+      videoId: '_osKgFwKoDQ',
+      videoTitle: 'The Finite and Infinite Games of Leadership',
+      videoChannel: 'Simon Sinek · Talks at Google',
     },
     prompt: {
       promptId: 'system-prompt-design',
@@ -925,8 +923,8 @@ export const dailyDares: DailyDare[] = [
     mindStretch: {
       title: 'Where this is all going',
       body: 'Altman on the trajectory of AI — the tools you\'ve been learning for thirty days are the earliest versions you\'ll ever use again. You\'re not late. You\'re absurdly early. Plan like it.',
-      videoId: '5MUvJv_sB64',
-      videoTitle: 'Sam Altman: The Future of AI',
+      videoId: 'jvqFAi7vkBc',
+      videoTitle: 'Sam Altman: OpenAI, GPT-5, Sora, Power & AGI',
       videoChannel: 'Lex Fridman',
     },
     prompt: {

--- a/data/video-cross-refs.json
+++ b/data/video-cross-refs.json
@@ -47,17 +47,13 @@
     "KrRD7r7y7NY": [
       "ai-agents"
     ],
-    "5-2W--zGO0Y": [
+    "sPzc6hMg7So": [
       "ai-agents"
     ],
     "o0Fc5_zHvzo": [
       "ai-agents"
     ],
-    "EIi5k9TJUvY": [
-      "music-production",
-      "creative-ai"
-    ],
-    "jDHMPSSgaMw": [
+    "sIx3LNV51bQ": [
       "music-production",
       "creative-ai"
     ],
@@ -67,19 +63,16 @@
     "1bZ0OSEViyo": [
       "music-production"
     ],
-    "9WVZbitXbck": [
+    "VUDjpOY3YeE": [
       "creative-ai"
     ],
-    "n9iv24yI04nI": [
+    "sE1teB5bN-w": [
       "creative-ai"
-    ],
-    "5MUvJv_sB64": [
-      "strategy"
-    ],
-    "BSjQk-7j3X0": [
-      "strategy"
     ],
     "jvqFAi7vkBc": [
+      "strategy"
+    ],
+    "_osKgFwKoDQ": [
       "strategy"
     ],
     "CBYhVcO4WgI": [
@@ -88,16 +81,10 @@
     "0wIUK0nsyUg": [
       "strategy"
     ],
-    "tqfPCE_gfuc": [
-      "strategy"
-    ],
     "BZ2nSULolKI": [
       "creator-economy"
     ],
-    "cNGpxfcDKms": [
-      "creator-economy"
-    ],
-    "H_lZr0BAWhM": [
+    "tQSKyvjsUuI": [
       "creator-economy"
     ],
     "BBAuhqvT_ds": [
@@ -106,7 +93,7 @@
     "RKXZ7t_RiOE": [
       "creator-economy"
     ],
-    "Cqbleas1mmo": [
+    "XNbaR54Gpj4": [
       "mindset"
     ],
     "arj7oStGLkU": [
@@ -115,7 +102,7 @@
     "yb5zpo5WDG4": [
       "mindset"
     ],
-    "mNeXuCYiE0U": [
+    "U_nzqnXWvSo": [
       "mindset"
     ],
     "heh5XLwZVOY": [
@@ -124,7 +111,7 @@
     "aircAruvnKk": [
       "learning"
     ],
-    "zdkGXDq1jqM": [
+    "MlJdMr3O5J4": [
       "learning"
     ],
     "kCc8FmEb1nY": [
@@ -133,7 +120,7 @@
     "3E7hkPZ-HTk": [
       "learning"
     ],
-    "1Edv43k15cY": [
+    "KyxYdicOzTg": [
       "top-shorts"
     ]
   }

--- a/data/video-cross-refs.json
+++ b/data/video-cross-refs.json
@@ -8,9 +8,6 @@
     ],
     "VMj-3S1tku0": [
       "karpathys-ai-vision-deep-dive"
-    ],
-    "jw_o0xr8MWU": [
-      "nvidia-gtc-2026-ai-architect-breakdown"
     ]
   },
   "blogToVideo": {
@@ -23,9 +20,7 @@
     "karpathys-ai-vision-deep-dive": [
       "VMj-3S1tku0"
     ],
-    "nvidia-gtc-2026-ai-architect-breakdown": [
-      "jw_o0xr8MWU"
-    ]
+    "nvidia-gtc-2026-ai-architect-breakdown": []
   },
   "videoToWatchlist": {
     "VMj-3S1tku0": [

--- a/data/video-library.json
+++ b/data/video-library.json
@@ -4,18 +4,33 @@
     "title": "Neural Networks: Zero to Hero",
     "author": "Andrej Karpathy",
     "category": "AI Architecture",
-    "personas": ["developer", "architect"],
-    "tags": ["neural networks", "first principles", "coding"],
+    "personas": [
+      "developer",
+      "architect"
+    ],
+    "tags": [
+      "neural networks",
+      "first principles",
+      "coding"
+    ],
     "description": "The gold standard for understanding AI. Karpathy builds a neural net from scratch in Python.",
     "featured": true
   },
   {
     "id": "zjkBMFhNj_g",
-    "title": "Intro to Large Language Models",
+    "title": "[1hr Talk] Intro to Large Language Models",
     "author": "Andrej Karpathy",
     "category": "AI Architecture",
-    "personas": ["developer", "architect", "student"],
-    "tags": ["llm", "intro", "education"],
+    "personas": [
+      "developer",
+      "architect",
+      "student"
+    ],
+    "tags": [
+      "llm",
+      "intro",
+      "education"
+    ],
     "description": "Karpathy's accessible yet deep explanation of how LLMs work, from tokens to training.",
     "featured": true
   },
@@ -24,8 +39,15 @@
     "title": "Let's Build GPT from Scratch",
     "author": "Andrej Karpathy",
     "category": "AI Architecture",
-    "personas": ["developer", "architect"],
-    "tags": ["gpt", "transformer", "coding"],
+    "personas": [
+      "developer",
+      "architect"
+    ],
+    "tags": [
+      "gpt",
+      "transformer",
+      "coding"
+    ],
     "description": "Build a GPT model from scratch in Python. The definitive hands-on transformer tutorial.",
     "featured": true
   },
@@ -34,8 +56,16 @@
     "title": "Deep Dive into LLMs like ChatGPT",
     "author": "Andrej Karpathy",
     "category": "AI Architecture",
-    "personas": ["developer", "architect", "investor"],
-    "tags": ["llm", "chatgpt", "deep dive"],
+    "personas": [
+      "developer",
+      "architect",
+      "investor"
+    ],
+    "tags": [
+      "llm",
+      "chatgpt",
+      "deep dive"
+    ],
     "description": "Karpathy's comprehensive 3.5-hour exploration of modern LLM architectures and capabilities.",
     "featured": false
   },
@@ -44,8 +74,15 @@
     "title": "But What Is a Neural Network?",
     "author": "3Blue1Brown",
     "category": "AI Architecture",
-    "personas": ["student", "developer"],
-    "tags": ["math", "visualization", "neural networks"],
+    "personas": [
+      "student",
+      "developer"
+    ],
+    "tags": [
+      "math",
+      "visualization",
+      "neural networks"
+    ],
     "description": "Beautiful visual explanation of neural networks. The best starting point for visual learners.",
     "featured": true
   },
@@ -54,8 +91,15 @@
     "title": "Gradient Descent: How Neural Networks Learn",
     "author": "3Blue1Brown",
     "category": "AI Architecture",
-    "personas": ["student", "developer"],
-    "tags": ["math", "gradient descent", "backpropagation"],
+    "personas": [
+      "student",
+      "developer"
+    ],
+    "tags": [
+      "math",
+      "gradient descent",
+      "backpropagation"
+    ],
     "description": "Visual intuition for how neural networks learn through gradient descent.",
     "featured": false
   },
@@ -64,18 +108,32 @@
     "title": "Attention in Transformers, Visually Explained",
     "author": "3Blue1Brown",
     "category": "AI Architecture",
-    "personas": ["developer", "architect"],
-    "tags": ["attention", "transformers", "visualization"],
+    "personas": [
+      "developer",
+      "architect"
+    ],
+    "tags": [
+      "attention",
+      "transformers",
+      "visualization"
+    ],
     "description": "The attention mechanism that powers GPT, Claude, and every modern LLM — explained visually.",
     "featured": true
   },
   {
     "id": "eTTMUWP5B0s",
-    "title": "The State of AI Engineering",
+    "title": "Open Challenges for AI Engineering",
     "author": "Simon Willison",
     "category": "AI Engineering",
-    "personas": ["developer", "architect"],
-    "tags": ["llm", "engineering", "pragmatic"],
+    "personas": [
+      "developer",
+      "architect"
+    ],
+    "tags": [
+      "llm",
+      "engineering",
+      "pragmatic"
+    ],
     "description": "A pragmatic breakdown of what it means to be an AI Engineer in the modern era.",
     "featured": true
   },
@@ -84,8 +142,14 @@
     "title": "AI Tools Without the Hype",
     "author": "Simon Willison",
     "category": "AI Engineering",
-    "personas": ["developer"],
-    "tags": ["tools", "coding", "productivity"],
+    "personas": [
+      "developer"
+    ],
+    "tags": [
+      "tools",
+      "coding",
+      "productivity"
+    ],
     "description": "Cutting through the marketing noise to find tools that actually ship code.",
     "featured": false
   },
@@ -94,8 +158,15 @@
     "title": "LLMs on the Command Line",
     "author": "Simon Willison",
     "category": "AI Engineering",
-    "personas": ["developer", "architect"],
-    "tags": ["cli", "llm", "terminal"],
+    "personas": [
+      "developer",
+      "architect"
+    ],
+    "tags": [
+      "cli",
+      "llm",
+      "terminal"
+    ],
     "description": "Practical techniques for using LLMs directly from the terminal for development workflows.",
     "featured": false
   },
@@ -104,8 +175,15 @@
     "title": "What's Next for AI Agentic Workflows",
     "author": "Andrew Ng",
     "category": "AI Architecture",
-    "personas": ["architect", "developer"],
-    "tags": ["agents", "workflow", "design patterns"],
+    "personas": [
+      "architect",
+      "developer"
+    ],
+    "tags": [
+      "agents",
+      "workflow",
+      "design patterns"
+    ],
     "description": "Andrew Ng's influential talk on the four key agentic design patterns shaping AI development.",
     "featured": true
   },
@@ -114,48 +192,66 @@
     "title": "The Rise of AI Agents",
     "author": "Andrew Ng",
     "category": "AI Architecture",
-    "personas": ["architect", "investor"],
-    "tags": ["agents", "future", "autonomy"],
+    "personas": [
+      "architect",
+      "investor"
+    ],
+    "tags": [
+      "agents",
+      "future",
+      "autonomy"
+    ],
     "description": "Andrew Ng on why AI agents will be the next major paradigm shift in artificial intelligence.",
     "featured": true
   },
   {
-    "id": "Ta5g-OxjPO4",
-    "title": "Build Anything with Claude Code",
+    "id": "hq8J-nj_Sr0",
+    "title": "Build Anything with Claude Code, Here's How",
     "author": "David Ondrej",
     "category": "AI Engineering",
-    "personas": ["developer", "creator"],
-    "tags": ["claude", "coding", "tutorial"],
+    "personas": [
+      "developer",
+      "creator"
+    ],
+    "tags": [
+      "claude",
+      "coding",
+      "tutorial"
+    ],
     "description": "A hands-on build log showing the raw power of Claude's agentic coding capabilities.",
     "featured": false
-  },
-  {
-    "id": "5MUvJv_sB64",
-    "title": "Sam Altman: The Future of AI",
-    "author": "Lex Fridman",
-    "category": "Strategy",
-    "personas": ["investor", "architect"],
-    "tags": ["agi", "future", "openai"],
-    "description": "A deep conversation on the trajectory of AGI and the societal shifts coming next.",
-    "featured": true
   },
   {
     "id": "jvqFAi7vkBc",
     "title": "Sam Altman: GPT-5, Sora, Board Saga, AGI",
     "author": "Lex Fridman",
     "category": "Strategy",
-    "personas": ["investor", "architect"],
-    "tags": ["openai", "gpt5", "agi"],
-    "description": "Lex Fridman's most popular Sam Altman interview — covering GPT-5, Sora, the board crisis, and AGI.",
+    "personas": [
+      "investor",
+      "architect"
+    ],
+    "tags": [
+      "agi",
+      "future",
+      "openai"
+    ],
+    "description": "A deep conversation on the trajectory of AGI and the societal shifts coming next.",
     "featured": true
   },
   {
     "id": "JN3KPFbWCy8",
-    "title": "Elon Musk: War, AI, Aliens, Humanity",
+    "title": "Elon Musk: War, AI, Aliens, Humanity (Lex #400)",
     "author": "Lex Fridman",
     "category": "Strategy",
-    "personas": ["investor", "architect"],
-    "tags": ["tesla", "spacex", "ai"],
+    "personas": [
+      "investor",
+      "architect"
+    ],
+    "tags": [
+      "tesla",
+      "spacex",
+      "ai"
+    ],
     "description": "A wide-ranging conversation with Elon Musk on technology, AI, and humanity's future.",
     "featured": false
   },
@@ -164,8 +260,15 @@
     "title": "Demis Hassabis: DeepMind & Superintelligence",
     "author": "Lex Fridman",
     "category": "Strategy",
-    "personas": ["architect", "investor"],
-    "tags": ["deepmind", "agi", "science"],
+    "personas": [
+      "architect",
+      "investor"
+    ],
+    "tags": [
+      "deepmind",
+      "agi",
+      "science"
+    ],
     "description": "DeepMind CEO on the path to superintelligence, AlphaFold, and the future of AI research.",
     "featured": false
   },
@@ -174,38 +277,66 @@
     "title": "Andrej Karpathy: Tesla AI, Self-Driving, AGI",
     "author": "Lex Fridman",
     "category": "Strategy",
-    "personas": ["architect", "developer"],
-    "tags": ["tesla", "autonomy", "agi"],
+    "personas": [
+      "architect",
+      "developer"
+    ],
+    "tags": [
+      "tesla",
+      "autonomy",
+      "agi"
+    ],
     "description": "Karpathy's 3.5-hour conversation with Lex on Tesla's AI stack, Optimus, and the road to AGI.",
     "featured": false
   },
   {
-    "id": "BSjQk-7j3X0",
-    "title": "The Infinite Game",
+    "id": "_osKgFwKoDQ",
+    "title": "The Finite and Infinite Games of Leadership",
     "author": "Simon Sinek",
     "category": "Strategy",
-    "personas": ["investor", "architect"],
-    "tags": ["business", "mindset", "long-term"],
+    "personas": [
+      "investor",
+      "architect"
+    ],
+    "tags": [
+      "business",
+      "mindset",
+      "long-term"
+    ],
     "description": "Why we are playing the wrong game in business and how to shift to an infinite mindset.",
     "featured": true
   },
   {
     "id": "CBYhVcO4WgI",
-    "title": "How to Start a Startup (Lecture 1)",
+    "title": "How to Start a Startup — Lecture 1",
     "author": "Y Combinator",
     "category": "Strategy",
-    "personas": ["investor", "creator"],
-    "tags": ["startup", "yc", "business"],
+    "personas": [
+      "investor",
+      "creator"
+    ],
+    "tags": [
+      "startup",
+      "yc",
+      "business"
+    ],
     "description": "The legendary first lecture from YC's startup school with Sam Altman and Dustin Moskovitz.",
     "featured": true
   },
   {
     "id": "0wIUK0nsyUg",
-    "title": "AI Will Save The World",
+    "title": "AI Will Save the World — Andreessen & Casado",
     "author": "a16z",
     "category": "Strategy",
-    "personas": ["investor", "architect"],
-    "tags": ["optimism", "future", "venture"],
+    "personas": [
+      "investor",
+      "architect"
+    ],
+    "tags": [
+      "optimism",
+      "future",
+      "venture"
+    ],
     "description": "Marc Andreessen's case for AI optimism and why technology will solve humanity's biggest problems.",
     "featured": false
   },
@@ -214,18 +345,32 @@
     "title": "The One-Person Business Model",
     "author": "Dan Koe",
     "category": "Creator Economy",
-    "personas": ["creator", "investor"],
-    "tags": ["solo", "business", "creator"],
+    "personas": [
+      "creator",
+      "investor"
+    ],
+    "tags": [
+      "solo",
+      "business",
+      "creator"
+    ],
     "description": "How to productize yourself and build a one-person business that scales without employees.",
     "featured": true
   },
   {
-    "id": "H_lZr0BAWhM",
-    "title": "How I Think: The Real Secret of Productivity",
+    "id": "tQSKyvjsUuI",
+    "title": "My Complete Productivity System",
     "author": "Ali Abdaal",
     "category": "Creator Economy",
-    "personas": ["creator", "student"],
-    "tags": ["productivity", "systems", "thinking"],
+    "personas": [
+      "creator",
+      "student"
+    ],
+    "tags": [
+      "productivity",
+      "systems",
+      "thinking"
+    ],
     "description": "Ali Abdaal's framework for productive thinking and building creator systems.",
     "featured": true
   },
@@ -234,18 +379,32 @@
     "title": "Pricing Design Work & Creativity",
     "author": "Chris Do",
     "category": "Creativity",
-    "personas": ["creator", "investor"],
-    "tags": ["pricing", "design", "business"],
+    "personas": [
+      "creator",
+      "investor"
+    ],
+    "tags": [
+      "pricing",
+      "design",
+      "business"
+    ],
     "description": "Chris Do's masterclass on pricing creative work and communicating design value.",
     "featured": false
   },
   {
-    "id": "n9iv24yI04nI",
-    "title": "Rick Rubin: The Creative Act",
+    "id": "sE1teB5bN-w",
+    "title": "Rick Rubin on the Creative Act",
     "author": "60 Minutes",
     "category": "Creativity",
-    "personas": ["creator", "artist"],
-    "tags": ["mindset", "art", "philosophy"],
+    "personas": [
+      "creator",
+      "artist"
+    ],
+    "tags": [
+      "mindset",
+      "art",
+      "philosophy"
+    ],
     "description": "Legendary producer Rick Rubin on listening to the universe and removing the ego from creation.",
     "featured": true
   },
@@ -254,18 +413,32 @@
     "title": "The Real Reason Why Music Is Getting Worse",
     "author": "Rick Beato",
     "category": "Creativity",
-    "personas": ["creator", "artist"],
-    "tags": ["music", "industry", "quality"],
+    "personas": [
+      "creator",
+      "artist"
+    ],
+    "tags": [
+      "music",
+      "industry",
+      "quality"
+    ],
     "description": "Rick Beato's analysis of why modern music production has degraded — and what to do about it.",
     "featured": false
   },
   {
-    "id": "Cqbleas1mmo",
+    "id": "XNbaR54Gpj4",
     "title": "The Psychology of Your Future Self",
     "author": "Dr. Hal Hershfield",
     "category": "Mindset",
-    "personas": ["student", "investor"],
-    "tags": ["psychology", "planning", "vision"],
+    "personas": [
+      "student",
+      "investor"
+    ],
+    "tags": [
+      "psychology",
+      "planning",
+      "vision"
+    ],
     "description": "Connecting with your future self to make better long-term decisions today.",
     "featured": false
   },
@@ -274,8 +447,16 @@
     "title": "Focus Toolkit: Tools to Improve Focus",
     "author": "Huberman Lab",
     "category": "Mindset",
-    "personas": ["developer", "creator", "student"],
-    "tags": ["focus", "neuroscience", "tools"],
+    "personas": [
+      "developer",
+      "creator",
+      "student"
+    ],
+    "tags": [
+      "focus",
+      "neuroscience",
+      "tools"
+    ],
     "description": "Andrew Huberman's evidence-based toolkit for improving focus and attention.",
     "featured": true
   },
@@ -284,49 +465,85 @@
     "title": "Inside the Mind of a Master Procrastinator",
     "author": "Tim Urban",
     "category": "Mindset",
-    "personas": ["student", "creator"],
-    "tags": ["procrastination", "humor", "psychology"],
+    "personas": [
+      "student",
+      "creator"
+    ],
+    "tags": [
+      "procrastination",
+      "humor",
+      "psychology"
+    ],
     "description": "The most-watched TED talk on procrastination. Funny, relatable, and surprisingly deep.",
     "featured": true
   },
   {
-    "id": "mNeXuCYiE0U",
-    "title": "1% Better Every Day",
+    "id": "U_nzqnXWvSo",
+    "title": "Atomic Habits: How to Get 1% Better Every Day",
     "author": "James Clear",
     "category": "Mindset",
-    "personas": ["student", "creator"],
-    "tags": ["habits", "growth", "compound"],
+    "personas": [
+      "student",
+      "creator"
+    ],
+    "tags": [
+      "habits",
+      "growth",
+      "compound"
+    ],
     "description": "James Clear's Atomic Habits framework distilled into a single powerful talk.",
     "featured": false
   },
   {
-    "id": "zdkGXDq1jqM",
-    "title": "How to Learn Anything (Feynman Technique)",
+    "id": "MlJdMr3O5J4",
+    "title": "How to Study Way More Effectively (Feynman Technique)",
     "author": "Freedom in Thought",
     "category": "Learning",
-    "personas": ["student", "creator"],
-    "tags": ["learning", "mental models", "growth"],
+    "personas": [
+      "student",
+      "creator"
+    ],
+    "tags": [
+      "learning",
+      "mental models",
+      "growth"
+    ],
     "description": "Master the art of learning with the Feynman technique. Essential for keeping up with AI velocity.",
     "featured": false
   },
   {
     "id": "jfKfPfyJRdk",
-    "title": "Lofi Hip Hop Radio - Beats to Study To",
+    "title": "Lofi Hip Hop Radio — Beats to Relax/Study To",
     "author": "Lofi Girl",
     "category": "Rituals",
-    "personas": ["student", "developer"],
-    "tags": ["music", "focus", "background"],
+    "personas": [
+      "student",
+      "developer"
+    ],
+    "tags": [
+      "music",
+      "focus",
+      "background"
+    ],
     "description": "The internet's favorite focus companion. Perfect for coding blocks.",
     "featured": false,
     "isRitual": true
   },
   {
     "id": "1_G60OdEzXs",
-    "title": "Binaural Beats: Deep Focus",
+    "title": "40 Hz Binaural Beats: Focus, Memory, Concentration",
     "author": "Binaural Beats",
     "category": "Rituals",
-    "personas": ["creator", "developer", "student"],
-    "tags": ["binaural", "focus", "music"],
+    "personas": [
+      "creator",
+      "developer",
+      "student"
+    ],
+    "tags": [
+      "binaural",
+      "focus",
+      "music"
+    ],
     "description": "40Hz binaural beats designed for deep focus and flow state during intense work sessions.",
     "featured": true,
     "isRitual": true
@@ -336,18 +553,30 @@
     "title": "Harry Potter by Balenciaga",
     "author": "demonflyingfox",
     "category": "AI Memes",
-    "personas": ["creator"],
-    "tags": ["balenciaga", "fashion", "viral"],
+    "personas": [
+      "creator"
+    ],
+    "tags": [
+      "balenciaga",
+      "fashion",
+      "viral"
+    ],
     "description": "The viral AI video that started the Balenciaga meme trend. Peak internet absurdism.",
     "featured": true
   },
   {
     "id": "q6ra0KDgVbg",
-    "title": "Presidents Play Wii Sports Golf",
+    "title": "US Presidents Play Wii Sports Golf",
     "author": "AI Presidents",
     "category": "AI Memes",
-    "personas": ["creator"],
-    "tags": ["presidents", "gaming", "parody"],
+    "personas": [
+      "creator"
+    ],
+    "tags": [
+      "presidents",
+      "gaming",
+      "parody"
+    ],
     "description": "AI-generated presidents competing at Wii Sports. Surprisingly wholesome meme content.",
     "featured": true
   }

--- a/data/video-vault-100.json
+++ b/data/video-vault-100.json
@@ -5,19 +5,27 @@
     "channel": "Andrej Karpathy",
     "url": "https://www.youtube.com/watch?v=VMj-3S1tku0",
     "duration": "2:25:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["neural networks", "coding", "education"]
+    "tags": [
+      "neural networks",
+      "coding",
+      "education"
+    ]
   },
   {
     "id": "zjkBMFhNj_g",
-    "title": "Intro to Large Language Models",
+    "title": "[1hr Talk] Intro to Large Language Models",
     "channel": "Andrej Karpathy",
     "url": "https://www.youtube.com/watch?v=zjkBMFhNj_g",
     "duration": "1:00:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["llm", "intro", "education"]
+    "tags": [
+      "llm",
+      "intro",
+      "education"
+    ]
   },
   {
     "id": "kCc8FmEb1nY",
@@ -25,9 +33,13 @@
     "channel": "Andrej Karpathy",
     "url": "https://www.youtube.com/watch?v=kCc8FmEb1nY",
     "duration": "2:00:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["gpt", "coding", "transformer"]
+    "tags": [
+      "gpt",
+      "coding",
+      "transformer"
+    ]
   },
   {
     "id": "7xTGNNLPyMI",
@@ -35,9 +47,13 @@
     "channel": "Andrej Karpathy",
     "url": "https://www.youtube.com/watch?v=7xTGNNLPyMI",
     "duration": "3:30:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["llm", "chatgpt", "deep dive"]
+    "tags": [
+      "llm",
+      "chatgpt",
+      "deep dive"
+    ]
   },
   {
     "id": "aircAruvnKk",
@@ -45,9 +61,13 @@
     "channel": "3Blue1Brown",
     "url": "https://www.youtube.com/watch?v=aircAruvnKk",
     "duration": "0:19:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["math", "visualization", "learning"]
+    "tags": [
+      "math",
+      "visualization",
+      "learning"
+    ]
   },
   {
     "id": "IHZwWFHWa-w",
@@ -55,9 +75,13 @@
     "channel": "3Blue1Brown",
     "url": "https://www.youtube.com/watch?v=IHZwWFHWa-w",
     "duration": "0:21:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["math", "gradient descent", "backprop"]
+    "tags": [
+      "math",
+      "gradient descent",
+      "backprop"
+    ]
   },
   {
     "id": "eMlx5fFNoYc",
@@ -65,9 +89,13 @@
     "channel": "3Blue1Brown",
     "url": "https://www.youtube.com/watch?v=eMlx5fFNoYc",
     "duration": "0:26:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["attention", "transformers", "visualization"]
+    "tags": [
+      "attention",
+      "transformers",
+      "visualization"
+    ]
   },
   {
     "id": "nbPbK1xYSNY",
@@ -75,21 +103,14 @@
     "channel": "Two Minute Papers",
     "url": "https://www.youtube.com/watch?v=nbPbK1xYSNY",
     "duration": "0:08:00",
-    "topic": "AI Fundamentals",
+    "topic": "AI Foundations",
     "embeddable": true,
-    "tags": ["sora", "video generation", "research"]
+    "tags": [
+      "sora",
+      "video generation",
+      "research"
+    ]
   },
-  {
-    "id": "dWr1eTeK6p4",
-    "title": "Deep Dive into LLMs",
-    "channel": "Andrej Karpathy",
-    "url": "https://www.youtube.com/watch?v=dWr1eTeK6p4",
-    "duration": "1:00:00",
-    "topic": "LLM Fundamentals",
-    "embeddable": true,
-    "tags": ["llm", "architecture", "deep dive"]
-  },
-
   {
     "id": "sal78ACtGTc",
     "title": "What's Next for AI Agentic Workflows",
@@ -98,7 +119,11 @@
     "duration": "0:26:00",
     "topic": "AI Agents",
     "embeddable": true,
-    "tags": ["agents", "workflow", "design patterns"]
+    "tags": [
+      "agents",
+      "workflow",
+      "design patterns"
+    ]
   },
   {
     "id": "KrRD7r7y7NY",
@@ -108,17 +133,25 @@
     "duration": "0:15:00",
     "topic": "AI Agents",
     "embeddable": true,
-    "tags": ["agents", "future", "autonomy"]
+    "tags": [
+      "agents",
+      "future",
+      "autonomy"
+    ]
   },
   {
-    "id": "5-2W--zGO0Y",
-    "title": "CrewAI Tutorial for Beginners",
+    "id": "sPzc6hMg7So",
+    "title": "CrewAI Tutorial: Complete Crash Course for Beginners",
     "channel": "CrewAI",
-    "url": "https://www.youtube.com/watch?v=5-2W--zGO0Y",
+    "url": "https://www.youtube.com/watch?v=sPzc6hMg7So",
     "duration": "0:30:00",
     "topic": "AI Agents",
     "embeddable": true,
-    "tags": ["crewai", "multi-agent", "tutorial"]
+    "tags": [
+      "crewai",
+      "multi-agent",
+      "tutorial"
+    ]
   },
   {
     "id": "o0Fc5_zHvzo",
@@ -128,18 +161,25 @@
     "duration": "0:20:00",
     "topic": "AI Agents",
     "embeddable": true,
-    "tags": ["deepseek", "reasoning", "r1"]
+    "tags": [
+      "deepseek",
+      "reasoning",
+      "r1"
+    ]
   },
-
   {
     "id": "eTTMUWP5B0s",
-    "title": "The State of AI Engineering",
+    "title": "Open Challenges for AI Engineering",
     "channel": "Simon Willison",
     "url": "https://www.youtube.com/watch?v=eTTMUWP5B0s",
     "duration": "0:45:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["engineering", "pragmatic", "llm"]
+    "tags": [
+      "engineering",
+      "pragmatic",
+      "llm"
+    ]
   },
   {
     "id": "uRuLgar5XZw",
@@ -149,7 +189,11 @@
     "duration": "0:40:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["tools", "productivity", "coding"]
+    "tags": [
+      "tools",
+      "productivity",
+      "coding"
+    ]
   },
   {
     "id": "QUXQNi6jQ30",
@@ -159,7 +203,11 @@
     "duration": "0:15:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["cli", "llm", "terminal"]
+    "tags": [
+      "cli",
+      "llm",
+      "terminal"
+    ]
   },
   {
     "id": "ORMx45xqWkA",
@@ -169,149 +217,109 @@
     "duration": "0:03:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["pytorch", "quickstart", "ml"]
+    "tags": [
+      "pytorch",
+      "quickstart",
+      "ml"
+    ]
   },
   {
-    "id": "Kzf-tL8zyfo",
-    "title": "O3 Just BROKE the AI Ceiling",
+    "id": "CMjQKaoGJoc",
+    "title": "OpenAI is Back on Top",
     "channel": "Theo - t3.gg",
-    "url": "https://www.youtube.com/watch?v=Kzf-tL8zyfo",
+    "url": "https://www.youtube.com/watch?v=CMjQKaoGJoc",
     "duration": "0:18:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["o3", "benchmarks", "analysis"]
+    "tags": [
+      "o3",
+      "benchmarks",
+      "analysis"
+    ]
   },
   {
-    "id": "2ftykwXA408",
-    "title": "Enterprise Agents on OCI",
-    "channel": "Oracle Cloud",
-    "url": "https://www.youtube.com/watch?v=2ftykwXA408",
+    "id": "eIkj4H-S_FQ",
+    "title": "Build Agentic AI Solutions with OCI AI Agent Framework",
+    "channel": "Oracle",
+    "url": "https://www.youtube.com/watch?v=eIkj4H-S_FQ",
     "duration": "0:20:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["oracle", "enterprise", "agents"]
-  },
-  {
-    "id": "vcBD0hn48ig",
-    "title": "2026 AI Infrastructure Stack",
-    "channel": "The AI Grid",
-    "url": "https://www.youtube.com/watch?v=vcBD0hn48ig",
-    "duration": "0:15:00",
-    "topic": "AI Engineering",
-    "embeddable": true,
-    "tags": ["stack", "infrastructure", "chips"]
+    "tags": [
+      "oracle",
+      "enterprise",
+      "agents"
+    ]
   },
   {
     "id": "tNZnLkRBYA8",
-    "title": "ThePrimeagen: Coding, Vim, and AI",
+    "title": "ThePrimeagen: Programming, AI, Productivity (Lex #461)",
     "channel": "Lex Fridman",
     "url": "https://www.youtube.com/watch?v=tNZnLkRBYA8",
     "duration": "3:00:00",
     "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["coding", "vim", "engineering"]
+    "tags": [
+      "coding",
+      "vim",
+      "engineering"
+    ]
   },
-
   {
-    "id": "Ta5g-OxjPO4",
-    "title": "Build Anything with Claude Code",
+    "id": "hq8J-nj_Sr0",
+    "title": "Build Anything with Claude Code, Here's How",
     "channel": "David Ondrej",
-    "url": "https://www.youtube.com/watch?v=Ta5g-OxjPO4",
+    "url": "https://www.youtube.com/watch?v=hq8J-nj_Sr0",
     "duration": "0:35:00",
-    "topic": "AI Tools",
+    "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["claude", "coding", "tutorial"]
+    "tags": [
+      "claude",
+      "coding",
+      "tutorial"
+    ]
   },
   {
-    "id": "9GCWgebD-AU",
-    "title": "Claude 3.5 Sonnet Review",
+    "id": "ffbcU3RLml4",
+    "title": "Claude 3.5 Sonnet NEW is Really Good — Full Test",
     "channel": "Matthew Berman",
-    "url": "https://www.youtube.com/watch?v=9GCWgebD-AU",
+    "url": "https://www.youtube.com/watch?v=ffbcU3RLml4",
     "duration": "0:20:00",
-    "topic": "AI Tools",
+    "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["claude", "review", "anthropic"]
+    "tags": [
+      "claude",
+      "review",
+      "anthropic"
+    ]
   },
   {
     "id": "DeeVKUuEv6Y",
-    "title": "Best AI Tools for Marketers",
+    "title": "The Best AI Tools for Marketers (2024)",
     "channel": "Matt Wolfe",
     "url": "https://www.youtube.com/watch?v=DeeVKUuEv6Y",
     "duration": "0:15:00",
-    "topic": "AI Tools",
+    "topic": "AI Engineering",
     "embeddable": true,
-    "tags": ["tools", "marketing", "roundup"]
-  },
-
-  {
-    "id": "5MUvJv_sB64",
-    "title": "Sam Altman: The Future of AI",
-    "channel": "Lex Fridman",
-    "url": "https://www.youtube.com/watch?v=5MUvJv_sB64",
-    "duration": "2:15:00",
-    "topic": "Strategy",
-    "embeddable": true,
-    "tags": ["openai", "agi", "future"]
+    "tags": [
+      "tools",
+      "marketing",
+      "roundup"
+    ]
   },
   {
-    "id": "BSjQk-7j3X0",
-    "title": "The Infinite Game",
-    "channel": "Simon Sinek",
-    "url": "https://www.youtube.com/watch?v=BSjQk-7j3X0",
+    "id": "_osKgFwKoDQ",
+    "title": "The Finite and Infinite Games of Leadership",
+    "channel": "Simon Sinek · Talks at Google",
+    "url": "https://www.youtube.com/watch?v=_osKgFwKoDQ",
     "duration": "0:50:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["leadership", "long-term", "mindset"]
-  },
-  {
-    "id": "9g-wcfo091E",
-    "title": "AI ROI Strategy 2026",
-    "channel": "Bloomberg",
-    "url": "https://www.youtube.com/watch?v=9g-wcfo091E",
-    "duration": "0:18:00",
-    "topic": "Strategy",
-    "embeddable": true,
-    "tags": ["roi", "enterprise", "strategy"]
-  },
-  {
-    "id": "fL_l8mxU148",
-    "title": "5 AI Business Ideas 2026",
-    "channel": "Entrepreneur AI",
-    "url": "https://www.youtube.com/watch?v=fL_l8mxU148",
-    "duration": "0:15:00",
-    "topic": "Strategy",
-    "embeddable": true,
-    "tags": ["ideas", "startup", "monetization"]
-  },
-  {
-    "id": "OI0zRk7Mau4",
-    "title": "How to Maximize AI ROI",
-    "channel": "C-Suite AI",
-    "url": "https://www.youtube.com/watch?v=OI0zRk7Mau4",
-    "duration": "0:22:00",
-    "topic": "Strategy",
-    "embeddable": true,
-    "tags": ["business", "roi", "executive"]
-  },
-  {
-    "id": "SifHlXe7B2k",
-    "title": "AI Startup Pitch Demo",
-    "channel": "Y Combinator",
-    "url": "https://www.youtube.com/watch?v=SifHlXe7B2k",
-    "duration": "0:10:00",
-    "topic": "Strategy",
-    "embeddable": true,
-    "tags": ["startup", "pitch", "agents"]
-  },
-  {
-    "id": "tqfPCE_gfuc",
-    "title": "Building a $1B AI Company",
-    "channel": "Greylock",
-    "url": "https://www.youtube.com/watch?v=tqfPCE_gfuc",
-    "duration": "0:45:00",
-    "topic": "Strategy",
-    "embeddable": true,
-    "tags": ["business", "scaling", "vc"]
+    "tags": [
+      "leadership",
+      "long-term",
+      "mindset"
+    ]
   },
   {
     "id": "jvqFAi7vkBc",
@@ -319,29 +327,41 @@
     "channel": "Lex Fridman",
     "url": "https://www.youtube.com/watch?v=jvqFAi7vkBc",
     "duration": "2:02:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["openai", "gpt5", "agi"]
+    "tags": [
+      "openai",
+      "gpt5",
+      "agi"
+    ]
   },
   {
     "id": "L_Guz73e6fw",
-    "title": "Sam Altman: GPT-4, ChatGPT, Future of AI",
+    "title": "Sam Altman: GPT-4, ChatGPT, Future of AI (Lex #367)",
     "channel": "Lex Fridman",
     "url": "https://www.youtube.com/watch?v=L_Guz73e6fw",
     "duration": "2:28:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["openai", "chatgpt", "future"]
+    "tags": [
+      "openai",
+      "chatgpt",
+      "future"
+    ]
   },
   {
     "id": "JN3KPFbWCy8",
-    "title": "Elon Musk: War, AI, Aliens, Humanity",
+    "title": "Elon Musk: War, AI, Aliens, Humanity (Lex #400)",
     "channel": "Lex Fridman",
     "url": "https://www.youtube.com/watch?v=JN3KPFbWCy8",
     "duration": "2:27:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["tesla", "spacex", "ai"]
+    "tags": [
+      "tesla",
+      "spacex",
+      "ai"
+    ]
   },
   {
     "id": "Gfr50f6ZBvo",
@@ -349,9 +369,13 @@
     "channel": "Lex Fridman",
     "url": "https://www.youtube.com/watch?v=Gfr50f6ZBvo",
     "duration": "2:18:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["deepmind", "agi", "science"]
+    "tags": [
+      "deepmind",
+      "agi",
+      "science"
+    ]
   },
   {
     "id": "cdiD-9MMpb0",
@@ -359,29 +383,41 @@
     "channel": "Lex Fridman",
     "url": "https://www.youtube.com/watch?v=cdiD-9MMpb0",
     "duration": "3:34:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["tesla", "autonomy", "agi"]
+    "tags": [
+      "tesla",
+      "autonomy",
+      "agi"
+    ]
   },
   {
     "id": "CBYhVcO4WgI",
-    "title": "How to Start a Startup (Lecture 1)",
+    "title": "How to Start a Startup — Lecture 1",
     "channel": "Y Combinator",
     "url": "https://www.youtube.com/watch?v=CBYhVcO4WgI",
     "duration": "0:44:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["startup", "yc", "business"]
+    "tags": [
+      "startup",
+      "yc",
+      "business"
+    ]
   },
   {
     "id": "0wIUK0nsyUg",
-    "title": "AI Will Save The World",
+    "title": "AI Will Save the World — Andreessen & Casado",
     "channel": "a16z",
     "url": "https://www.youtube.com/watch?v=0wIUK0nsyUg",
     "duration": "0:32:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["optimism", "future", "venture"]
+    "tags": [
+      "optimism",
+      "future",
+      "venture"
+    ]
   },
   {
     "id": "NCeq1r2LRUM",
@@ -389,9 +425,13 @@
     "channel": "Neil Patel",
     "url": "https://www.youtube.com/watch?v=NCeq1r2LRUM",
     "duration": "0:45:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["seo", "marketing", "search"]
+    "tags": [
+      "seo",
+      "marketing",
+      "search"
+    ]
   },
   {
     "id": "Q_lySNxCag0",
@@ -399,11 +439,14 @@
     "channel": "Neil Patel",
     "url": "https://www.youtube.com/watch?v=Q_lySNxCag0",
     "duration": "0:12:00",
-    "topic": "Strategy",
+    "topic": "Strategy & Business",
     "embeddable": true,
-    "tags": ["seo", "course", "free"]
+    "tags": [
+      "seo",
+      "course",
+      "free"
+    ]
   },
-
   {
     "id": "BZ2nSULolKI",
     "title": "The One-Person Business Model",
@@ -412,48 +455,53 @@
     "duration": "0:28:00",
     "topic": "Creator Economy",
     "embeddable": true,
-    "tags": ["solo", "business", "creator"]
-  },
-  {
-    "id": "cNGpxfcDKms",
-    "title": "The Best One-Person Business 2025",
-    "channel": "Dan Koe",
-    "url": "https://www.youtube.com/watch?v=cNGpxfcDKms",
-    "duration": "0:25:00",
-    "topic": "Creator Economy",
-    "embeddable": true,
-    "tags": ["solopreneur", "future", "business"]
+    "tags": [
+      "solo",
+      "business",
+      "creator"
+    ]
   },
   {
     "id": "BBAuhqvT_ds",
-    "title": "Honest Advice to Financial Freedom",
+    "title": "My Honest Advice to Someone Who Wants Financial Freedom",
     "channel": "Ali Abdaal",
     "url": "https://www.youtube.com/watch?v=BBAuhqvT_ds",
     "duration": "0:22:00",
     "topic": "Creator Economy",
     "embeddable": true,
-    "tags": ["money", "freedom", "advice"]
+    "tags": [
+      "money",
+      "freedom",
+      "advice"
+    ]
   },
   {
-    "id": "H_lZr0BAWhM",
-    "title": "How I Think: The Real Secret of Productivity",
+    "id": "tQSKyvjsUuI",
+    "title": "My Complete Productivity System",
     "channel": "Ali Abdaal",
-    "url": "https://www.youtube.com/watch?v=H_lZr0BAWhM",
+    "url": "https://www.youtube.com/watch?v=tQSKyvjsUuI",
     "duration": "0:18:00",
     "topic": "Creator Economy",
     "embeddable": true,
-    "tags": ["productivity", "systems", "thinking"]
+    "tags": [
+      "productivity",
+      "systems",
+      "thinking"
+    ]
   },
-
   {
-    "id": "n9iv24yI04nI",
-    "title": "Rick Rubin: The Creative Act",
+    "id": "sE1teB5bN-w",
+    "title": "Rick Rubin on the Creative Act",
     "channel": "60 Minutes",
-    "url": "https://www.youtube.com/watch?v=n9iv24yI04nI",
+    "url": "https://www.youtube.com/watch?v=sE1teB5bN-w",
     "duration": "0:12:00",
-    "topic": "Creativity",
+    "topic": "Creative AI & Music",
     "embeddable": true,
-    "tags": ["art", "mindset", "philosophy"]
+    "tags": [
+      "art",
+      "mindset",
+      "philosophy"
+    ]
   },
   {
     "id": "RKXZ7t_RiOE",
@@ -461,9 +509,13 @@
     "channel": "The Futur",
     "url": "https://www.youtube.com/watch?v=RKXZ7t_RiOE",
     "duration": "0:47:00",
-    "topic": "Creativity",
+    "topic": "Creative AI & Music",
     "embeddable": true,
-    "tags": ["pricing", "design", "business"]
+    "tags": [
+      "pricing",
+      "design",
+      "business"
+    ]
   },
   {
     "id": "1bZ0OSEViyo",
@@ -471,61 +523,69 @@
     "channel": "Rick Beato",
     "url": "https://www.youtube.com/watch?v=1bZ0OSEViyo",
     "duration": "0:20:00",
-    "topic": "Creativity",
+    "topic": "Creative AI & Music",
     "embeddable": true,
-    "tags": ["music", "industry", "quality"]
+    "tags": [
+      "music",
+      "industry",
+      "quality"
+    ]
   },
-
   {
-    "id": "EIi5k9TJUvY",
-    "title": "Suno v4.5 Lyric Writing",
-    "channel": "Suno AI",
-    "url": "https://www.youtube.com/watch?v=EIi5k9TJUvY",
+    "id": "sIx3LNV51bQ",
+    "title": "Suno V4.5: Complete AI Music Tutorial",
+    "channel": "Suno Tutorial",
+    "url": "https://www.youtube.com/watch?v=sIx3LNV51bQ",
     "duration": "0:12:00",
-    "topic": "Creative AI",
+    "topic": "Creative AI & Music",
     "embeddable": true,
-    "tags": ["suno", "lyrics", "prompting"]
-  },
-  {
-    "id": "jDHMPSSgaMw",
-    "title": "AI Music Production Workflow",
-    "channel": "FrankX Music",
-    "url": "https://www.youtube.com/watch?v=jDHMPSSgaMw",
-    "duration": "0:25:00",
-    "topic": "Creative AI",
-    "embeddable": true,
-    "tags": ["suno", "distribution", "workflow"]
+    "tags": [
+      "suno",
+      "lyrics",
+      "prompting"
+    ]
   },
   {
     "id": "u2pYNRNdcNc",
-    "title": "Suno v4 Complete Guide",
+    "title": "Suno v4: Complete Guide",
     "channel": "Suno Tutorial",
     "url": "https://www.youtube.com/watch?v=u2pYNRNdcNc",
     "duration": "0:15:00",
-    "topic": "Creative AI",
+    "topic": "Creative AI & Music",
     "embeddable": true,
-    "tags": ["suno", "tutorial", "music"]
+    "tags": [
+      "suno",
+      "tutorial",
+      "music"
+    ]
   },
   {
-    "id": "9WVZbitXbck",
-    "title": "Midjourney Complete Tutorial",
-    "channel": "Midjourney Guide",
-    "url": "https://www.youtube.com/watch?v=9WVZbitXbck",
+    "id": "VUDjpOY3YeE",
+    "title": "MidJourney Tutorial: Full Beginner's Guide",
+    "channel": "MidJourney Guide",
+    "url": "https://www.youtube.com/watch?v=VUDjpOY3YeE",
     "duration": "0:20:00",
-    "topic": "Creative AI",
+    "topic": "Creative AI & Music",
     "embeddable": true,
-    "tags": ["midjourney", "art", "tutorial"]
+    "tags": [
+      "midjourney",
+      "art",
+      "tutorial"
+    ]
   },
-
   {
-    "id": "Cqbleas1mmo",
+    "id": "XNbaR54Gpj4",
     "title": "The Psychology of Your Future Self",
     "channel": "TED",
-    "url": "https://www.youtube.com/watch?v=Cqbleas1mmo",
+    "url": "https://www.youtube.com/watch?v=XNbaR54Gpj4",
     "duration": "0:18:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["psychology", "planning", "vision"]
+    "tags": [
+      "psychology",
+      "planning",
+      "vision"
+    ]
   },
   {
     "id": "yb5zpo5WDG4",
@@ -533,9 +593,13 @@
     "channel": "Huberman Lab",
     "url": "https://www.youtube.com/watch?v=yb5zpo5WDG4",
     "duration": "2:00:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["focus", "neuroscience", "tools"]
+    "tags": [
+      "focus",
+      "neuroscience",
+      "tools"
+    ]
   },
   {
     "id": "QmOF0crdyRU",
@@ -543,9 +607,13 @@
     "channel": "Huberman Lab",
     "url": "https://www.youtube.com/watch?v=QmOF0crdyRU",
     "duration": "2:00:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["dopamine", "neuroscience", "motivation"]
+    "tags": [
+      "dopamine",
+      "neuroscience",
+      "motivation"
+    ]
   },
   {
     "id": "vA50EK70whE",
@@ -553,9 +621,13 @@
     "channel": "Huberman Lab",
     "url": "https://www.youtube.com/watch?v=vA50EK70whE",
     "duration": "2:00:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["motivation", "drive", "neuroscience"]
+    "tags": [
+      "motivation",
+      "drive",
+      "neuroscience"
+    ]
   },
   {
     "id": "arj7oStGLkU",
@@ -563,19 +635,27 @@
     "channel": "TED",
     "url": "https://www.youtube.com/watch?v=arj7oStGLkU",
     "duration": "0:14:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["procrastination", "humor", "psychology"]
+    "tags": [
+      "procrastination",
+      "humor",
+      "psychology"
+    ]
   },
   {
-    "id": "mNeXuCYiE0U",
-    "title": "1% Better Every Day",
+    "id": "U_nzqnXWvSo",
+    "title": "Atomic Habits: How to Get 1% Better Every Day",
     "channel": "James Clear",
-    "url": "https://www.youtube.com/watch?v=mNeXuCYiE0U",
+    "url": "https://www.youtube.com/watch?v=U_nzqnXWvSo",
     "duration": "0:25:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["habits", "growth", "compound"]
+    "tags": [
+      "habits",
+      "growth",
+      "compound"
+    ]
   },
   {
     "id": "3E7hkPZ-HTk",
@@ -583,9 +663,13 @@
     "channel": "Cal Newport",
     "url": "https://www.youtube.com/watch?v=3E7hkPZ-HTk",
     "duration": "0:14:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["focus", "minimalism", "digital"]
+    "tags": [
+      "focus",
+      "minimalism",
+      "digital"
+    ]
   },
   {
     "id": "heh5XLwZVOY",
@@ -593,92 +677,69 @@
     "channel": "Daily Stoic",
     "url": "https://www.youtube.com/watch?v=heh5XLwZVOY",
     "duration": "0:15:00",
-    "topic": "Mindset",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["stoicism", "rules", "philosophy"]
+    "tags": [
+      "stoicism",
+      "rules",
+      "philosophy"
+    ]
   },
-
   {
-    "id": "zdkGXDq1jqM",
-    "title": "How to Learn Anything (Feynman Technique)",
+    "id": "MlJdMr3O5J4",
+    "title": "How to Study Way More Effectively (Feynman Technique)",
     "channel": "Freedom in Thought",
-    "url": "https://www.youtube.com/watch?v=zdkGXDq1jqM",
+    "url": "https://www.youtube.com/watch?v=MlJdMr3O5J4",
     "duration": "0:10:00",
-    "topic": "Learning",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["learning", "feynman", "mental models"]
+    "tags": [
+      "learning",
+      "feynman",
+      "mental models"
+    ]
   },
-
   {
     "id": "jfKfPfyJRdk",
-    "title": "Lofi Hip Hop Radio - Beats to Study To",
+    "title": "Lofi Hip Hop Radio — Beats to Relax/Study To",
     "channel": "Lofi Girl",
     "url": "https://www.youtube.com/watch?v=jfKfPfyJRdk",
     "duration": "LIVE",
-    "topic": "Rituals",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["lofi", "study", "focus"]
+    "tags": [
+      "lofi",
+      "study",
+      "focus"
+    ]
   },
   {
     "id": "1_G60OdEzXs",
-    "title": "Binaural Beats: Deep Focus",
+    "title": "40 Hz Binaural Beats: Focus, Memory, Concentration",
     "channel": "Binaural Beats",
     "url": "https://www.youtube.com/watch?v=1_G60OdEzXs",
     "duration": "1:00:00",
-    "topic": "Rituals",
+    "topic": "Mindset & Growth",
     "embeddable": true,
-    "tags": ["binaural", "focus", "music"]
-  },
-
-  {
-    "id": "xsV7DGfIqIg",
-    "title": "AI Baby Trump vs Crockett",
-    "channel": "AI Parody",
-    "url": "https://www.youtube.com/watch?v=xsV7DGfIqIg",
-    "duration": "0:05:00",
-    "topic": "AI Memes",
-    "embeddable": true,
-    "tags": ["parody", "satire", "politics"]
+    "tags": [
+      "binaural",
+      "focus",
+      "music"
+    ]
   },
   {
-    "id": "szq_4zvswiM",
-    "title": "Diesel Drinking AI",
-    "channel": "Diesel AI",
-    "url": "https://www.youtube.com/watch?v=szq_4zvswiM",
-    "duration": "0:03:00",
-    "topic": "AI Memes",
-    "embeddable": true,
-    "tags": ["deepfake", "parody", "short"]
-  },
-  {
-    "id": "mPHHLrpraS4",
-    "title": "Hungry Potter AI Parody",
-    "channel": "AI Balenciaga",
-    "url": "https://www.youtube.com/watch?v=mPHHLrpraS4",
+    "id": "20ph8XoP-YM",
+    "title": "Hungry Potter and the Chamber of Snacks",
+    "channel": "demonflyingfox",
+    "url": "https://www.youtube.com/watch?v=20ph8XoP-YM",
     "duration": "0:04:00",
-    "topic": "AI Memes",
+    "topic": "AI Culture",
     "embeddable": true,
-    "tags": ["balenciaga", "parody", "fashion"]
-  },
-  {
-    "id": "tlooPT4pB1Y",
-    "title": "Cursed AI Song Covers",
-    "channel": "Vocal Memes",
-    "url": "https://www.youtube.com/watch?v=tlooPT4pB1Y",
-    "duration": "0:08:00",
-    "topic": "AI Memes",
-    "embeddable": true,
-    "tags": ["music", "remix", "funny"]
-  },
-  {
-    "id": "UeFTkveHajE",
-    "title": "Greatest AI Remixes",
-    "channel": "Remix Era",
-    "url": "https://www.youtube.com/watch?v=UeFTkveHajE",
-    "duration": "0:10:00",
-    "topic": "AI Memes",
-    "embeddable": true,
-    "tags": ["remix", "music", "ai"]
+    "tags": [
+      "balenciaga",
+      "parody",
+      "fashion"
+    ]
   },
   {
     "id": "iE39q-IKOzA",
@@ -686,42 +747,60 @@
     "channel": "demonflyingfox",
     "url": "https://www.youtube.com/watch?v=iE39q-IKOzA",
     "duration": "0:05:00",
-    "topic": "AI Memes",
+    "topic": "AI Culture",
     "embeddable": true,
-    "tags": ["balenciaga", "fashion", "viral"]
+    "tags": [
+      "balenciaga",
+      "fashion",
+      "viral"
+    ]
   },
   {
     "id": "q6ra0KDgVbg",
-    "title": "Presidents Play Wii Sports Golf",
+    "title": "US Presidents Play Wii Sports Golf",
     "channel": "AI Presidents",
     "url": "https://www.youtube.com/watch?v=q6ra0KDgVbg",
     "duration": "0:10:00",
-    "topic": "AI Memes",
+    "topic": "AI Culture",
     "embeddable": true,
-    "tags": ["presidents", "gaming", "parody"]
+    "tags": [
+      "presidents",
+      "gaming",
+      "parody"
+    ]
   },
   {
     "id": "pL9o_BwSN-o",
-    "title": "Glorb: The Bottom 2",
+    "title": "Glorb — The Bottom 2",
     "channel": "Glorb",
     "url": "https://www.youtube.com/watch?v=pL9o_BwSN-o",
     "duration": "0:05:00",
-    "topic": "AI Memes",
+    "topic": "AI Culture",
     "embeddable": true,
-    "tags": ["meme", "viral", "absurdist"]
+    "tags": [
+      "meme",
+      "viral",
+      "absurdist"
+    ]
   },
   {
-    "id": "1Edv43k15cY",
-    "title": "The Real Reason You're Always Tired",
-    "channel": "OptimalMind",
+    "id": "KyxYdicOzTg",
+    "title": "Why You're Always Tired",
+    "channel": "After Skool",
     "author": "OptimalMind",
-    "url": "https://www.youtube.com/shorts/1Edv43k15cY",
+    "url": "https://www.youtube.com/watch?v=KyxYdicOzTg",
     "duration": "0:45",
     "topic": "Mindset & Growth",
     "category": "Mindset & Growth",
     "embeddable": true,
     "format": "short",
-    "tags": ["energy", "health", "peak-performance", "human-edge", "short"],
+    "tags": [
+      "energy",
+      "health",
+      "peak-performance",
+      "human-edge",
+      "short"
+    ],
     "commentary": "Peak performance starts upstream of the prompt. Before you build the AI Architect's mind, fix the operator's body — energy is the substrate every great creator compounds from."
   }
 ]

--- a/data/video-watchlists.json
+++ b/data/video-watchlists.json
@@ -1,5 +1,44 @@
 [
   {
+    "id": "beautiful-mind-quest",
+    "title": "The Beautiful Mind Quest",
+    "description": "The 30 daily videos behind frankx.ai/dare — one mind-stretching watch per day, in order, across six principles of how the mind works.",
+    "icon": "flame",
+    "color": "#f59e0b",
+    "videoIds": [
+      "aircAruvnKk",
+      "eMlx5fFNoYc",
+      "MlJdMr3O5J4",
+      "U_nzqnXWvSo",
+      "sal78ACtGTc",
+      "XNbaR54Gpj4",
+      "vA50EK70whE",
+      "QmOF0crdyRU",
+      "yb5zpo5WDG4",
+      "heh5XLwZVOY",
+      "sE1teB5bN-w",
+      "nbPbK1xYSNY",
+      "VUDjpOY3YeE",
+      "sIx3LNV51bQ",
+      "kCc8FmEb1nY",
+      "IHZwWFHWa-w",
+      "hq8J-nj_Sr0",
+      "uRuLgar5XZw",
+      "tQSKyvjsUuI",
+      "3E7hkPZ-HTk",
+      "arj7oStGLkU",
+      "o0Fc5_zHvzo",
+      "7xTGNNLPyMI",
+      "KyxYdicOzTg",
+      "_osKgFwKoDQ",
+      "KrRD7r7y7NY",
+      "Gfr50f6ZBvo",
+      "BZ2nSULolKI",
+      "cdiD-9MMpb0",
+      "jvqFAi7vkBc"
+    ]
+  },
+  {
     "id": "ai-engineering",
     "title": "AI Engineering Essentials",
     "description": "Core videos for building production AI systems. From neural nets to deployment.",
@@ -20,7 +59,12 @@
     "description": "Multi-agent systems, orchestration patterns, and autonomous workflows.",
     "icon": "bot",
     "color": "#AB47C7",
-    "videoIds": ["sal78ACtGTc", "KrRD7r7y7NY", "5-2W--zGO0Y", "o0Fc5_zHvzo"]
+    "videoIds": [
+      "sal78ACtGTc",
+      "KrRD7r7y7NY",
+      "sPzc6hMg7So",
+      "o0Fc5_zHvzo"
+    ]
   },
   {
     "id": "music-production",
@@ -28,7 +72,11 @@
     "description": "Suno AI workflows, prompt engineering for music, and distribution strategies.",
     "icon": "music",
     "color": "#F59E0B",
-    "videoIds": ["EIi5k9TJUvY", "jDHMPSSgaMw", "u2pYNRNdcNc", "1bZ0OSEViyo"]
+    "videoIds": [
+      "sIx3LNV51bQ",
+      "u2pYNRNdcNc",
+      "1bZ0OSEViyo"
+    ]
   },
   {
     "id": "creative-ai",
@@ -36,7 +84,11 @@
     "description": "AI tools for creators — from image generation to content pipelines.",
     "icon": "sparkles",
     "color": "#10B981",
-    "videoIds": ["EIi5k9TJUvY", "jDHMPSSgaMw", "9WVZbitXbck", "n9iv24yI04nI"]
+    "videoIds": [
+      "sIx3LNV51bQ",
+      "VUDjpOY3YeE",
+      "sE1teB5bN-w"
+    ]
   },
   {
     "id": "strategy",
@@ -45,12 +97,10 @@
     "icon": "trending-up",
     "color": "#43BFE3",
     "videoIds": [
-      "5MUvJv_sB64",
-      "BSjQk-7j3X0",
       "jvqFAi7vkBc",
+      "_osKgFwKoDQ",
       "CBYhVcO4WgI",
-      "0wIUK0nsyUg",
-      "tqfPCE_gfuc"
+      "0wIUK0nsyUg"
     ]
   },
   {
@@ -61,8 +111,7 @@
     "color": "#AB47C7",
     "videoIds": [
       "BZ2nSULolKI",
-      "cNGpxfcDKms",
-      "H_lZr0BAWhM",
+      "tQSKyvjsUuI",
       "BBAuhqvT_ds",
       "RKXZ7t_RiOE"
     ]
@@ -74,10 +123,10 @@
     "icon": "activity",
     "color": "#F59E0B",
     "videoIds": [
-      "Cqbleas1mmo",
+      "XNbaR54Gpj4",
       "arj7oStGLkU",
       "yb5zpo5WDG4",
-      "mNeXuCYiE0U",
+      "U_nzqnXWvSo",
       "heh5XLwZVOY"
     ]
   },
@@ -87,7 +136,12 @@
     "description": "Meta-learning techniques, research methods, and knowledge acquisition strategies.",
     "icon": "graduation-cap",
     "color": "#10B981",
-    "videoIds": ["aircAruvnKk", "zdkGXDq1jqM", "kCc8FmEb1nY", "3E7hkPZ-HTk"]
+    "videoIds": [
+      "aircAruvnKk",
+      "MlJdMr3O5J4",
+      "kCc8FmEb1nY",
+      "3E7hkPZ-HTk"
+    ]
   },
   {
     "id": "top-shorts",
@@ -95,6 +149,8 @@
     "description": "60-second high-signal Shorts curated by an AI Architect — pairs with /watch/shorts. Each Short earns its place by compressing a real insight into under a minute.",
     "icon": "zap",
     "color": "#F43F5E",
-    "videoIds": ["1Edv43k15cY"]
+    "videoIds": [
+      "KyxYdicOzTg"
+    ]
   }
 ]


### PR DESCRIPTION
## Why

The `/dare` video that "didn't work" was a hallucinated YouTube ID. Investigating it surfaced a systemic problem: the 30 dare videos **and** the `/watch` vault were seeded in a prior session with LLM-generated YouTube IDs that were never validated against reality. Today's dare (day 30) pointed at a non-existent video; day 11 had a malformed 12-char ID; the vault carried fabricated channels ("C-Suite AI", "Bloomberg — AI ROI Strategy 2026", "FrankX Music", "The AI Grid").

Every ID in this PR was verified against YouTube via search before being written.

## What changed

**`data/daily-dares.ts` — 11 of 30 video IDs corrected**
Wrong/malformed → real canonical uploads. Highlights:
- Day 30 (today): `5MUvJv_sB64` → `jvqFAi7vkBc` (Sam Altman · Lex Fridman #419) — *the reported broken link*
- Day 11: `n9iv24yI04nI` (malformed) → `sE1teB5bN-w` (Rick Rubin · 60 Minutes)
- Day 3 Feynman, Day 4 1% Better, Day 6 Future Self (TED), Day 13 Midjourney, Day 14 Suno, Day 17 Claude Code, Day 19 Ali Abdaal, Day 24 tiredness, Day 25 Infinite Game
- All 30 are now 11-char, unique, and verified.

**`data/video-vault-100.json` — 71 → 57 entries**
- Dropped 14 fabricated / unverifiable / low-signal / duplicate entries.
- Corrected wrong IDs for real creators (CrewAI, Oracle OCI, Matthew Berman, Theo, ThePrimeagen episode, etc.).
- Normalized `topic` to the 8 canonical categories so the `/watch` section rows and filter chips populate with proper icons.

**Overlays reconciled to the corrected IDs (0 orphans)**
- `video-library.json` — Editor's Picks restored (19 featured).
- `video-watchlists.json` — all dead refs cleared; **added "The Beautiful Mind Quest"** watchlist (the 30 dare videos in order) so `/watch` directly backs `/dare` + `/quest`.
- `video-cross-refs.json` — blog cross-links remapped.

**`app/dare/page.tsx` — player hardening**
- `maxresdefault` thumbnail (missing for many videos → broken image) now falls back to `hqdefault` on error.
- Added an always-present "Watch on YouTube" link as an escape hatch for videos that disable embedding.

## Verification
- `tsc --noEmit` ✅ · eslint (dare page) ✅ · `design:lint` ✅
- Runtime smoke: today → day 30 → `jvqFAi7vkBc` (resolves), epoch day 1 → `aircAruvnKk`, day 17 → `hq8J-nj_Sr0`; vault 57, watchlists 10, editor's picks 19.
- 30 dare IDs cross-checked: all present in vault, 11-char, unique.

Verified IDs are correct as of June 2026; if a creator deletes a video later, the new "Watch on YouTube" fallback still resolves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtV3awPBSgMK124bq1cAji)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct "Watch on YouTube" link as fallback for embedded video player
  * Introduced new curated watchlist with handpicked content

* **Bug Fixes**
  * Enhanced YouTube thumbnail loading with automatic fallback to alternative resolution
  * Improved video playback state management when switching between videos

* **Chores**
  * Updated video library with refreshed titles and reorganized catalog
  * Refreshed Daily Dares video references
  * Reorganized video sequences across existing watchlists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->