### PR TITLE
feat(motion): two-track motion system — GSAP+Lenis scroll primitives

### DIFF
--- a/.claude/skills/motion-system/SKILL.md
+++ b/.claude/skills/motion-system/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: motion-system
+description: "Operationalized scroll-driven motion for frankx.ai. Use when a page needs cinematic scroll storytelling — pinned sections, parallax depth, scroll-scrubbed video, or a timeline-orchestrated reveal — beyond what Framer Motion's mount/hover/whileInView patterns cover. Covers the two-track model (Framer Motion for micro-interactions, GSAP ScrollTrigger + Lenis for scroll choreography), the decision rule for picking a track, copy-correct Next.js patterns, and the performance + accessibility budget every motion-heavy page must hold. Governed by taste.md's \"Motion: the earned scroll set-piece\" — read that section before shipping a Track-B moment."
+---
+
+# Motion System
+
+Premium motion is not "more animation." It is **one continuous scroll timeline** the eye can follow, plus crisp component feedback — held inside a strict performance and taste budget.
+
+frankx.ai already ships Framer Motion heavily (hundreds of components) for mount/hover/`whileInView` reveals — that's working and should stay untouched. What's missing is scroll storytelling: pinned sections, scrubbed media, coordinated multi-element scroll sequences. This skill is the manual for that missing half, and the governance that keeps it from becoming AI-slop.
+
+---
+
+## The two-track model
+
+Two libraries, two jobs, never fighting for the same element.
+
+| Track | Library | Owns | Use for |
+|---|---|---|---|
+| **Micro** | Framer Motion | mount/enter, hover, tap, layout, `whileInView` | buttons, cards, nav, modals, list reveals, the page-load hero moment — the current default everywhere |
+| **Scroll** | GSAP `ScrollTrigger` + Lenis | the scroll timeline | pinned sections, parallax layers, scrubbed video/media, multi-element sequences tied to scroll progress |
+
+**Decision rule — pick the Scroll track when ANY is true:**
+- A section should **pin** (stay fixed) while content moves over/through it.
+- Media (video, image sequence) should **scrub** — progress bound to scroll position.
+- **≥5 elements** animate in a coordinated sequence as scroll crosses a threshold.
+- You need **parallax depth** (≥3 layers moving at different rates).
+
+Otherwise stay on Framer. Nearly every page is Framer-only. A flagship page (a hub landing, a hero-led product page) is Framer everywhere + **one** Scroll set-piece — see `taste.md`'s four-point bar before adding it.
+
+> Never drive the same property of the same element from both libraries. Framer owns the card's hover; GSAP owns the section's scroll. Clean seam.
+
+---
+
+## Setup (once per page/layout)
+
+### Smooth scroll root
+
+Wrap the page (or a layout) in `SmoothScroll` — Lenis smoothing bridged to GSAP's ticker so `ScrollTrigger` reads Lenis positions.
+
+```tsx
+import { SmoothScroll } from '@/components/motion';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <SmoothScroll>{children}</SmoothScroll>;
+}
+```
+
+`SmoothScroll` is a no-op under `prefers-reduced-motion: reduce` — native scroll, zero smoothing. That's the correct fallback, not an afterthought.
+
+### GSAP plugin registration
+
+`ScrollScene` registers `ScrollTrigger` once, client-side, guarded so it never double-registers. Never `registerPlugin` in a server component.
+
+---
+
+## Patterns (copy-correct)
+
+### A. Pinned scroll section
+
+```tsx
+'use client';
+import { ScrollScene } from '@/components/motion';
+
+export function ManifestoPin() {
+  return (
+    <ScrollScene
+      pin
+      scrub
+      start="top top"
+      end="+=120%"
+      className="min-h-screen"
+      timeline={(tl, root) => {
+        const lines = root.querySelectorAll('[data-line]');
+        tl.from(lines, { opacity: 0.15, y: 24, stagger: 0.2, ease: 'none' });
+      }}
+    >
+      <p data-line>The work is the proof.</p>
+      <p data-line>Everything else is chrome.</p>
+    </ScrollScene>
+  );
+}
+```
+
+### B. Parallax depth (3 layers)
+
+```tsx
+timeline={(tl) => {
+  tl.to('[data-depth="back"]',  { yPercent: -8,  ease: 'none' }, 0)
+    .to('[data-depth="mid"]',   { yPercent: -18, ease: 'none' }, 0)
+    .to('[data-depth="front"]', { yPercent: -32, ease: 'none' }, 0);
+}}
+```
+`ease: 'none'` is mandatory for anything `scrub`-bound — the scroll *is* the easing. An easing curve on a scrubbed tween fights the reader's finger.
+
+### C. Scroll-scrubbed video
+
+```tsx
+timeline={(tl, root) => {
+  const v = root.querySelector('video') as HTMLVideoElement;
+  v.pause();
+  const onMeta = () => tl.fromTo(v, { currentTime: 0 }, { currentTime: v.duration, ease: 'none' });
+  if (v.readyState >= 1) onMeta(); else v.addEventListener('loadedmetadata', onMeta, { once: true });
+}}
+```
+Asset rules: short hero clip (≤4 MB WebM + MP4 fallback), `muted playsInline preload="auto"`, and a `poster` still that is exactly what reduced-motion readers see.
+
+### D. Component micro (stays on Framer — the default)
+
+```tsx
+import { motion } from 'framer-motion';
+
+<motion.div initial={{ opacity: 0, y: 24 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, margin: '-15%' }}>
+  {children}
+</motion.div>
+```
+
+---
+
+## Performance budget (non-negotiable)
+
+Motion that drops frames reads as cheap, not premium.
+
+- **60fps under scroll.** Only animate `transform` and `opacity`. Never `top/left/width/height/margin` in a scrubbed tween.
+- **LCP unaffected.** Lazy-load any Scroll-track set-piece below the fold (`next/dynamic`, `ssr: false`). The hero's first paint never waits on GSAP.
+- **Hero video ≤ 4 MB** WebM (+ MP4 fallback), poster ships immediately.
+- **One pinned section per page**, max — see `taste.md`'s four-point bar.
+- Call `ScrollTrigger.refresh()` after async content/images change layout, or pins drift.
+
+---
+
+## Accessibility (the fallback is part of the design)
+
+- Every scroll set-piece has a **static composition** under `prefers-reduced-motion: reduce`. `SmoothScroll`/`ScrollScene` already early-return; the *static* layout must still tell the story (video → poster, scrubbed reveal → all content visible).
+- Scrubbed video is `muted` (never autoplay sound — also a taste rule) and carries a poster.
+- Pinned content stays keyboard-reachable — it's still in normal DOM order.
+- Don't gate meaning behind motion. If a number only makes sense after a count-up, also render the final value.
+
+---
+
+## Workflow
+
+1. **Classify the page.** Framer-only, or Framer + one Scroll set-piece? Apply the decision rule.
+2. **Build static first.** Motion is added to approved structure, not baked into layout.
+3. **Micro track:** Framer Motion, as already used across the codebase — no change to existing patterns.
+4. **Scroll track:** `SmoothScroll` / `ScrollScene` from `@/components/motion` — read `taste.md`'s four-point bar first.
+5. **Verify:** reduced-motion still tells the story; scroll at 60fps; hero video under budget; exactly one set-piece.
+
+## Never
+
+- Lenis + a CSS `scroll-behavior: smooth` at the same time (they fight).
+- An easing curve on a `scrub` tween (use `ease: 'none'`).
+- Two pinned sections stacked.
+- A scroll set-piece above the fold that blocks LCP.
+- Motion as the only carrier of meaning.
+- Applying this to existing pages unprompted — Track B is opt-in per flagship page, not a retrofit sweep.

--- a/components/motion/ScrollScene.tsx
+++ b/components/motion/ScrollScene.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import type { ReactNode, ReactElement } from 'react'
 import { gsap } from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
@@ -49,8 +49,11 @@ export function ScrollScene({
 }: ScrollSceneProps): ReactElement {
   const ref = useRef<HTMLDivElement>(null)
   // Keep the latest timeline callback without re-running the scene when only it changes.
+  // Assigned in an effect, not during render — refs can't be written while rendering.
   const timelineRef = useRef(timeline)
-  timelineRef.current = timeline
+  useEffect(() => {
+    timelineRef.current = timeline
+  })
 
   useGSAP(
     () => {

--- a/components/motion/ScrollScene.tsx
+++ b/components/motion/ScrollScene.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useRef } from 'react'
+import type { ReactNode, ReactElement } from 'react'
+import { gsap } from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import { useGSAP } from '@gsap/react'
+
+let pluginRegistered = false
+
+export interface ScrollSceneProps {
+  children: ReactNode
+  /** Pin the scene while its timeline scrubs. One pinned scene per page, max. */
+  pin?: boolean
+  /** Bind the timeline to scroll position. `true` = smooth catch-up (scrub: 1). */
+  scrub?: boolean | number
+  /** ScrollTrigger start, e.g. "top top" or "top 80%". */
+  start?: string
+  /** ScrollTrigger end, e.g. "+=120%" or "bottom top". */
+  end?: string
+  className?: string
+  /**
+   * Build the scene's timeline. Receives the GSAP timeline (already wired to the
+   * ScrollTrigger) and the scoped root element. Query children off `root`.
+   * For scrubbed tweens use `ease: 'none'` — the scroll IS the easing.
+   */
+  timeline?: (tl: gsap.core.Timeline, root: HTMLDivElement) => void
+}
+
+/**
+ * ScrollScene — a scoped GSAP ScrollTrigger timeline wrapper for scroll-driven
+ * choreography (pinned sections, parallax, scrubbed media). `useGSAP` handles
+ * cleanup (and pin teardown) automatically on unmount.
+ *
+ * Per `taste.md` ("No animations on text"), never animate copy inside a scene —
+ * scrub composition, media, and layout instead. Text is already there.
+ *
+ * No-op under `prefers-reduced-motion: reduce`: children render in their static
+ * composition, which must already tell the story. See the `motion-system` skill.
+ */
+export function ScrollScene({
+  children,
+  pin = false,
+  scrub = true,
+  start = 'top top',
+  end = '+=100%',
+  className,
+  timeline,
+}: ScrollSceneProps): ReactElement {
+  const ref = useRef<HTMLDivElement>(null)
+  // Keep the latest timeline callback without re-running the scene when only it changes.
+  const timelineRef = useRef(timeline)
+  timelineRef.current = timeline
+
+  useGSAP(
+    () => {
+      const root = ref.current
+      if (!root) return
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+      if (!pluginRegistered) {
+        gsap.registerPlugin(ScrollTrigger)
+        pluginRegistered = true
+      }
+
+      const tl = gsap.timeline({
+        scrollTrigger: {
+          trigger: root,
+          start,
+          end,
+          pin,
+          scrub: scrub === true ? 1 : scrub,
+        },
+      })
+
+      timelineRef.current?.(tl, root)
+    },
+    { scope: ref, dependencies: [pin, scrub, start, end] },
+  )
+
+  return (
+    <div ref={ref} className={className}>
+      {children}
+    </div>
+  )
+}

--- a/components/motion/SmoothScroll.tsx
+++ b/components/motion/SmoothScroll.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { ReactNode, ReactElement } from 'react'
+import Lenis from 'lenis'
+import { gsap } from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+
+let pluginRegistered = false
+
+export interface SmoothScrollProps {
+  children: ReactNode
+  /** Lenis interpolation factor — lower is heavier/slower. 0.1 is the buttery default. */
+  lerp?: number
+}
+
+/**
+ * SmoothScroll — Lenis smoothing bridged to GSAP's ticker so ScrollTrigger reads
+ * Lenis positions (not native scroll). Wrap a page or route-group layout that ships
+ * a `ScrollScene` set-piece — not the global root layout, since most FrankX pages
+ * stay on native scroll.
+ *
+ * Under `prefers-reduced-motion: reduce` this is a no-op: native scroll, zero smoothing.
+ * That is the correct fallback — never force smoothing on users who opted out.
+ *
+ * See the `motion-system` skill for the full two-track model and patterns.
+ */
+export function SmoothScroll({ children, lerp = 0.1 }: SmoothScrollProps): ReactElement {
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    if (!pluginRegistered) {
+      gsap.registerPlugin(ScrollTrigger)
+      pluginRegistered = true
+    }
+
+    const lenis = new Lenis({ lerp, smoothWheel: true })
+
+    // Bridge: every Lenis scroll updates ScrollTrigger; GSAP's ticker drives Lenis' RAF.
+    lenis.on('scroll', ScrollTrigger.update)
+    const onTick = (time: number) => lenis.raf(time * 1000)
+    gsap.ticker.add(onTick)
+    gsap.ticker.lagSmoothing(0)
+
+    return () => {
+      gsap.ticker.remove(onTick)
+      lenis.destroy()
+    }
+  }, [lerp])
+
+  return <>{children}</>
+}

--- a/components/motion/SmoothScroll.tsx
+++ b/components/motion/SmoothScroll.tsx
@@ -45,6 +45,10 @@ export function SmoothScroll({ children, lerp = 0.1 }: SmoothScrollProps): React
     return () => {
       gsap.ticker.remove(onTick)
       lenis.destroy()
+      // SmoothScroll is scoped to a page/layout and can unmount — restore GSAP's
+      // default lag smoothing so other pages' GSAP animations aren't left with it
+      // permanently disabled.
+      gsap.ticker.lagSmoothing(500, 33)
     }
   }, [lerp])
 

--- a/components/motion/index.ts
+++ b/components/motion/index.ts
@@ -1,0 +1,4 @@
+export { SmoothScroll } from './SmoothScroll'
+export type { SmoothScrollProps } from './SmoothScroll'
+export { ScrollScene } from './ScrollScene'
+export type { ScrollSceneProps } from './ScrollScene'

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "framer-motion": "^11.15.0",
     "fuse.js": "^7.3.0",
     "glob": "^10.5.0",
+    "lenis": "^1.1.18",
     "gray-matter": "^4.0.3",
     "isomorphic-dompurify": "^2.35.0",
     "lucide-react": "^0.468.0",
@@ -173,6 +174,7 @@
   },
   "devDependencies": {
     "@google/design.md": "^0.1.1",
+    "@gsap/react": "^2.1.2",
     "@mermaid-js/mermaid-cli": "^11.12.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@nivo/sunburst": "^0.99.0",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "framer-motion": "^11.15.0",
     "fuse.js": "^7.3.0",
     "glob": "^10.5.0",
+    "@gsap/react": "^2.1.2",
     "lenis": "^1.1.18",
     "gray-matter": "^4.0.3",
     "isomorphic-dompurify": "^2.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.15.0)(react@18.3.1)
       '@headlessui/react':
         specifier: ^2.2.9
         version: 2.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -216,9 +219,6 @@ importers:
       '@google/design.md':
         specifier: ^0.1.1
         version: 0.1.1(@types/react@18.3.28)
-      '@gsap/react':
-        specifier: ^2.1.2
-        version: 2.1.2(gsap@3.15.0)(react@18.3.1)
       '@mermaid-js/mermaid-cli':
         specifier: ^11.12.0
         version: 11.14.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(puppeteer@24.43.0(typescript@5.9.3))(yaml@2.8.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       isomorphic-dompurify:
         specifier: ^2.35.0
         version: 2.36.0
+      lenis:
+        specifier: ^1.1.18
+        version: 1.3.25(react@18.3.1)
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@18.3.1)
@@ -213,6 +216,9 @@ importers:
       '@google/design.md':
         specifier: ^0.1.1
         version: 0.1.1(@types/react@18.3.28)
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.15.0)(react@18.3.1)
       '@mermaid-js/mermaid-cli':
         specifier: ^11.12.0
         version: 11.14.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(puppeteer@24.43.0(typescript@5.9.3))(yaml@2.8.4)
@@ -576,6 +582,12 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@gsap/react@2.1.2':
+    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
+    peerDependencies:
+      gsap: ^3.12.5
+      react: '>=17'
 
   '@headlessui/react@2.2.10':
     resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
@@ -5297,6 +5309,20 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
+  lenis@1.3.25:
+    resolution: {integrity: sha512-mOKxayErlaONK8fm4LN3XNd99Qu4plTpn9h9qf8wxzjGrJDzuD84FYzZ81HCd6ZsWp++VWVwOzL286Pf2s2u4A==}
+    peerDependencies:
+      '@nuxt/kit': '>=3.0.0'
+      react: '>=17.0.0'
+      vue: '>=3.0.0'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      react:
+        optional: true
+      vue:
+        optional: true
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -7869,7 +7895,7 @@ snapshots:
   '@google/design.md@0.1.1(@types/react@18.3.28)':
     dependencies:
       '@json-render/core': 0.16.0(zod@3.25.76)
-      '@json-render/ink': 0.16.0(ink@7.0.2(@types/react@18.3.28)(react@18.3.1))(react@19.2.6)(zod@3.25.76)
+      '@json-render/ink': 0.16.0(ink@7.0.2(@types/react@18.3.28)(react@19.2.6))(react@19.2.6)(zod@3.25.76)
       citty: 0.1.6
       ink: 7.0.2(@types/react@18.3.28)(react@19.2.6)
       mdast: 3.0.0
@@ -7902,6 +7928,11 @@ snapshots:
       protobufjs: 7.5.6
       yargs: 17.7.2
     optional: true
+
+  '@gsap/react@2.1.2(gsap@3.15.0)(react@18.3.1)':
+    dependencies:
+      gsap: 3.15.0
+      react: 18.3.1
 
   '@headlessui/react@2.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8117,7 +8148,7 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@json-render/ink@0.16.0(ink@7.0.2(@types/react@18.3.28)(react@18.3.1))(react@19.2.6)(zod@3.25.76)':
+  '@json-render/ink@0.16.0(ink@7.0.2(@types/react@18.3.28)(react@19.2.6))(react@19.2.6)(zod@3.25.76)':
     dependencies:
       '@json-render/core': 0.16.0(zod@3.25.76)
       ink: 7.0.2(@types/react@18.3.28)(react@19.2.6)
@@ -13059,6 +13090,10 @@ snapshots:
   layout-base@2.0.1: {}
 
   leac@0.6.0: {}
+
+  lenis@1.3.25(react@18.3.1):
+    optionalDependencies:
+      react: 18.3.1
 
   levn@0.4.1:
     dependencies:

--- a/taste.md
+++ b/taste.md
@@ -116,9 +116,28 @@ Frozen choices. Don't relitigate without explicit cause.
 - **Inter for body, Poppins for display ≥18px.** This pairing is solved. Do not propose alternatives.
 - **`rounded-full` primary CTAs.** This is the recognizable FrankX button shape. Don't square them.
 - **The eyebrow pattern.** 11px / 0.25em tracking / 60% alpha / above the h2. This is the section-opener fingerprint of the brand.
-- **No animations on text.** Type does not slide in, fade in, or scale in. It's already there. Page-load motion is reserved for hero imagery and accent elements.
+- **No animations on text.** Type does not slide in, fade in, or scale in. It's already there. Page-load motion is reserved for hero imagery and accent elements — with one governed exception, see below.
 - **No light-on-light.** White cards on white pages happen on other brands. Not this one.
 - **The two-spectrum rule.** A page picks tech (emerald) *or* soul (amber). Bridge spectrum is a third tier for the worlds where they meet — not a license to mix.
+
+---
+
+## Motion: the earned scroll set-piece
+
+Most motion on this brand is quiet — a hero fades up, a card lifts on hover, a number counts once. That's Framer Motion territory, and it stays that way for 95% of what ships.
+
+But long-scroll cinema (see "Reference points" — Apple's Pro pages, Linear's landing) earns its motion budget differently: one section per flagship page where the *scroll itself* is the choreography. A pinned panel that reveals as you scroll through it. A hero video scrubbed frame-by-frame to your finger. Depth layers drifting at different speeds. That's a different tool — GSAP `ScrollTrigger` bridged to Lenis smooth-scroll, not Framer — and it's governed, not free, because unearned scroll tricks are exactly the kind of thing that makes a page feel like a demo instead of a product.
+
+**The primitives:** `components/motion/SmoothScroll.tsx` (Lenis↔GSAP ticker bridge, wraps the page) and `components/motion/ScrollScene.tsx` (a scoped `ScrollTrigger` timeline for pin/scrub/parallax work). Both are no-ops under `prefers-reduced-motion: reduce` by design — the reduced-motion reader gets the real page, not a broken half-animation.
+
+**The bar.** A scroll set-piece ships only when it clears all four:
+
+1. **It demonstrates, not decorates.** It shows the product or the idea unfolding — a system assembling, a feature loop, a narrative beat. Never motion for its own sake.
+2. **It holds the performance budget.** 60fps under scroll (`transform`/`opacity` only — never `width`, `height`, `top`, `left` in a scrubbed tween), LCP under 2.5s, hero video under 4MB.
+3. **It degrades on purpose.** Under reduced-motion, the static composition still tells the whole story — the scrubbed video shows its poster, the scroll reveal shows all its content.
+4. **There is exactly one per page.** One pinned or scrubbed moment. A second one turns cinema into a tech demo.
+
+Miss any of the four — cut it. This is the same restraint test as everything else on this brand; scroll choreography doesn't get a pass from it, it gets held to it more precisely because it's louder.
 
 ---
 


### PR DESCRIPTION
## Summary

Ports the validated "two-track motion system" from [arcanea-ai-app#179](https://github.com/frankxai/arcanea-ai-app/pull/179) to frankx.ai prod — adapted to this repo's actual conventions rather than copy-pasted. Closes the gap where GSAP is installed but used in only ~4 files, while Framer Motion (used heavily, hundreds of components) has zero scroll-driven choreography — no pinned sections, no scrubbed media, no real `ScrollTrigger` usage anywhere.

**Nothing existing is touched.** This adds shared primitives + documentation + a governance rule; no pages are redesigned.

## Changes

- **`components/motion/`** — new reusable primitives:
  - `SmoothScroll` — Lenis smoothing bridged to GSAP's ticker so `ScrollTrigger` reads Lenis positions. Scoped to a page/layout (not the global root) since most FrankX pages stay on native scroll. No-op under `prefers-reduced-motion: reduce`.
  - `ScrollScene` — scoped `ScrollTrigger` timeline wrapper (pin/scrub/parallax), cleanup via `@gsap/react`'s `useGSAP`. Reduced-motion no-op.
- **`package.json`** — add `lenis` + `@gsap/react` (`gsap` already present).
- **`.claude/skills/motion-system/SKILL.md`** — the two-track decision rule (Framer for micro-interactions vs GSAP+Lenis for scroll choreography), copy-correct patterns, performance budget, accessibility rules.
- **`taste.md`** — new "Motion: the earned scroll set-piece" section + a carve-out note on the existing "No animations on text" frozen choice: one governed Track-B scroll moment per flagship page, gated on (1) demonstrates not decorates, (2) holds a 60fps/LCP/hero-video-size performance budget, (3) has a deliberate reduced-motion fallback, (4) exactly one per page.

## Test plan

- [x] `npx tsc --noEmit` — clean, zero errors.
- [x] `npx next build` — succeeds (the `pnpm run build` prebuild script fails only in this sandbox because it needs a sibling repo clone unrelated to this change; `next build` directly confirms the actual compilation).
- [ ] Wire `<SmoothScroll>` + one `<ScrollScene>` set-piece on a real flagship page; verify 60fps under scroll in DevTools Performance.
- [ ] Toggle `prefers-reduced-motion: reduce` → smoothing off, scene renders its static composition, story intact.

## Risk / rollback

Low. New, additively-imported components (nothing consumes them yet) + two dependencies + docs/taste prose. Rollback = revert the commit. No existing motion, pages, or components touched.

## Related

- [arcanea-ai-app#179](https://github.com/frankxai/arcanea-ai-app/pull/179) — the validated reference this ports from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123wdnzNzHcx29JFrwzCY71

---
_Generated by [Claude Code](https://claude.ai/code/session_0123wdnzNzHcx29JFrwzCY71)_