### PR TITLE
fix(downloads): repair syntax corruption breaking type-check on main

### DIFF
--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -53,7 +53,6 @@ const downloads: DownloadItem[] = [
     icon: '🎵',
   },
   {
-  {
     id: 'blue-life-commons',
     title: 'Blue Life Commons',
     subtitle: 'Ocean Intelligence System — Founding Knowledgebase',
@@ -94,7 +93,6 @@ const downloads: DownloadItem[] = [
     features: ['4 Codex Plugins', 'GitHub Prerelease', 'SHA256 Checksum', 'Install Guide'],
     variant: 'ocean' as const,
     icon: 'CLI',
-  },
   },
 ]
 


### PR DESCRIPTION
## Fixes a syntax corruption that breaks `tsc --noEmit` on `main`

`app/downloads/page.tsx` carries two stray braces introduced in `32900c90` ("feat: add social cockpit dashboard, downloads, and newsletters"):

1. A **duplicate `{`** before the `blue-life-commons` entry (`TS1136: Property assignment expected`)
2. A **duplicate `},`** before the array's closing `]` (`TS1137` / `TS1128`)

These break `npm run type-check`, which reds the **merge-CI on `main` and on every open PR** (the failure surfaces only in the PR-merge build, not in Vercel's branch-HEAD build — which is why preview deploys stayed green while CI went red).

## The fix
Removed the two stray braces. **No change to the downloads content** — all entries (incl. Health Intelligence System, Starlight SIP/Plugin Starters, Blue Life Commons) are intact.

## Verification
`tsc --noEmit` clean on the corrected tree (exit 0).

Isolated hotfix off current `main`, kept separate from in-flight feature PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSB5ZaV6vyJWbXDFUmUE5V

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSB5ZaV6vyJWbXDFUmUE5V)_