### PR TITLE
fix(blog): strip markdown links from title and fix carousel 404s

### DIFF
--- a/components/blog/PremiumVisualCarousel.tsx
+++ b/components/blog/PremiumVisualCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { motion, useMotionValue, useTransform } from 'framer-motion'
+import { motion, useMotionValue } from 'framer-motion'
 import { ChevronLeft, ChevronRight, Play } from 'lucide-react'
 
 interface VisualItem {

--- a/components/blog/PremiumVisualCarousel.tsx
+++ b/components/blog/PremiumVisualCarousel.tsx
@@ -14,15 +14,15 @@ interface VisualItem {
 }
 
 const visuals: VisualItem[] = [
-  { slug: 'agent-family-architecture', title: 'Agent Family Architecture vs Swarms', image: '/images/blog/agent-family-architecture-hero-v3.jpg', category: 'AI Architecture' },
-  { slug: 'multi-agent-orchestration-patterns-2026', title: 'Multi-Agent Orchestration Patterns', image: '/images/blog/multi-agent-orchestration-patterns-2026-hero-v3.jpg', category: 'Production AI', hasVideo: true },
-  { slug: 'acos-enterprise-deployment-guide', title: 'ACOS for Enterprise', image: '/images/blog/acos-enterprise-deployment-guide-hero-v3.jpg', category: 'ACOS' },
-  { slug: 'aeo-playbook-get-cited-by-ai-2026', title: 'AEO Playbook 2026', image: '/images/blog/aeo-playbook-get-cited-by-ai-2026-hero-v3.jpg', category: 'Intelligence', hasVideo: true },
-  { slug: 'agentic-ai-roadmap-2026', title: 'Agentic AI Roadmap 2026', image: '/images/blog/agentic-ai-roadmap-2026-hero-v3.jpg', category: 'Strategy' },
-  { slug: 'prompt-engineering-mastery-workshop', title: 'Prompt Engineering Mastery', image: '/images/blog/prompt-engineering-mastery-2026-hero-v3.jpg', category: 'Prompts' },
-  { slug: 'gemma-3-analysis-2026', title: 'Gemma 3 Analysis 2026', image: '/images/blog/gemma-3-analysis-2026-hero-v5.jpg', category: 'Model Intelligence' },
-  { slug: 'llama-4-analysis-2026', title: 'Llama 4 Analysis 2026', image: '/images/blog/llama-4-analysis-2026-hero-v5.jpg', category: 'Model Intelligence' },
-  { slug: 'mistral-large-3-analysis-2026', title: 'Mistral Large 3 Analysis 2026', image: '/images/blog/mistral-large-3-analysis-2026-hero-v5.jpg', category: 'Model Intelligence' },
+  { slug: 'agent-family-architecture', title: 'Agent Family Architecture vs Swarms', image: '/images/blog/editorial/headers/agent-family-architecture-hero.webp', category: 'AI Architecture' },
+  { slug: 'multi-agent-orchestration-patterns-2026', title: 'Multi-Agent Orchestration Patterns', image: '/images/blog/multi-agent-orchestration-v2.png', category: 'Production AI', hasVideo: true },
+  { slug: 'acos-enterprise-deployment-guide', title: 'ACOS for Enterprise', image: '/images/blog/acos-enterprise-deployment-guide-hero-v8.jpg', category: 'ACOS' },
+  { slug: 'aeo-playbook-get-cited-by-ai-2026', title: 'AEO Playbook 2026', image: '/images/blog/editorial/headers/aeo-playbook-get-cited-by-ai-2026-hero.webp', category: 'Intelligence', hasVideo: true },
+  { slug: 'agentic-ai-roadmap-2026', title: 'Agentic AI Roadmap 2026', image: '/images/blog/agentic-ai-roadmap-2026-hero-v2.png', category: 'Strategy' },
+  { slug: 'prompt-engineering-mastery-workshop', title: 'Prompt Engineering Mastery', image: '/images/blog/editorial/headers/prompt-engineering-mastery-workshop-hero.webp', category: 'Prompts' },
+  { slug: 'gemma-3-analysis-2026', title: 'Gemma 3 Analysis 2026', image: '/images/blog/gemma-3-analysis-2026-hero-v8.jpg', category: 'Model Intelligence' },
+  { slug: 'llama-4-analysis-2026', title: 'Llama 4 Analysis 2026', image: '/images/blog/llama-4-analysis-2026-hero-premium.png', category: 'Model Intelligence' },
+  { slug: 'mistral-large-3-analysis-2026', title: 'Mistral Large 3 Analysis 2026', image: '/images/blog/editorial/headers/mistral-large-3-analysis-2026-hero.webp', category: 'Model Intelligence' },
 ]
 
 export default function PremiumVisualCarousel() {

--- a/content/blog/using-elevenlabs-for-faceless-youtube-channels-and-higgsfield-for-b-roll.mdx
+++ b/content/blog/using-elevenlabs-for-faceless-youtube-channels-and-higgsfield-for-b-roll.mdx
@@ -1,5 +1,5 @@
 ---
-title: "The Ultimate Guide: Using [ElevenLabs](https://try.elevenlabs.io/7x6qh6upgry8) for faceless Youtube channels and [Higgsfield](https://go.agenticincome.ai/higgsfield) for B-roll"
+title: "The Ultimate Guide: Using ElevenLabs for Faceless YouTube Channels and Higgsfield for B-Roll"
 description: "How to combine modern AI voice models with responsive video tools for high-retention faceless production."
 category: "Creator Systems"
 badge: "ACOS PIPELINE"


### PR DESCRIPTION
## Summary

- **Article title had raw markdown link syntax** — `[ElevenLabs](url)` and `[Higgsfield](url)` in the frontmatter `title` field was leaking into the page `<title>`, the H1 heading, breadcrumbs, and the blog index hero as literal text. Fixed to plain text.
- **PremiumVisualCarousel had 9 broken image paths** — all carousel entries referenced `-v3.jpg` / `-v5.jpg` paths that don't exist on disk. Updated each to the correct existing path (editorial `.webp` headers or versioned `.jpg`/`.png` files). This was causing 10 console 404 errors on every blog index page load.
- **Removed unused `useTransform` import** from `PremiumVisualCarousel.tsx`.

## Test plan

- [ ] `/blog` index page loads without console image 404 errors
- [ ] `/blog/using-elevenlabs-for-faceless-youtube-channels-and-higgsfield-for-b-roll` shows clean title in H1, `<title>`, and breadcrumbs — no `[ElevenLabs](url)` text
- [ ] Carousel images render correctly on blog index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated carousel visuals with refreshed image assets while keeping the same cards and content structure.
  * Cleaned up an article title for more consistent plain-text formatting and capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->