### PR TITLE
feat(books): Wonderproof book foundation + Library additions + ExperimentCard reader component

### DIFF
--- a/app/books/components/BookReader.tsx
+++ b/app/books/components/BookReader.tsx
@@ -8,6 +8,7 @@ import DOMPurify from 'isomorphic-dompurify';
 import BookProgress from './BookProgress';
 import BookTOC from './BookTOC';
 import BookChapterNav from './BookChapterNav';
+import ExperimentCard from './ExperimentCard';
 import type { BookChapter, BookTheme, TOCItem } from '../types';
 import { getThemeClasses } from '../lib/theme-classes';
 
@@ -317,6 +318,17 @@ export default function BookReader({
                   background: rgba(255,255,255,0.06); height: 1px;
                 }
               `}</style>
+
+              {chapter.experiment && (
+                <div className="mt-12">
+                  <ExperimentCard
+                    experiment={chapter.experiment}
+                    borderClass={tc.borderPrimary}
+                    bookSlug={bookSlug}
+                    chapterSlug={chapter.slug}
+                  />
+                </div>
+              )}
 
               <BookChapterNav
                 bookSlug={bookSlug}

--- a/app/books/components/ExperimentCard.tsx
+++ b/app/books/components/ExperimentCard.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useState } from 'react';
+import type { Experiment } from '../types';
+
+interface ExperimentCardProps {
+  experiment: Experiment;
+  borderClass?: string;
+  accentColor?: string;
+  bookSlug?: string;
+  chapterSlug?: string;
+}
+
+export default function ExperimentCard({
+  experiment,
+  borderClass = 'border-amber-500/40',
+  accentColor = '#fbbf24',
+}: ExperimentCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const shareText = [
+    `Experiment ${experiment.number}: ${experiment.title}`,
+    '',
+    `Hypothesis: "${experiment.hypothesis}"`,
+    '',
+    `Setup (${experiment.duration}): ${experiment.setup}`,
+    '',
+    `Track: ${experiment.track}`,
+    '',
+    `— from Wonderproof by Frank Riemer`,
+  ].join('\n');
+
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(shareText)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {
+        // clipboard blocked in some environments — silent fail
+      });
+  };
+
+  const hexBg = `${accentColor}18`;
+  const hexBorder = `${accentColor}30`;
+  const hexTag = `${accentColor}15`;
+  const hexTagBorder = `${accentColor}25`;
+
+  return (
+    <div
+      className={`relative rounded-2xl border-2 ${borderClass} bg-white/[0.03] overflow-hidden`}
+      role="region"
+      aria-label={`Experiment ${experiment.number}: ${experiment.title}`}
+    >
+      {/* Header */}
+      <div className="px-6 pt-6 pb-4 border-b border-white/10">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            {/* Flask icon */}
+            <div
+              className="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center"
+              style={{ backgroundColor: hexBg, border: `1px solid ${hexBorder}` }}
+              aria-hidden="true"
+            >
+              <svg
+                className="w-5 h-5"
+                style={{ color: accentColor }}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15M14.25 3.104c.251.023.501.05.75.082M19.8 15a2.25 2.25 0 01-.659 1.591l-2.634 2.634a2.25 2.25 0 01-1.591.659H9.084a2.25 2.25 0 01-1.591-.659L4.859 16.59A2.25 2.25 0 014.2 15m15.6 0H4.2"
+                />
+              </svg>
+            </div>
+
+            <div>
+              <div className="text-xs font-mono uppercase tracking-widest text-white/40 mb-0.5">
+                Experiment {experiment.number}
+              </div>
+              <h3 className="text-lg font-semibold text-white leading-tight">
+                {experiment.title}
+              </h3>
+            </div>
+          </div>
+
+          {/* Duration badge */}
+          <div
+            className="flex-shrink-0 px-2.5 py-1 rounded-full text-xs font-mono"
+            style={{
+              backgroundColor: hexTag,
+              color: accentColor,
+              border: `1px solid ${hexTagBorder}`,
+            }}
+          >
+            {experiment.duration}
+          </div>
+        </div>
+      </div>
+
+      {/* Sections */}
+      <div className="px-6 py-5 space-y-5">
+        {/* Hypothesis */}
+        <div>
+          <div className="text-xs font-mono uppercase tracking-widest text-white/35 mb-1.5">
+            Hypothesis
+          </div>
+          <p className="text-white/85 leading-relaxed italic">
+            &ldquo;{experiment.hypothesis}&rdquo;
+          </p>
+        </div>
+
+        {/* Setup */}
+        <div>
+          <div className="text-xs font-mono uppercase tracking-widest text-white/35 mb-1.5">
+            Setup
+          </div>
+          <p className="text-white/70 leading-relaxed">{experiment.setup}</p>
+        </div>
+
+        {/* Track */}
+        <div>
+          <div className="text-xs font-mono uppercase tracking-widest text-white/35 mb-1.5">
+            What to track
+          </div>
+          <p className="text-white/70 leading-relaxed">{experiment.track}</p>
+        </div>
+
+        {/* Result guide */}
+        <div className="rounded-xl bg-white/[0.03] border border-white/[0.08] p-4">
+          <div className="text-xs font-mono uppercase tracking-widest text-white/35 mb-1.5">
+            What it means
+          </div>
+          <p className="text-white/65 leading-relaxed text-sm">
+            {experiment.whatItMeans}
+          </p>
+        </div>
+      </div>
+
+      {/* Share footer */}
+      <div className="px-6 pb-5">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-white/60 hover:text-white/90 text-sm font-medium transition-colors"
+          aria-label="Copy experiment details to clipboard"
+        >
+          {copied ? (
+            <>
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+              Copied to clipboard
+            </>
+          ) : (
+            <>
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+                />
+              </svg>
+              Share this experiment
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/books/lib/books-registry.ts
+++ b/app/books/lib/books-registry.ts
@@ -1155,6 +1155,42 @@ export const booksRegistry: BookConfig[] = [
       { slug: '27-close-the-fable-neither-would-claim', title: 'The Fable Neither of Us Would Claim', number: 27, label: 'Closing', readingTime: '6 min', description: 'The last story that passed between us, that I cannot in honesty sign alone — and why that is the right ending.', published: true, type: 'prose' },
     ],
   },
+  // ─── Wonderproof ─────────────────────────────────────────────
+  {
+    slug: 'wonderproof',
+    title: 'Wonderproof',
+    subtitle: 'Nine Experiments to Prove What Your Mind Can Do',
+    author: 'Frank',
+    publishDate: '2026',
+    description:
+      'A lab manual for human potential. Nine experiments designed to give you direct, personal evidence of what attention, expectation, and perception can do. No belief required. Run the test, record the result, draw your own conclusion.',
+    keywords: ['human potential', 'experiments', 'attention', 'neuroscience', 'evidence-based', 'RAS', 'expectation'],
+    coverImage: '',
+    theme: {
+      id: 'wonderproof',
+      name: 'Wonderproof',
+      primary: 'amber',
+      accent: 'emerald',
+      bgDark: '#0a0a0b',
+      headingFont: 'sans',
+      bodyFont: 'sans',
+    },
+    status: 'in-progress',
+    categories: ['Human Potential', 'Science', 'Experiments'],
+    contentDir: 'content/books/wonderproof',
+    chapters: [
+      { slug: 'introduction', title: 'Introduction: The Laboratory', number: 0, readingTime: '8 min', description: 'Why the lab-manual format works where belief fails. The one rule: record before you interpret.', published: true, type: 'prose' },
+      { slug: 'chapter-01-the-filter', title: 'The Filter: How Your Brain Decides What Exists', number: 1, readingTime: '18 min', description: 'The Reticular Activating System filters 11 million bits per second down to roughly 40. Change what the filter is tuned for and what you perceive changes with it.', published: true, type: 'prose' },
+      { slug: 'chapter-02-the-milkshake-effect', title: 'The Milkshake Effect: Expectation as Physiology', number: 2, readingTime: '20 min', description: "Alia Crum's milkshake study showed that what subjects believed about a meal changed the ghrelin their bodies produced — without changing the meal itself.", published: true, type: 'prose' },
+      { slug: 'chapter-03-the-body-vote', title: 'The Body Vote', number: 3, readingTime: '15 min', description: 'HRV, slow breathing, and the bidirectional link between cardiac rhythm and mental state.', published: false, type: 'prose' },
+      { slug: 'chapter-04-the-attention-experiment', title: 'The Attention Experiment', number: 4, readingTime: '15 min', description: "Amishi Jha's controlled trials: 12 minutes of daily attention training protects working memory under stress.", published: false, type: 'prose' },
+      { slug: 'chapter-05-the-placebo-is-the-treatment', title: 'The Placebo Is the Treatment', number: 5, readingTime: '16 min', description: "Ted Kaptchuk's open-label placebo trials at Harvard: outcomes improved even when patients knew they were receiving a placebo.", published: false, type: 'prose' },
+      { slug: 'chapter-06-the-rewire', title: 'The Rewire', number: 6, readingTime: '17 min', description: "Bogdan Draganski's MRI studies: three months of juggling practice produced measurable gray-matter expansion in areas that handle visual motion.", published: false, type: 'prose' },
+      { slug: 'chapter-07-the-field-of-others', title: 'The Field of Others', number: 7, readingTime: '14 min', description: 'How shared attention and group coherence affect individual physiology — and what the evidence actually says.', published: false, type: 'prose' },
+      { slug: 'chapter-08-the-meaning-layer', title: 'The Meaning Layer', number: 8, readingTime: '15 min', description: "Viktor Frankl's core insight meets modern stress research: perceived meaning is a measurable buffer against cortisol response.", published: false, type: 'prose' },
+      { slug: 'chapter-09-your-personal-protocol', title: 'Your Personal Protocol', number: 9, readingTime: '12 min', description: 'Designing a 9-week personal experiment stack from your own baseline data. The protocol belongs to you.', published: false, type: 'prose' },
+    ],
+  },
 ];
 
 // ─── Helper Functions ───────────────────────────────────────────

--- a/app/books/types.ts
+++ b/app/books/types.ts
@@ -14,6 +14,18 @@ export interface BookTheme {
   bodyFont: 'serif' | 'sans';
 }
 
+// ─── Experiment Device (Wonderproof signature) ──────────────────
+
+export interface Experiment {
+  title: string;
+  number: number;
+  hypothesis: string;
+  setup: string;
+  duration: string; // e.g. '24 hours', '3 days'
+  track: string;
+  whatItMeans: string;
+}
+
 // ─── Core Book Types ────────────────────────────────────────────
 
 export interface BookChapter {
@@ -28,6 +40,7 @@ export interface BookChapter {
   epigraph?: { text: string; author: string };
   /** Overrides the "Chapter {number}" badge (e.g. "Prologue", "Epilogue"). */
   label?: string;
+  experiment?: Experiment;
 }
 
 export interface BookConfig {

--- a/content/books/wonderproof/chapter-01-the-filter.md
+++ b/content/books/wonderproof/chapter-01-the-filter.md
@@ -1,0 +1,120 @@
+# The Filter
+
+Right now, while you read this sentence, your nervous system is processing approximately eleven million bits of information per second.
+
+You are consciously aware of roughly forty.
+
+The other 10,999,960 bits are being handled somewhere below the threshold of your attention — your peripheral vision tracking movement, your proprioceptive system monitoring posture and balance, your auditory system filtering ambient sound, your interoceptive system tracking body temperature, hunger state, and the hundred small signals of physiology. All of it arriving, processed, sorted, and mostly discarded before it ever reaches conscious experience.
+
+The question is not whether your brain filters incoming information. The question is what it uses as the filter criteria.
+
+## The Brainstem Gatekeeper
+
+The reticular activating system — RAS — is a network of nuclei running through the brainstem, roughly two centimeters in length. It receives input from every sensory channel: visual, auditory, somatosensory, olfactory. It projects upward to the thalamus, which projects to the cortex. It is, functionally, the gate between the world and your awareness.
+
+The RAS has two jobs. The first is arousal: maintaining the wakefulness state that makes conscious experience possible at all. Damage to the RAS produces coma. This function is well established and uncontroversial.
+
+The second job is relevance sorting: determining which incoming signals get flagged for conscious attention and which get suppressed. This is where things get interesting.
+
+The RAS does not apply random filtering. It filters based on what is primed as relevant. Your current goals, your recent experiences, your active anxieties, the names you have been hearing repeatedly — all of these load the filter criteria. The RAS then searches incoming data for matches and elevates them to consciousness. Non-matches are suppressed.
+
+This is not mystical. It is a selection-bias mechanism built into the neural architecture.
+
+## Broadbent's Cocktail Party
+
+In 1953, British psychologist Donald Broadbent ran a now-classic set of experiments on selective attention. The setup was simple: subjects wore headphones. Different audio streams played in each ear simultaneously. Subjects were asked to attend to one stream and repeat it back (a task called shadowing).
+
+What Broadbent found — and published in full detail in *Perception and Communication* in 1958 — was that subjects could shadow one stream with high accuracy while receiving almost no conscious information from the other. But they were not *ignoring* the unattended stream. They were *filtering* it. Certain signals broke through the filter reliably: the subject's own name, a sudden loud noise, a highly familiar phrase. The filter had rules, not a blanket off-switch.
+
+This became known as the cocktail party effect: your ability to pull your own name out of background noise across a crowded room. You are not monitoring every conversation. You are filtering. And the filter is tuned, in part, by what matters to you.
+
+Broadbent's model has been refined over the decades — there are now early-selection and late-selection accounts, and the debate about where in processing the filter applies is still active. What is not debated is the fundamental finding: selective attention is real, it is partially voluntary, and it is significantly shaped by what the person has primed as relevant.
+
+## Raz and Buhle: Threads of Thought
+
+In 2006, Amir Raz and Jason Buhle published a review in *Nature Reviews Neuroscience* titled "Threads of Thought." They were mapping the neural basis of selective attention — specifically, what brain regions are responsible for directing the attention spotlight and what modulates its sensitivity.
+
+The review confirmed and extended Broadbent's work with neuroimaging data. Selective attention involves a frontoparietal network — regions including the frontal eye fields, anterior cingulate cortex, and intraparietal sulcus — that direct the spotlight and suppress competing input. The prefrontal cortex plays a top-down regulatory role: it receives goals, expectations, and intentions, and uses them to bias the attentional filter.
+
+The relevance for Wonderproof: the prefrontal cortex is the part of the brain that handles explicit goals and intentions. When you consciously form an intention to notice something, you are giving your prefrontal cortex a directive, which it passes to the attentional network, which retunes the filter. This is a real neural pathway, not a metaphor.
+
+## The Prediction Machine
+
+More recent work in theoretical neuroscience has expanded the picture further. Karl Friston's predictive processing model, which has become one of the most influential frameworks in computational neuroscience over the past fifteen years, proposes that the brain is fundamentally a prediction machine.
+
+In Friston's model, the brain continuously generates predictions about incoming sensory data based on prior experience. These predictions propagate down through the neural hierarchy, from cortex toward the sensory periphery. What propagates *up* is not raw sensory data but prediction errors — the gap between what was expected and what arrived. The brain updates its model based on prediction errors, not on a full-fidelity recording of experience.
+
+What this means for attention: the brain is not passively receiving the world. It is actively constructing a model of the world and testing it against incoming data. What you have primed through intention, expectation, or recent experience literally shapes the predictions — and therefore shapes what prediction errors get generated — and therefore shapes what you perceive as salient.
+
+The world does not change when you prime your attention. The predictions do. And because perception is prediction-filtered, the world as you experience it changes.
+
+## What RAS Is Not
+
+Here is where a significant amount of popular writing about the reticular activating system goes wrong.
+
+The RAS is a *selection bias mechanism*. It finds more of what you prime it to find, in the environment around you. It does not cause the thing to appear. It does not cause the universe to send it to you. It causes you to notice what was already there.
+
+This sounds like a small distinction. It is not. The RAS explanation requires only that the primed object or experience was present in your environment at some detectable level and that you were previously filtering it out. The "universe responds to your vibration" explanation requires a causal mechanism that current physics cannot account for.
+
+The RAS explanation is sufficient to explain the most dramatic anecdotal claims about intention-setting: you set an intention to find a new apartment in your price range, and suddenly listings are everywhere. They were always there. Your filter was previously excluding them as low-priority.
+
+For most of the effects that popular self-development books attribute to quantum consciousness or field theory, the RAS explanation is both more parsimonious and more accurate. It does not require any physics beyond what is established. It is also practically actionable: because the mechanism is a trainable neural filter, not a cosmic force, you can get better at using it through practice.
+
+## The Gap Between Tradition and Science
+
+"As a man thinketh in his heart, so is he." That is Proverbs 23:7, written roughly 2,700 years ago.
+
+"Train your mind to think the thoughts you want to be thinking" is a restatement of Stoic practice from Marcus Aurelius, written roughly 1,900 years ago.
+
+"Keep your mind on what it is you want" appears in nearly identical form across Hindu, Buddhist, and Jewish devotional texts spanning thousands of years.
+
+The ancient observation was accurate. The mechanism was not understood. The mechanism is the RAS, the predictive processing hierarchy, and the frontoparietal attention network. The ancient texts had the effect right. They did not have the neuroscience, because neuroscience did not exist.
+
+The mistake is to reject the ancient observation because the ancient explanation (divine favor, cosmic sympathy, universal law) does not hold up under scrutiny. The observation holds up. The mechanism is neuroscience. Both facts can be true simultaneously.
+
+## Practical: How to Retune the Filter
+
+The science above converges on a practical implication: if you want to notice something more, prime your filter for it explicitly.
+
+This is not vague. There is a specific mechanism:
+
+1. **State the target clearly and specifically.** Vague priming produces vague results. "I want to be more successful" gives the filter nothing to search for. "I want to notice opportunities to help someone with a technical problem" gives it a specific search pattern.
+
+2. **Write it on paper.** Physical writing engages encoding differently than typing or mental intention. The act of writing sends a stronger signal to the prefrontal cortex's goal-maintenance systems.
+
+3. **Review it in the morning, before the day's noise accumulates.** The filter calibration is most plastic when the working memory slate is relatively clean.
+
+4. **Stay physically present.** The attentional filter works on what is physically in front of you. If you are on your phone at a party, the filter cannot flag the relevant conversations happening around you.
+
+5. **Track what you notice.** Writing down instances reinforces the filter's relevance signal and closes the feedback loop.
+
+These are not motivational techniques. They are filter calibration practices, grounded in how the frontoparietal attentional network functions.
+
+---
+
+## Experiment 1: The RAS Tuning Test
+
+**Hypothesis:** A stated, written intention primes the attentional filter, increasing the noticing rate of related instances within 24 hours.
+
+**Setup:** Right now, write down ONE specific thing you want to notice more of in the next 3 days. Not a goal or outcome — a *thing to notice*. Examples:
+- "Moments where I procrastinated on something small"
+- "Instances of unexpected generosity from strangers"
+- "Times I felt unexpectedly energized during the day"
+- "Conversations where the other person seemed genuinely listened to"
+
+Write it on paper (not your phone). Write the full sentence. Then read it each morning for the next 3 days.
+
+**Track:** Each day, write down every instance you notice. Use a tally or a list. At the end of Day 3, count your total. Also: rate how vividly you noticed each instance (1 = faint impression, 10 = unmistakable).
+
+**Controls to note:**
+- Did you spend time in unusual environments vs. your typical locations?
+- Was your mood state significantly different from your baseline?
+- Did you sleep unusually well or poorly?
+
+**What it means:**
+
+If your noticing rate increased from Day 1 to Day 3, you have demonstrated RAS priming. Your environment did not change. Your filter did. The instances were present before you set the intention; you were previously sorting them below the threshold of attention.
+
+If your noticing rate did not change, there are several possible explanations worth examining: the target was too abstract to generate a concrete search pattern; you did not review the written intention consistently; the target was something so common that baseline noticing was already at ceiling; or your attention is unusually heavily allocated to other priorities during this period. None of these is a failure — they are findings about your particular filter state.
+
+Record your results. The data is yours.

--- a/content/books/wonderproof/chapter-02-the-milkshake-effect.md
+++ b/content/books/wonderproof/chapter-02-the-milkshake-effect.md
@@ -1,0 +1,125 @@
+# The Milkshake Effect
+
+In 2011, Alia Crum and her colleagues at Yale served two groups of subjects a milkshake.
+
+Both groups received the same drink: 380 calories, same ingredients, same volume, same temperature. The only difference was the label. One group received a cup labeled "Indulgent" — described as a 620-calorie "decadent" indulgence shake. The other group received a cup labeled "Sensible" — described as a 140-calorie low-fat health shake.
+
+Crum's team measured ghrelin levels — the hunger hormone that signals the stomach's state to the brain — before and after the drink.
+
+Ghrelin levels in the Indulgent group dropped steeply after drinking, following the pattern you would expect from a large, satisfying meal. Ghrelin levels in the Sensible group barely moved, following the pattern of a small, insufficient snack.
+
+Same drink. Different physiological response. The body responded to what the subject *believed* they had consumed, not to what they had actually consumed.
+
+The study appeared in *Health Psychology* in 2011 (Crum et al., 30(4), 424-429). It has been replicated and extended. It is among the clearest demonstrations of top-down physiological modulation in the literature: cognitive appraisal — the frame applied to an experience — directly altering measurable biological response.
+
+## The Hotel Maids Study
+
+Four years earlier, Crum had run an even more striking demonstration with Erin Langer at Harvard.
+
+The subjects were 84 hotel room-cleaning staff at seven hotels. The work is physically substantial — Crum and Langer calculated that it met or exceeded the Surgeon General's recommendations for daily physical activity. But the maids did not think of their work as exercise. When surveyed, 67 percent reported that they did not regularly exercise.
+
+Crum and Langer split the maids into two groups. The experimental group received information explaining how their daily cleaning work qualified as physical exercise — how many calories mopping burned, what the cardiovascular equivalent of vacuuming was. The control group received no such information.
+
+Four weeks later, Crum and Langer measured both groups. The experimental group — who had been told their work was exercise — showed significant decreases in weight, blood pressure, body fat, body mass index, and waist-to-hip ratio compared to the control group.
+
+Same cleaning tasks. Same hours. Same everything, except what they believed about what they were doing.
+
+The study appeared in *Psychological Science* in 2007 (Crum & Langer, 18(2), 165-171). It has generated substantial debate and several replications with mixed results. The original findings, while dramatic, should be understood as a demonstration of the mechanism's existence rather than a precise estimate of its magnitude. The mechanism is real. The effect size in your specific situation will depend on many variables.
+
+## The Mechanism: Top-Down Modulation
+
+What is happening in both studies is a process called top-down cognitive modulation of physiological response.
+
+The classical view of the body held that physiological processes were mostly bottom-up: the body detects a physical condition and responds to it. Hunger is caused by low blood sugar. Physical exertion causes cardiovascular response. The relationship runs from physical reality upward to the body's response.
+
+Decades of research on placebo effects, expectation, and conditioning have complicated this picture significantly. There is now strong evidence for the reverse pathway: cognitive appraisal of a situation — the meaning assigned to it, the expectation about it — flows *downward* through neural pathways and directly modulates physiological processes.
+
+The pathways are real and anatomically traceable. The prefrontal cortex, which handles evaluation and prediction, has direct connections to the hypothalamus, which regulates endocrine and autonomic function. The anterior cingulate cortex modulates pain signaling and autonomic activity based on attention and expectation. The insula integrates cognitive and interoceptive signals and influences both immune function and gut signaling.
+
+When you apply a frame to an experience — this milkshake is indulgent; this work is exercise; this injection will reduce my pain — that frame activates a cascade of top-down signals that reach ghrelin secretion, cortisol levels, inflammatory markers, and autonomic nervous system tone. The body receives instructions from the appraising mind, not just from the physical reality of the stimulus.
+
+## Where This Works
+
+The evidence base for top-down modulation is strongest in specific domains:
+
+**Exercise perception.** Reframing physical activity as more intensive or meaningful increases cardiovascular benefit and perceived exertion tolerance. This works via both attention to bodily signals and direct physiological pathways.
+
+**Food and satiety.** The milkshake effect and related studies show that calorie labeling, portion framing, and presentation all influence ghrelin, dopamine, and satiety signaling beyond what the nutritional content alone would predict.
+
+**Stress.** Alia Crum's stress research at Stanford has shown that framing stress as functional ("stress enhances performance") vs. harmful ("stress is damaging") produces measurably different cortisol and DHEA profiles under acute stress conditions. The frame shapes the biochemistry.
+
+**Pain.** The placebo literature on pain modulation is one of the most robust bodies of evidence in medicine. Expectation of relief activates endogenous opioid release. This is fMRI-visible — Tor Wager's team showed in 2004 that placebo analgesia is accompanied by reduced activity in pain-processing regions of the brain.
+
+**Sleep quality.** Research on sleep suggestion — telling subjects they had slept well or poorly — produces measurable effects on cognitive performance, even when the actual sleep duration is controlled.
+
+## Where This Does Not Work
+
+This is the part that popular presentations of mindset research frequently omit.
+
+Top-down modulation works on systems that have plasticity in their response — systems where the cognitive layer has genuine access to the physiological process. It does not work on systems where the physical state is determinative.
+
+A fractured bone does not heal faster because you believe it will. An advanced tumor does not regress through expectation alone. A genuinely deficient immune system cannot be improved by framing. Serious structural injuries require structural interventions.
+
+Crum herself is explicit about this in her published work. The mindset effect modulates the physiological response *to* a condition — it changes how the body interprets and responds to a stimulus. It does not alter the objective physical reality of the stimulus. The maids who were told their work was exercise got measurable cardiovascular benefit from that frame. They did not stop aging or become immune to injury.
+
+The practical implication: these experiments are most valuable in domains where your appraisal of a situation has genuine access to the physiological response — exercise, food, stress, pain, sleep, social interaction. They are least useful when applied to conditions that require medical intervention.
+
+## Leibniz, Leibniz, Leibniz
+
+The observation that mind shapes physiology predates modern science by a considerable margin.
+
+Hippocrates noted that patients who believed in the effectiveness of a treatment recovered better than those who did not — a proto-placebo observation from the fifth century BCE. The Stoics built an entire practice around the insight that it is not events but our *appraisal* of events that determines our emotional and physiological state. Epictetus: "Men are disturbed not by things, but by the opinions about things."
+
+These are not precise statements of mechanism. But they are accurate phenomenological observations that the relationship between interpretation and experience runs deeper than common sense suggests. The mechanism was not available to them. The observation was.
+
+The mistake is to dismiss the observation because the ancient explanation was often framed in terms of divine intervention, humoral theory, or moral virtue. The observation is separable from the explanation. Modern mechanism explains the observation more precisely, but does not invalidate the millennia of practice built on top of it.
+
+## A Note on Expectation vs. Wishful Thinking
+
+There is a category distinction that matters here.
+
+Expectation, in the scientific sense, means a calibrated prediction based on prior experience and current evidence. It activates the top-down modulation pathway when the prediction is specific enough to generate a concrete physiological signal.
+
+Wishful thinking means wanting a certain outcome regardless of evidence. It does not reliably activate the same pathway, and when it produces a mismatch between the predicted and actual state, the resulting prediction error can increase stress rather than reduce it.
+
+The exercises in this book target expectation, not wishful thinking. The difference is: expectation is earned through evidence and practice. You build genuine confidence in a frame by running it and observing the result, accumulating experience that justifies the expectation. You do not install the expectation by force of will and then reverse-engineer the evidence.
+
+This is why the experiments come before the conclusions.
+
+---
+
+## Experiment 2: The Frame Test
+
+**Hypothesis:** Applying a different frame to a physically identical stimulus produces measurable differences in subjective experience, even when the frame is consciously constructed.
+
+**Setup:** Choose one recurring physical activity this week that you do at least twice — a walk, a work session, a meal, a workout, a social interaction. For half your instances, engage in the activity with your default attitude. For the other half, actively prime yourself with a specific positive expectation *before you begin*: not vague optimism, but a concrete statement. For example:
+- Before a walk: "This is 20 minutes of cardiovascular training that will sharpen my thinking for the rest of the afternoon."
+- Before a meal: "This food is nutritionally dense and will support my energy for the next 4 hours."
+- Before a work session: "This is a focused block where my most important ideas will surface."
+
+The statement must be specific and plausible — not a claim you disbelieve. Write the statement down before starting each primed instance.
+
+**Track:** After each instance, immediately rate on a 1-10 scale:
+- Energy level
+- Engagement (how present and focused you were)
+- Satisfaction (how the activity felt in retrospect)
+
+Record which instances were primed vs. unprimed. Track over at least 4-6 total instances (2-3 of each type).
+
+**Controls to note:**
+- Same time of day vs. different times? (energy naturally varies across the day)
+- Same physical location vs. different?
+- Sleep quality on primed vs. unprimed days?
+- Anything else that was notably different between the two sets?
+
+**What it means:**
+
+If your primed instances score consistently higher on energy, engagement, and satisfaction, you have observed the frame effect on yourself. The physical activity was identical. The physiological and subjective response differed.
+
+The mechanism tested: cognitive appraisal activating top-down modulation of the physiological response. Same stimulus, different frame, different body response.
+
+If the scores do not differ, examine the priming statement: was it specific enough to generate a genuine expectation, or was it so vague that it did not activate a real prediction? Also consider whether your baseline attitude toward the activity is already positive — ceiling effects are real.
+
+Note: you are not being asked to *fake* enthusiasm. You are being asked to *install* a specific expectation before the experience begins. These are different. Fake enthusiasm is affective performance. Expectation installation is loading a frame that shapes perception from the start — which is what Crum's hotel maids were doing.
+
+Record your data. Bring it to Chapter 3.

--- a/content/books/wonderproof/introduction.md
+++ b/content/books/wonderproof/introduction.md
@@ -1,0 +1,103 @@
+# The Experiment Begins
+
+There are two kinds of books about human potential.
+
+The first kind asks you to believe something. It presents a claim — about the power of thought, the field of possibility, the nature of consciousness — and invites you to accept it on the strength of the argument, the author's credentials, or the testimonials of people who swear it worked for them. Many of these books have sold in the millions. Some of them contain real insights buried under the belief requirement.
+
+This is not that kind of book.
+
+The second kind asks you to run an experiment. It gives you a hypothesis, a protocol, and a way to record what happens. You form your own conclusion based on your own data. The author's opinion becomes irrelevant the moment you start measuring.
+
+This is that kind of book.
+
+Wonderproof is a lab manual for human potential. Nine experiments, 24 to 72 hours each, drawn from peer-reviewed research on attention, expectation, physiology, and perception. Each experiment tests one mechanism. Each mechanism has a scientific name and a research history. None of them require you to believe anything before you run the protocol.
+
+## What This Book Is Not
+
+It is not positive thinking. Positive thinking is about the content of your thoughts — replacing negative ones with positive ones. This book is about the *structure* of attention: what your nervous system selects, amplifies, and suppresses, and how that selection can be deliberately calibrated.
+
+It is not the law of attraction. The law of attraction, as typically presented, claims the universe responds to your emotional frequency by rearranging circumstances to match it. That is not what the science shows. What the science shows is more interesting and more verifiable: your *attention* rearranges. Your *physiology* responds to expectation. Your *nervous system state* influences what you notice, which influences what you act on, which influences outcomes. The mechanism is internal. It is also powerful enough to produce dramatic differences in experience.
+
+It is not quantum mechanics applied to consciousness. Quantum effects do not scale to neural or social phenomena in any way that current physics can demonstrate. When you see "quantum" in a self-development book, it is almost always a metaphor — and usually an inaccurate one. This book uses the word only when discussing physics.
+
+It is not a spiritual practice guide. But several chapters draw on traditions that have been running experiments on human attention and perception for two or three thousand years. Stoic philosophy, Buddhist mindfulness, Upanishadic inquiry — these are documented practice traditions that anticipated many findings that neuroscience has since verified. They appear in this book with full attribution and a clear label: *this is tradition, not neuroscience*. The distinction matters.
+
+## How the Science Warrant Works
+
+Every experiment in this book is grounded in peer-reviewed research. The citations are in the chapters, not hidden in footnotes. Here is the core evidence base in brief:
+
+Your brain has a **reticular activating system** — a brainstem filter that determines what reaches your conscious awareness. It is not metaphor. It is anatomy: a cluster of nuclei in the brainstem that acts as a relevance-sorting mechanism. What you prime it to look for, it finds more of. Broadbent demonstrated selective attention in 1958. Modern neuroimaging confirms the mechanism.
+
+Expectation **rewrites physiology**. Alia Crum at Stanford ran a study on hotel maids in 2007. Forty-four maids doing the same physical work as always, told half of them that their work counted as meaningful exercise. Seven weeks later, the informed group had lost weight, reduced blood pressure, and changed body fat percentage — same behavior, different frame. The effect works on ghrelin levels, pain perception, and immune response. The mechanism is real. The limits are real too.
+
+Attention is **trainable**. Amishi Jha's work at the University of Miami trained military personnel in mindful attention for eight weeks. Their attentional control improved measurably under high-stress conditions. The training did not require spiritual belief. It required practice.
+
+The brain **changes its physical structure** in response to directed experience. Bogdan Draganski's team at the University of Regensburg scanned brains before and after three months of juggling practice. Gray matter increased in areas associated with visual motion processing. The same brain that was there before practice was structurally different after. Three months.
+
+These are not fringe findings. They are published in *Nature*, *Science*, *Psychological Science*, and *Frontiers in Psychology*. They are also findings that the wellness industry frequently distorts by removing the caveats and scaling up the claims. This book tries to restore the caveats.
+
+## The Experiment Device
+
+Every chapter closes with a structured experiment. The format is invariant:
+
+**Hypothesis** — a falsifiable, first-person prediction. Not "the universe will send me a sign" but "my noticing rate for X will increase after priming."
+
+**Setup** — concrete actions, specific timing, physical materials where relevant. Duration: 24, 48, or 72 hours.
+
+**Track** — what to measure or record. Rating scales (1-10), raw counts, written observations. Track before and after.
+
+**Controls to note** — variables that might confound your reading: different environment, unusual mood state, sleep deficit.
+
+**What it means** — interpretation framework. What a positive result demonstrates, mechanistically. What a null result might indicate. These are the two outcomes the scientist records without embarrassment.
+
+One important design choice: the mechanism is explained *after* the setup in each chapter, so the experiment runs before you know exactly what it is supposed to demonstrate. This is not perfect blinding, but it partially decouples your expectation from the result.
+
+## A Preview of the Nine Experiments
+
+Chapter 1 tests the **reticular activating system** — your brain's relevance filter. Can a stated intention prime your attention within 24 hours?
+
+Chapter 2 tests **expectation physiology** — the Milkshake Effect. Does changing the frame of a physically identical stimulus change your subjective experience of it?
+
+Chapter 3 tests **resonance breathing** — slow breathing at 0.1 Hz and its effect on nervous system state.
+
+Chapter 4 tests **attention training** — can 10 minutes of daily focused practice improve your attentional control in two weeks?
+
+Chapter 5 tests **neuroplasticity** — physical skill acquisition over 30 days. Can you observe your own competence curve?
+
+Chapter 6 tests **behavioral contagion** — the social mirror. Do you absorb state from the people you spend concentrated time with?
+
+Chapter 7 tests **Stoic negative visualization** — premeditatio malorum as a cognitive tool. Does pre-imagining loss increase present appreciation?
+
+Chapter 8 tests the **open placebo** — the effect that works even when you know it is an inert ritual.
+
+Chapter 9 tests the **field hypothesis** — the most contested and most interesting question. Can intention produce measurable effects at a distance? You design the protocol. You decide what the data means.
+
+## The Only Hypothesis That Matters
+
+You will form your own conclusions.
+
+Some experiments will produce results that match the science exactly. Some will produce null results that tell you something specific about your particular nervous system, context, or compliance. Some will produce results that surprise you in ways neither the research nor the chapter predicted.
+
+All of those are valid outcomes. The scientist's job is to record what happened, not to find what they hoped to find.
+
+The only hypothesis you need going in is this: *I do not fully know the range of my own attention, physiology, and perception. I am willing to find out.*
+
+That is enough to begin.
+
+---
+
+## Experiment 0: The Blue Test
+
+*Before you read Chapter 1, run this experiment. It takes 24 hours and requires no equipment.*
+
+**Hypothesis:** Where your attention is primed, you find more.
+
+**Setup:** For the next 24 hours, notice every time you see the color blue — any shade, any object, any context. Write down each instance in a notebook or phone note. Count as you go.
+
+**Track:** How many blue things did you notice today? Compare to your rough estimate of how many you would have noticed on a typical day before reading this.
+
+**Controls to note:** Same route as usual vs. a different environment? High-stimulation vs. low-stimulation day?
+
+**What it means:** The blue things were always there. You were not. The reticular activating system selected them because you primed it to. You have not changed the world — you have recalibrated the filter. That recalibration is the subject of this entire book.
+
+Record your count. Come back to it after Chapter 1.

--- a/data/book-reviews.ts
+++ b/data/book-reviews.ts
@@ -6899,7 +6899,96 @@ export const bookReviews: BookReview[] = [
       ],
     },
   },
-
+  {
+    slug: 'the-power-of-eight',
+    title: 'The Power of Eight',
+    author: 'Lynne McTaggart',
+    publicationYear: 2017,
+    coverImage: '/images/library/power-of-eight-cover.jpg',
+    hasCover: false,
+    amazonUrl: 'https://www.amazon.com/Power-Eight-Harnessing-Miraculous-Energies/dp/1501115650',
+    categories: ['Human Potential', 'Group Dynamics', 'Intention Research'],
+    reviewDate: '2026-06-22',
+    rating: 4,
+    readingTime: '6 min',
+    tldr: 'McTaggart ran thousands of controlled intention experiments online and in live groups, finding that small groups of eight people focusing a healing intention for ten minutes show measurable physiological effects in the target — and unexpected healing effects in the senders. The evidence is preliminary but the documentation is unusually rigorous for the genre.',
+    bestFor: ['Readers interested in the science of group intention, healing research, and the social amplification of attention.'],
+    keyInsights: [
+      'Small groups of eight people directing a shared intention for a fixed period produced measurable changes in the target person\'s physiological markers in a series of documented trials across multiple countries.',
+      'A surprising finding: participants in the sending group consistently reported their own unexpected healings — suggesting that focused altruistic intention has a measurable feedback effect on the sender.',
+      'McTaggart\'s Intention Experiments (the online large-scale version) included peer-reviewed studies on plant growth, water contamination, and PTSD symptoms in veterans — not all replicated, but some published in peer-reviewed journals.',
+      'The mechanism McTaggart proposes — quantum field entanglement between sender and receiver — remains contested. The documented effects themselves are the stronger empirical claim.',
+      'Group coherence amplifies individual signal: the same intention expressed by eight people in rapport appears to outperform the same intention expressed by eight people without social connection.',
+    ],
+    faq: [
+      {
+        q: 'Is there peer-reviewed evidence for intention experiments?',
+        a: 'Some. McTaggart collaborated with researchers including Gary Schwartz at the University of Arizona and published results from several plant studies and a PTSD trial. Not all studies have been independently replicated. The book presents the evidence honestly with methodology sections rather than hiding study design.',
+      },
+      {
+        q: 'What is the Power of Eight format in practice?',
+        a: 'Eight participants sit in a circle. One person states a specific, concrete healing intention for a person or situation outside the group. The group focuses together for ten minutes in silence or with gentle guidance. Results are documented in a standardized form. McTaggart\'s most documented finding is the boomerang effect on senders.',
+      },
+      {
+        q: 'How does this relate to Wonderproof?',
+        a: 'Chapter 7 of Wonderproof (The Field of Others) draws on McTaggart\'s group coherence research as evidence that attention is not purely individual — shared focus produces measurable effects that solo practice does not.',
+      },
+      {
+        q: 'Is The Intention Experiment (2007) a better starting point?',
+        a: 'The Intention Experiment covers the earlier science more systematically. The Power of Eight is more personal and documents the group format with more case studies. Read The Intention Experiment for the science foundation, The Power of Eight for the practice format.',
+      },
+      {
+        q: 'What are the limitations of the research?',
+        a: 'Sample sizes are small in most studies. Independent replication is limited. The theoretical framework (quantum entanglement as mechanism) goes beyond what the data supports. The documented phenomena are interesting; the explanation is speculative.',
+      },
+    ],
+    relatedBook: 'wonderproof',
+  },
+  {
+    slug: 'altered-traits',
+    title: 'Altered Traits',
+    author: 'Daniel Goleman and Richard Davidson',
+    publicationYear: 2017,
+    coverImage: '/images/library/altered-traits-cover.jpg',
+    hasCover: false,
+    amazonUrl: 'https://www.amazon.com/Altered-Traits-Science-Reveals-Meditation/dp/0399184384',
+    categories: ['Neuroscience', 'Meditation', 'Human Potential'],
+    reviewDate: '2026-06-22',
+    rating: 5,
+    readingTime: '7 min',
+    tldr: 'A methodical audit of meditation research by two scientists who have studied it for 50 years combined. Goleman and Davidson separate what the data actually shows (reduced amygdala reactivity, sustained attention gains, structural brain changes with long practice) from overclaimed benefits, and define what "deep practice" looks like compared to the light doses most apps deliver.',
+    bestFor: ['Anyone who wants to know what meditation actually does — and does not do — based on rigorous evidence rather than marketing claims.'],
+    keyInsights: [
+      'Most meditation studies use doses of 5–20 minutes and measure self-reported wellbeing. These produce small, real effects. The large effects — structural brain changes, reduced cortisol reactivity, sustained attentional control — require years of intensive practice, not months of app use.',
+      'The "altered traits" framing is precise: lasting change in baseline personality, reactivity, and cognition requires practice deep enough to alter neural structure — not just regular sessions that produce temporary states.',
+      'Amygdala reactivity — the speed and intensity of the stress response — is measurably reduced in long-term practitioners in well-controlled lab studies, including during novel stressors they have not encountered before.',
+      'Richard Davidson\'s lab studies on attention (with practitioners averaging 44,000 hours of lifetime practice) found response accuracy and alertness at age 60+ matching people decades younger — a structural finding, not self-report.',
+      'Goleman and Davidson\'s honest assessment: the field is contaminated by "McMindfulness" research that studies insufficient doses and overstates outcomes. Their meta-analysis strips these out, leaving a smaller but more credible evidence base.',
+    ],
+    faq: [
+      {
+        q: 'Does meditation actually change the brain?',
+        a: 'Yes, with meaningful practice. Studies show increased cortical thickness in areas linked to attention and interoception, and reduced amygdala gray matter density in long-term practitioners. These structural changes are dose-dependent — apps delivering 10 minutes per day are unlikely to produce them.',
+      },
+      {
+        q: 'What does the evidence say about stress reduction?',
+        a: 'MBSR (Mindfulness-Based Stress Reduction) has the most replicated evidence: 8-week programs show real reductions in subjective stress, anxiety, and inflammatory markers. The effect size is moderate, not dramatic. For sustained cortisol reduction at baseline, the evidence points to deep, long-term practice.',
+      },
+      {
+        q: 'How does this relate to the Wonderproof framework?',
+        a: 'Chapter 4 (The Attention Experiment) draws on Amishi Jha\'s work, which Goleman and Davidson also cite as among the better-controlled studies. Altered Traits provides the broader scientific context for what attention training can and cannot produce at different dose levels.',
+      },
+      {
+        q: 'Is the book accessible without a science background?',
+        a: 'Yes. Goleman and Davidson write for intelligent general readers. They explain study design, effect sizes, and why they discount certain studies without requiring statistical background. The most technical sections are clearly signposted.',
+      },
+      {
+        q: 'What is the main criticism of popular mindfulness claims?',
+        a: 'That studies typically use self-selected populations, insufficient practice doses, and outcome measures prone to expectation effects (self-report). Goleman and Davidson apply stringent inclusion criteria to their review and are explicit when they cannot find solid evidence for widely promoted claims.',
+      },
+    ],
+    relatedBook: 'wonderproof',
+  },
 ];
 
 // ─── Helper Functions ────────────────────────────────────────────

--- a/docs/books/wonderproof/bible.md
+++ b/docs/books/wonderproof/bible.md
@@ -1,0 +1,233 @@
+# Wonderproof — Series Bible
+
+*Lab manual for human potential. Every chapter ends in an experiment you run on yourself.*
+
+---
+
+## The Promise
+
+You do not need to believe any of this.
+
+That is the point.
+
+Wonderproof is built on a single premise: the most useful things about human attention, expectation, and perception are testable. Not as laboratory science — you are one subject, not a controlled trial — but as personal empiricism. You form a hypothesis, run the protocol, track the result, and draw your own conclusion.
+
+"Don't believe it — prove it for yourself."
+
+This means the book has no doctrine to sell. It has hypotheses to test. If the experiment does not produce what the science predicts for you, that is a finding, not a failure. You have learned something specific about your particular nervous system, attention profile, and context.
+
+---
+
+## Why Wonderproof Surpasses E-Squared
+
+Pam Grout's *E-Squared* (2013) pioneered the experiment-lab-manual format and deserves credit for it. Nine DIY field experiments, 48-hour protocols, a hypothesis before each one. The posture — test it yourself rather than take it on faith — was exactly right.
+
+Wonderproof builds on that foundation and extends it in four ways:
+
+**1. A unified science field, not nine disconnected experiments.**
+Grout's nine experiments span attention, intention, and field theory but do not connect to a common mechanistic spine. Each one stands alone. Wonderproof runs a single through-line: the reticular activating system, predictive processing, and top-down modulation of physiology. Each chapter adds one mechanism to the model. By chapter nine, the reader has a coherent framework, not a collection of anecdotes.
+
+**2. Deeper and more honest science grounding.**
+Grout sometimes presents quantum field theory as an explanation for attentional priming effects. Wonderproof separates the two cleanly: what neuroscience explains (RAS, expectation effects, placebo, neuroplasticity) versus what ancient traditions have practiced for millennia as tradition (Upanishadic nine-gates, Stoic premeditatio, Buddhist sati). Both are treated with respect. Neither is misrepresented as the other.
+
+**3. More rigorous experiment protocols.**
+The Wonderproof Experiment device specifies a hypothesis, a 24-72 hour setup window, what to track and how, control conditions to note, and an interpretation framework. The 48-hour window in E-Squared is a good instinct; Wonderproof formalizes it into a replicable structure.
+
+**4. Body, mind, attention, and social field — not just attention.**
+E-Squared focuses primarily on attention and expectation effects. Wonderproof extends to the nervous system (slow breathing, HRV), neuroplasticity (structural brain change), and social field (behavioral contagion, group intention). The arc runs from the individual nervous system outward to the collective.
+
+---
+
+## The Experiment Device
+
+Every chapter closes with a structured experiment. The format is invariant:
+
+```
+### Experiment [N]: [Name]
+
+**Hypothesis:** A falsifiable, specific, first-person prediction.
+
+**Setup:** What to do. Concrete actions, timing, materials (if any). Duration: 24, 48, or 72 hours.
+
+**Track:** What to measure or record. Rating scales (1-10), counts, written observations. Track before and after.
+
+**Controls to note:** Variables that might confound your reading (different environment, mood state, sleep quality).
+
+**What it means:** Interpretation framework. What a positive result demonstrates. What a null result might indicate. The scientific mechanism it is testing.
+```
+
+The reader is not asked to believe the mechanism before running the experiment. The mechanism is explained after the setup, so the expectation effects from knowing the hypothesis are partially controlled.
+
+---
+
+## Voice Anchors
+
+- **Evidence-first.** Science citations appear in the chapter before the experiment, not as decoration but as the logical foundation for why the experiment makes sense to run.
+- **Concrete instructions.** "Write it on paper (not phone)" is more useful than "set your intention." Precision over poetry.
+- **Tradition as tradition.** The Upanishadic nine-gates are ancient wisdom with documented practice. They are not neuroscience. Both facts are stated plainly.
+- **No claims about the universe responding to you.** The reticular activating system selecting for what you prime is sufficient. It does not require field theory.
+- **No banned words.** See brand gate. Especially: no *manifestation*, no *transformation*, no *journey*, no *luminous*.
+- **Frank's voice throughout.** Direct, warm, technical, evidence-grounded. The tone of a researcher who is genuinely curious about what will happen.
+
+---
+
+## Series Arc
+
+**Book 1 — Foundational sensory and nervous system experiments**
+The individual: attention filter, expectation physiology, breath and nervous system, attention training, neuroplasticity. The reader learns to observe and recalibrate their own hardware.
+
+**Book 2 — Social field experiments**
+The dyad and group: behavioral contagion, mirror neuron effects, group synchrony, the transmission of emotional states across pairs and small groups. The reader learns that perception and state are not purely internal phenomena.
+
+**Book 3 — Long-range intention experiments**
+The contested edge: the PEAR lab findings, McTaggart's Intention Experiments, intercessory prayer studies, the methodological honesty required to engage this material without either dismissing it or overselling it. The reader designs and runs their own long-range protocol.
+
+---
+
+## Full Chapter Map — Book 1
+
+### Introduction: The Experiment Begins
+
+**Thesis:** You are a scientist with one subject: yourself. The only equipment is attention, a notebook, and the willingness to be surprised.
+
+**Experiment 0:** 24-hour blue-color count. Demonstrates selective attention priming before any theory is introduced.
+
+---
+
+### Chapter 1: The Filter
+
+**Thesis:** Your brain is a prediction machine, not a recording device. The reticular activating system determines what your consciousness receives.
+
+**Science:** Broadbent (1953/1958) selective attention; Raz & Buhle (2006) threads of thought; Karl Friston's predictive processing model.
+
+**Tradition presented as tradition:** "As a man thinketh in his heart, so is he" (Proverbs 23:7) — ancient observation of the same phenomenon, without the neuroanatomical explanation.
+
+**Experiment 1:** RAS Tuning Test — write one specific intended-notice, read it daily for 3 days, count instances.
+
+---
+
+### Chapter 2: The Milkshake Effect
+
+**Thesis:** Expectation rewrites physiology. The same physical stimulus produces different measurable biological responses depending on the frame applied to it.
+
+**Science:** Crum & Langer (2007) hotel maids — same physical activity, different framing, different weight outcomes. Crum et al. (2011) milkshake study — ghrelin response tracked the label, not the calories.
+
+**Mechanism:** Top-down cognitive appraisal modulating physiological response. Where this works (exercise, food, stress). Where it does not (structural injury, serious illness).
+
+**Experiment 2:** The Frame Test — same activity with neutral vs. primed expectation, compare subjective experience ratings.
+
+---
+
+### Chapter 3: The Open Channel
+
+**Thesis:** The breath is the only voluntary lever over the autonomic nervous system. Slow resonance breathing at 0.1 Hz measurably shifts cardiac and neural state.
+
+**Science:** Lehrer & Gevirtz (2014) HRV biofeedback at resonance frequency; vagal tone research; CO₂ tolerance as the driver of breathing urge.
+
+**Tradition presented as tradition:** Pranayama (Sanskrit: *prana* + *ayama*, control of vital force) — 3,000 years of documented practice of breath control, without the HRV measurement.
+
+**Experiment 3:** 5-minute resonance breathing before a high-stakes task. Track state before and after with ratings.
+
+---
+
+### Chapter 4: The Attention Athlete
+
+**Thesis:** Attention is a trainable capacity, not a fixed trait. Brief daily practice produces measurable improvements in weeks.
+
+**Science:** Amishi Jha (2007, 2010, 2015) — mindful attention training studies in military populations; attentional blink experiments; working memory and attention under stress.
+
+**Tradition presented as tradition:** Buddhist *sati* (Pali: mindfulness, or clear awareness) — the original attention-training technology, developed over 2,500 years.
+
+**Experiment 4:** 10 minutes of focused attention practice daily for 2 weeks. Track mind-wandering frequency and task engagement.
+
+---
+
+### Chapter 5: The Reshaping
+
+**Thesis:** The brain changes its physical structure in response to directed experience. Three months of consistent practice produces detectable gray matter change.
+
+**Science:** Hebb (1949) — "neurons that fire together wire together"; Draganski et al. (2004) juggling study — structural gray matter increase in 3 months; Doidge patient case evidence for adult neuroplasticity.
+
+**Tradition presented as tradition:** Aristotle's concept of *hexis* (disposition as second nature) — the ancient recognition that practice reshapes character and capacity.
+
+**Experiment 5:** One physical skill practice, daily for 30 days. Subjective competence ratings day 1, day 15, day 30.
+
+---
+
+### Chapter 6: The Social Mirror
+
+**Thesis:** Perception and state are not purely internal phenomena. Behavioral and emotional contagion are real, measurable effects that travel between people without deliberate transmission.
+
+**Science:** Mirror neuron research (Rizzolatti; Iacoboni 2008); behavioral contagion in group settings; emotional contagion (Hatfield et al.); the Framingham Heart Study happiness spread data.
+
+**Tradition presented as tradition:** *Sangha* (Buddhist community as practice support) — the ancient insight that who you spend time with reshapes who you become.
+
+**Experiment 6:** Spend concentrated time with one person whose state you want to observe. Track your own state before and after.
+
+---
+
+### Chapter 7: The Stoic Rehearsal
+
+**Thesis:** Pre-imagining the loss of something increases both resilience when it is lost and appreciation when it is present. The Stoic *premeditatio malorum* is a cognitive immunization protocol.
+
+**Science:** Negative visualization in cognitive psychology; implementation intention research (Gollwitzer); contrast explanation from Epictetus and Marcus Aurelius traced to modern stress inoculation training.
+
+**Tradition presented as tradition:** Stoic *premeditatio malorum* (premeditation of adversity) — Seneca, Marcus Aurelius, Epictetus on voluntary rehearsal of difficulty as preparation, not pessimism.
+
+**Experiment 7:** Write a detailed negative visualization of losing one relationship, object, or capability you take for granted. Record your appreciation rating before and 24 hours after.
+
+---
+
+### Chapter 8: The Open Placebo
+
+**Thesis:** The placebo effect does not require deception to work. Open-label placebos — where subjects know they are taking an inert pill — produce measurable effects.
+
+**Science:** Kaptchuk et al. (2010) open-label placebo study in IBS — improvement without deception. Wager et al. (2004) fMRI pain modulation — placebo effects visible in neural activity. The mechanism: expectation, conditioning, and the therapeutic ritual, not the biochemistry of the pill.
+
+**Tradition presented as tradition:** Healing ritual across traditions — the laying-on of hands, the medicine ceremony, the doctor's confident delivery — as documented placebo amplifiers before the mechanism was understood.
+
+**Experiment 8:** Design and run a deliberate ritual with known symbolic structure. Observe whether the ritual itself produces a state shift. Track before and after.
+
+---
+
+### Chapter 9: The Field
+
+**Thesis:** There is a body of peer-reviewed research suggesting that intention at a distance produces measurable effects beyond chance. The effect sizes are small, the replications are mixed, and the mechanism is not established. The honest position is curiosity, not belief or dismissal.
+
+**Science:** PEAR laboratory (Princeton Engineering Anomalies Research, 1979-2007) — thousands of trials, small but statistically significant effects of intention on random event generators. McTaggart's large-scale Intention Experiments. Methodological critique and what honest engagement requires.
+
+**Tradition presented as tradition:** Distance healing practices across shamanic, Hindu, Christian, and Indigenous traditions — the oldest hypothesis that intention has range beyond the individual body.
+
+**Experiment 9:** Design a personal long-range intention protocol. Select a target, set a protocol window, track a measurable proxy. Record results without interpretation. Return to them in 30 days.
+
+---
+
+## Science Evidence Base
+
+All citations are peer-reviewed or from primary sources unless explicitly labeled as tradition.
+
+| Domain | Key Citation | What It Shows |
+|---|---|---|
+| Selective attention | Broadbent (1958) *Perception and Communication* | Cocktail party effect — attention filters incoming signal based on primed categories |
+| Attentional selectivity | Raz & Buhle (2006) *Nature Reviews Neuroscience* | Threads of thought — selectivity of attention is active, not passive |
+| Expectation/physiology | Crum & Langer (2007) *Psychological Science* 18(2), 165-171 | Hotel maids study — framing exercise as work produces measurable physiological change |
+| Expectation/hormones | Crum et al. (2011) *Health Psychology* 30(4), 424-429 | Milkshake study — ghrelin tracks label, not caloric content |
+| Open-label placebo | Kaptchuk et al. (2010) *PLOS ONE* | IBS improvement without deception |
+| Placebo neuroscience | Wager et al. (2004) *Science* | fMRI pain modulation via expectation |
+| Resonance breathing | Lehrer & Gevirtz (2014) *Frontiers in Psychology* | 0.1 Hz breathing maximizes HRV and vagal tone |
+| Attention training | Jha et al. (2007, 2010, 2015) *Psychological Science*, *NeuroImage* | Brief training improves attentional capacity under stress |
+| Neuroplasticity | Draganski et al. (2004) *Nature* | Structural gray matter change in 3 months of learning |
+| Synaptic learning | Hebb (1949) *Organization of Behavior* | Neurons that fire together wire together |
+| PEAR lab | Jahn & Dunne (multiple, 1979-2007) | Small but statistically significant intention effects on REGs |
+
+---
+
+## What Wonderproof Is Not
+
+- Not a claim that the universe responds to your thoughts
+- Not a positive-thinking system
+- Not quantum mechanics applied to consciousness
+- Not a spiritual practice guide (though traditions appear — clearly labeled as such)
+- Not a promise that the experiments will produce dramatic results
+
+It is a structured invitation to observe your own nervous system, attention, and physiology more precisely than most people ever do.

--- a/docs/books/wonderproof/cover.md
+++ b/docs/books/wonderproof/cover.md
@@ -1,0 +1,114 @@
+# Wonderproof — Cover Direction Spec
+
+*Book 1 of the Wonderproof Series*
+
+---
+
+## Concept
+
+A single question mark composed of fractal dots — thousands of small points that form the curve of the mark, suggesting both particle physics and assembled data. Embedded into the curve of the question mark, a small lab flask or beaker: the union of curiosity and experiment. The flask sits at the inflection point of the curve, where the arc turns.
+
+The question mark is not stylized or decorative. It is precise, measured, scientific in its proportions — the same weight you would find in a technical instrument manual.
+
+The background: void black. No gradients, no texture, no haze. Pure #000000 or close to it.
+
+---
+
+## Typography
+
+**Title:** WONDERPROOF
+- Typeface: Clean geometric sans-serif (Geist, Inter, or equivalent)
+- Weight: Bold or ExtraBold
+- Letter-spacing: +0.05em to +0.1em (slightly open, not tight)
+- Case: All caps
+- Position: Centered, below the question mark
+- Color: White (#FFFFFF) or the accent color
+
+**Tagline:** Run the experiment. Then decide.
+- Typeface: Monospace (Geist Mono, IBM Plex Mono, or equivalent)
+- Weight: Regular
+- Size: Approximately 40% of title size
+- Position: Directly below title, same horizontal center
+- Color: Muted (#94a3b8 or similar cool gray)
+
+**Series indicator:** Book 1 of the Wonderproof Series
+- Typeface: Same monospace, lighter weight
+- Size: Small (approximately 60% of tagline size)
+- Position: Top of cover or bottom margin
+- Color: Muted gray
+
+**Author:** Frank Riemer
+- Position: Bottom of cover
+- Weight: Regular, same geometric sans
+
+---
+
+## Palette
+
+**Primary:** Void black background (#000000 or #0a0a0b)
+
+**Accent choice — pick one:**
+
+**Option A: Pure white**
+Question mark dots and typography in pure white (#FFFFFF). Clean, scientific, no-noise. The flask rendered as a fine white line drawing.
+
+**Option B: Emergent gold**
+Question mark dots in amber-gold (#fbbf24 or #f59e0b). The effect: a single glowing point of light in darkness, as if the question itself is the light source. Typography in white. The flask as a thin gold outline.
+
+Do not mix both options. Pick one and commit to it.
+
+---
+
+## Flask Integration
+
+The flask is not a prominent element — it is discovered on second look. It sits inside the loop at the bottom of the question mark curve, roughly where the dot of the question mark would be. The dot becomes the flask.
+
+The flask should read as a laboratory Erlenmeyer flask or beaker, rendered as a thin outline (not filled). The same color as the question mark dots.
+
+Size: The flask should be readable but not dominant — roughly 8-12% of the total image height.
+
+---
+
+## What to Avoid
+
+- No mystical swirls, aurora gradients, or nebula effects
+- No crystal, gemstone, or prism imagery
+- No human silhouettes or faces
+- No color gradients across the background
+- No serif typography (this is a lab manual, not a philosophy book)
+- No more than two colors plus black
+- No stock-photo textures
+
+---
+
+## Reference Points
+
+**Aesthetic direction:**
+- Scientific instrument manuals from the 1960s-1970s: precision, clarity, function
+- Particle physics visualizations: dots-as-structure, void backgrounds
+- Technical reference typography: monospace, open tracking, high contrast
+
+**Anti-references (do not resemble):**
+- *The Secret* — no golden light beams or cosmic imagery
+- Generic "mindset" books — no sunrise/mountain silhouettes
+- New Age covers — no sacred geometry overlays
+
+---
+
+## Deliverables
+
+- `public/images/books/wonderproof/cover.jpg` — 2000x3000px, 300dpi, JPEG quality 90+
+- `public/images/books/wonderproof/cover-thumbnail.jpg` — 400x600px, for library index cards
+- `public/images/books/wonderproof/cover-og.jpg` — 1200x630px, for Open Graph social preview
+
+---
+
+## Notes for Generation
+
+If generating via NB2 (Gemini image) or Higgsfield:
+
+```
+Minimalist book cover. Void black background (#000000). Single large question mark composed of hundreds of tiny white dots/particles, scientific and precise proportions. Small laboratory Erlenmeyer flask integrated as the dot of the question mark, rendered as thin white outline. Clean geometric sans-serif title text: WONDERPROOF. Monospace tagline below: Run the experiment. Then decide. No gradients, no mystical effects, no aurora, no human figures. Scientific instrument aesthetic. High contrast. Pure design.
+```
+
+For the gold variant, replace "white" with "amber-gold (#fbbf24)" throughout.


### PR DESCRIPTION
## Summary

This PR was originally cut 2026-06-22 and had drifted 53+ commits behind `main` (flagged `CONFLICTING`, stale >14d, tracked on #285). Rather than merge the literal old branch — which had accumulated ~2900 files of stale/superseded drift (a static content mirror, generated search index, scripts already reworked elsewhere, and two other books' registry entries that main had since shipped independently and more completely) — this PR was rebuilt from scratch on current `main`, keeping only the content verified as genuinely new.

### Wonderproof — book foundation
- `content/books/wonderproof/{introduction,chapter-01-the-filter,chapter-02-the-milkshake-effect}.md` — verified missing from main. Stripped an unused YAML frontmatter block from each (this repo's chapter loader does a raw `readFileSync` with no frontmatter parsing — the block would have rendered as literal visible text on the page).
- `docs/books/wonderproof/{bible,cover}.md` — planning docs, verified missing.
- `app/books/lib/books-registry.ts` — one new `wonderproof` entry (`status: in-progress`, matching the convention for partially-published books; `coverImage: ''` since no cover art exists yet — the same fallback the existing `coherence` entry uses).

### ExperimentCard reader component
- `app/books/components/ExperimentCard.tsx` — new interactive card for the book's lab-manual "Experiment N: Hypothesis / Setup / Track / What it means" format. Imports the shared `Experiment` type rather than duplicating it inline.
- `app/books/types.ts` — adds `Experiment` + optional `BookChapter.experiment` (additive, backward compatible).
- `app/books/components/BookReader.tsx` — renders `<ExperimentCard>` when a chapter carries structured experiment data, same optional pattern as `chapter.epigraph`.
- **Not populated in this PR:** both current chapters already present their experiment as complete markdown prose (a `## Experiment N: ...` section with Hypothesis/Setup/Track/What it means). Populating `chapter.experiment` now would duplicate that content in the reader rather than replace it — left as ready, inert infrastructure pending that content decision.

### Library additions
- `data/book-reviews.ts` — two new entries, both cross-linked via `relatedBook: 'wonderproof'` (both books are cited directly in Wonderproof's chapter FAQs): **The Power of Eight** (Lynne McTaggart, 2017) and **Altered Traits** (Goleman & Davidson, 2017). Both set `hasCover: false` (their cover images don't exist yet — same convention as the existing `e-squared` entry, gates `next/image` off a placeholder).
- **Not touched:** `e-squared` already exists on main with its own `relatedBook: 'the-wordless-laws'` — left as-is, since `relatedBook` is a single string field and overwriting it would remove that existing cross-link rather than add to it.

### Explicitly dropped from the original stale branch (each verified independently, not assumed)
- Registry duplicate entries for `the-wordless-laws` / `the-wordless-laws-book-two` — both already fully shipped on main (registry + all 14 chapters each).
- `ChapterEndZone.tsx`, `ResumeReading.tsx`, `lib/theme-classes.ts` — all three already exist on main via independent, more current work.
- ~2900 files of unrelated drift (scripts/, the `public/reading` static mirror, `search-index.json`, etc.) — none of it is "book foundation" content, all of it already independently superseded on main.

### Discovered, not fixed here (out of scope — flagging for a follow-up)
`content/books/coherence/` has all 3 chapters live on main but **no `books-registry.ts` entry** — `/books/coherence` is currently unreachable. Pre-existing gap, unrelated to this PR.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — 0 errors (8 pre-existing warnings in unrelated files, unchanged)
- [x] `npx next build` — exit 0, no errors, no warnings mentioning any changed file
- [x] `content:check` (MDX safety + integrity) — passes
- [x] `scripts/voice-audit.sh` against every new/changed file — zero flags in the new content (the full-file run surfaces ~30 pre-existing "consciousness" hits in unrelated, already-shipped reviews about consciousness research — none in this diff)
- [ ] Manual: `/books/wonderproof`, `/books/wonderproof/introduction`, `/library/the-power-of-eight`, `/library/altered-traits` render correctly in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)