### PR TITLE
docs: add ecosystem interconnection map

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,15 @@
+# frankx.ai — in the FrankX Ecosystem
+
+**Role:** The public front door and flagship brand site — research, library, and conscious-creator content.
+
+This site is one surface of the wider [FrankX ecosystem](https://github.com/frankxai/frankxai/blob/main/ECOSYSTEM.md), built on a shared three-layer spine:
+
+```
+SIS (memory) → Hermes (orchestration) → ACOS (operation) → frankx.ai (this surface)
+```
+
+- **Content & skills** run on [Agentic Creator OS](https://github.com/frankxai/agentic-creator-os).
+- **Memory** persists through the [Starlight Intelligence System](https://github.com/frankxai/Starlight-Intelligence-System).
+- **Updates** flow through [Hermes](https://github.com/frankxai/hermes) — this repo is the first live-run target for the governed intent → verified-PR loop.
+
+See the [canonical ecosystem map](https://github.com/frankxai/frankxai/blob/main/ECOSYSTEM.md) for how every project connects.


### PR DESCRIPTION
Adds `ECOSYSTEM.md` linking frankx.ai to the canonical [FrankX ecosystem map](https://github.com/frankxai/frankxai/blob/main/ECOSYSTEM.md).

Part of the 2026-06-23 ecosystem interconnection pass:
- Profile README + canonical `ECOSYSTEM.md` map (live)
- Hermes pushed to GitHub (private)
- `ECOSYSTEM.md` added to 14 hub repos
- 47 repo descriptions set; 5 intelligence-system shells scaffolded

Docs-only change. Leaving for review + CI per branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ecosystem documentation detailing the FrankX architecture layers, frankx.ai's position within the system, and links to related projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->