### PR TITLE
feat(learn): wire the Learn hub into guides & research + cross-link portals

### DIFF
--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { MDXContent } from '@/components/blog/MDXContent'
 import Link from 'next/link'
 import HeroImage from '@/components/ui/HeroImage'
 import Breadcrumbs from '@/components/seo/Breadcrumbs'
+import LearnHubSection from '@/components/learn/LearnHubSection'
+import { portalsForGuide } from '@/lib/learn/related-portals'
 
 // Static generation - content is read at build time
 export const dynamicParams = false
@@ -64,6 +66,12 @@ export default async function GuidePage({ params }: { params: Promise<{ slug: st
             <MDXContent source={guide.content} />
           </div>
         </div>
+        <LearnHubSection
+          relatedPortals={portalsForGuide(guide.slug)}
+          variant="compact"
+          eyebrow="Keep learning"
+          blurb="Curated videos, official docs, and expert channels for the platforms this guide touches."
+        />
       </main>
     </div>
   )

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -2,6 +2,8 @@ import { getAllGuides, type GuideDoc } from '@/lib/guides'
 import { createMetadata } from '@/lib/seo'
 import JsonLd from '@/components/seo/JsonLd'
 import GuidesPageClient from './GuidesPageClient'
+import LearnHubSection from '@/components/learn/LearnHubSection'
+import { MODEL_MAKER_PORTALS } from '@/lib/learn/related-portals'
 
 export const metadata = createMetadata({
   title: 'Creator Guides - Build What Matters with AI',
@@ -40,6 +42,14 @@ export default function GuidesPage() {
     <>
       <JsonLd type="ItemList" data={guideListSchema} />
       <GuidesPageClient guides={guides} />
+      <div className="bg-[#0a0a0b] pb-20">
+        <LearnHubSection
+          relatedPortals={[...MODEL_MAKER_PORTALS]}
+          eyebrow="Go deeper"
+          heading="Curated learning portals"
+          blurb="Guides give you the system. The Learn hub curates the best videos, official docs, and expert channels for each AI platform — updated as the tools ship."
+        />
+      </div>
     </>
   )
 }

--- a/app/research/[slug]/page.tsx
+++ b/app/research/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { getSourcesForDomain } from '@/lib/research/sources'
 import { getClaimCountForDomain } from '@/lib/research/validated-claims'
 import { getBlogPost } from '@/lib/blog'
 import ResearchDomainPage from './ResearchDomainPage'
+import LearnHubSection from '@/components/learn/LearnHubSection'
+import { portalsForResearch } from '@/lib/learn/related-portals'
 
 interface PageProps {
   params: Promise<{ slug: string }>
@@ -142,6 +144,15 @@ export default async function Page({ params }: PageProps) {
         dangerouslySetInnerHTML={{ __html: faqLd }}
       />
       <ResearchDomainPage domain={domain} relatedDomains={relatedDomains} claimCount={claimCount} blogPostTitles={blogPostTitles} />
+      <div className="bg-[#0a0a0b] pb-16">
+        <LearnHubSection
+          relatedPortals={portalsForResearch(domain.slug)}
+          variant="compact"
+          eyebrow="From research to practice"
+          heading="Learn these tools hands-on"
+          blurb="The research maps the landscape. These portals curate the videos, docs, and experts to actually build with the platforms it covers."
+        />
+      </div>
     </>
   )
 }

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -33,6 +33,8 @@ import {
 } from 'lucide-react'
 import { researchDomains, researchAgents, domainCategories } from '@/lib/research/domains'
 import type { DomainCategory } from '@/lib/research/domains'
+import LearnHubSection from '@/components/learn/LearnHubSection'
+import { MODEL_MAKER_PORTALS } from '@/lib/learn/related-portals'
 
 // Icon map for dynamic rendering
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -710,6 +712,12 @@ export default function ResearchPage() {
         <DomainsGrid />
         <ResearchTeamSection />
         <MethodologySection />
+        <LearnHubSection
+          relatedPortals={[...MODEL_MAKER_PORTALS]}
+          eyebrow="From research to practice"
+          heading="Learn the tools hands-on"
+          blurb="The research maps the landscape. These portals curate the videos, docs, and expert channels to actually build with each platform."
+        />
         <CTASection />
       </div>
     </main>

--- a/components/blog/MDXComponents.tsx
+++ b/components/blog/MDXComponents.tsx
@@ -5,6 +5,7 @@ import type { MDXComponents } from 'mdx/types'
 import AffiliateLink from '@/components/affiliates/AffiliateLink'
 import Diagram from '@/components/blog/Diagram'
 import { FunnelCTA } from '@/components/funnel/FunnelCTA'
+import LearnHubCallout from '@/components/learn/LearnHubCallout'
 import { buildInlineVideoSchema } from '@/lib/video-schema'
 
 // Embed components for immersive media
@@ -284,6 +285,7 @@ export const mdxComponents: MDXComponents = {
   Callout,
   AffiliateLink,
   FunnelCTA,
+  LearnHubCallout,
   Link,
   // Embed components for immersive media in blog posts
   YouTubeEmbed,

--- a/content/guides/claude-anthropic-guide.mdx
+++ b/content/guides/claude-anthropic-guide.mdx
@@ -14,6 +14,8 @@ Claude is Anthropic's AI assistant, and it has become my daily creative partner.
 
 This guide covers everything you need to know to make Claude a powerful extension of your creative practice.
 
+<LearnHubCallout slug="claude-mastery" blurb="Prefer to learn by watching? The video companion to this guide curates the best Claude walkthroughs, official docs, and expert channels in one place:" />
+
 ---
 
 ## Why Claude Stands Out

--- a/content/guides/openai-chatgpt-guide.mdx
+++ b/content/guides/openai-chatgpt-guide.mdx
@@ -12,6 +12,8 @@ image: ""
 
 ChatGPT started the AI revolution most creators are living now. As the most widely-used AI assistant, it remains a powerful tool for content creation, ideation, and workflow automation. Whether you're already using it casually or want to unlock its full potential, this guide covers what creators need to know.
 
+<LearnHubCallout slug="chatgpt-mastery" blurb="Want the video walkthroughs alongside this guide? The curated ChatGPT portal collects the best tutorials and prompt-engineering deep dives:" />
+
 ---
 
 ## Why ChatGPT Matters for Creators

--- a/data/learning-paths.ts
+++ b/data/learning-paths.ts
@@ -112,6 +112,8 @@ export const learningPaths: LearningPath[] = [
       '/guides/claude-anthropic-guide',
       '/blog/frontier-model-landscape-2026-claude-gpt-gemini-deepseek',
       '/learn/gemini-mastery',
+      '/learn/codex-mastery',
+      '/learn/chatgpt-mastery',
     ],
     videos: [
       {
@@ -485,6 +487,8 @@ export const learningPaths: LearningPath[] = [
       '/guides/claude-code-getting-started',
       '/blog/ultimate-guide-ai-coding-agents-2026',
       '/learn/claude-mastery',
+      '/learn/chatgpt-mastery',
+      '/learn/gemini-mastery',
     ],
     videos: [
       {
@@ -560,6 +564,8 @@ export const learningPaths: LearningPath[] = [
       '/guides/top-50-ai-prompts',
       '/guides/founder-ai-stack-2026',
       '/learn/codex-mastery',
+      '/learn/claude-mastery',
+      '/learn/gemini-mastery',
     ],
     videos: [
       {
@@ -646,6 +652,8 @@ export const learningPaths: LearningPath[] = [
       '/blog/best-ai-tools-for-creators-2026',
       '/blog/vibe-os-platform-introduction',
       '/learn/claude-mastery',
+      '/learn/codex-mastery',
+      '/learn/chatgpt-mastery',
     ],
     videos: [
       {

--- a/lib/learn/related-portals.ts
+++ b/lib/learn/related-portals.ts
@@ -52,10 +52,12 @@ const RESEARCH_PORTALS: Record<string, string[]> = {
 
 /** Portals to surface at the bottom of a guide page. */
 export function portalsForGuide(slug: string): string[] {
-  return GUIDE_PORTALS[slug] ?? [...MODEL_MAKER_PORTALS]
+  // Spread so callers get a fresh array — never a reference into the shared map.
+  return [...(GUIDE_PORTALS[slug] ?? MODEL_MAKER_PORTALS)]
 }
 
 /** Portals to surface at the bottom of a research domain page. */
 export function portalsForResearch(slug: string): string[] {
-  return RESEARCH_PORTALS[slug] ?? [...MODEL_MAKER_PORTALS]
+  // Spread so callers get a fresh array — never a reference into the shared map.
+  return [...(RESEARCH_PORTALS[slug] ?? MODEL_MAKER_PORTALS)]
 }

--- a/lib/learn/related-portals.ts
+++ b/lib/learn/related-portals.ts
@@ -1,0 +1,61 @@
+/**
+ * Explicit guide/research-slug → /learn portal-slug mappings.
+ *
+ * Deliberately explicit rather than tag-inferred: tags drift and retag over
+ * time, which would silently point a page at the wrong portal. A hand-kept map
+ * is greppable and reviewable in a PR. Unknown slugs fall back to the full set
+ * of model-maker portals (the hub as a whole), and LearnHubSection silently
+ * drops any portal slug that no longer resolves — so a rename can't break a page.
+ *
+ * When Phase 3 adds cloud (aws-bedrock, azure-ai-foundry, oracle-oci-genai) and
+ * creative (suno-music, midjourney, notebooklm) portals, add their slugs to the
+ * relevant guide/research entries here (e.g. midjourney-guide → midjourney).
+ */
+
+/** The four model-maker portals live today. Order is the display order. */
+export const MODEL_MAKER_PORTALS = [
+  'claude-mastery',
+  'codex-mastery',
+  'chatgpt-mastery',
+  'gemini-mastery',
+] as const
+
+/** content/guides/<slug>.mdx → portal slugs. Omitted guides get the default set. */
+const GUIDE_PORTALS: Record<string, string[]> = {
+  'claude-anthropic-guide': ['claude-mastery'],
+  'claude-code-getting-started': ['claude-mastery', 'codex-mastery'],
+  'openai-chatgpt-guide': ['chatgpt-mastery'],
+  'image-generation-mastery': ['gemini-mastery'],
+  'ai-writing-system': ['claude-mastery', 'chatgpt-mastery'],
+  'first-agent-primer': ['claude-mastery', 'codex-mastery'],
+  'agent-collective-operating-system': ['claude-mastery'],
+  'top-50-ai-prompts': ['chatgpt-mastery', 'claude-mastery'],
+  'skills-library-playbook': ['claude-mastery'],
+  'frankx-skill-creation-methodology': ['claude-mastery'],
+}
+
+/** lib/research/domains.ts <slug> → portal slugs. Omitted domains get the default set. */
+const RESEARCH_PORTALS: Record<string, string[]> = {
+  'generative-ai': ['claude-mastery', 'codex-mastery', 'chatgpt-mastery', 'gemini-mastery'],
+  'model-arena': ['claude-mastery', 'codex-mastery', 'chatgpt-mastery', 'gemini-mastery'],
+  'agent-benchmarks': ['claude-mastery', 'codex-mastery', 'chatgpt-mastery', 'gemini-mastery'],
+  'coding-assistants': ['claude-mastery', 'codex-mastery', 'gemini-mastery'],
+  'agent-frameworks': ['claude-mastery', 'codex-mastery', 'gemini-mastery'],
+  'ai-agent-config': ['claude-mastery', 'codex-mastery'],
+  'multi-agent-systems': ['claude-mastery', 'gemini-mastery'],
+  'prompt-engineering': ['claude-mastery', 'chatgpt-mastery'],
+  'context-engineering': ['claude-mastery'],
+  'production-patterns': ['claude-mastery'],
+  'mcp-ecosystem': ['claude-mastery'],
+  'ai-creative-tools': ['gemini-mastery'],
+}
+
+/** Portals to surface at the bottom of a guide page. */
+export function portalsForGuide(slug: string): string[] {
+  return GUIDE_PORTALS[slug] ?? [...MODEL_MAKER_PORTALS]
+}
+
+/** Portals to surface at the bottom of a research domain page. */
+export function portalsForResearch(slug: string): string[] {
+  return RESEARCH_PORTALS[slug] ?? [...MODEL_MAKER_PORTALS]
+}


### PR DESCRIPTION
## Why

`LearnHubSection` and `LearnHubCallout` shipped in the foundation PR (#172) but were **never imported anywhere** — dead code. The "interlinked" value of the Learn hub didn't exist on the live site: guides and research had zero links into `/learn`. This turns the components on across the site and cross-links the four model-maker portals to each other.

This is **step 1 of a re-sequenced 3-phase plan** (the codebase moved past the original plan — there are now 4 portals: `claude-mastery` + `gemini-mastery` rich, `codex-mastery` + `chatgpt-mastery` thin):
1. **Wire the interlinking** ← this PR (highest UX leverage, lowest risk)
2. Level the two thin portals to the claude/gemini depth bar
3. Breadth — cloud (AWS/Azure/OCI) + creative (Suno/Midjourney/NotebookLM) portals

## What changed

**New — `lib/learn/related-portals.ts`**
Explicit guide/research-slug → portal-slug maps (`portalsForGuide`, `portalsForResearch`) with a `MODEL_MAKER_PORTALS` default. Explicit over tag-inference on purpose: tags drift; a hand-kept map is greppable and reviewable. Unknown slugs fall back to the full set, and `LearnHubSection` already drops any slug that no longer resolves — a rename can't break a page.

**`LearnHubSection`** (bottom-of-content "Continue in the Learn Hub")
| Page | Context | Portals shown |
|------|---------|---------------|
| `app/guides/page.tsx` | server | all four, under the listing |
| `app/guides/[slug]/page.tsx` | server | compact, mapped per guide |
| `app/research/page.tsx` | client | all four, before the CTA |
| `app/research/[slug]/page.tsx` | server | compact, mapped per domain |

**`LearnHubCallout`** (inline MDX)
- Registered in `components/blog/MDXComponents.tsx` so any guide/blog MDX can drop `<LearnHubCallout slug="..." />` (replaces the old ad-hoc blockquote-link pattern)
- Added to the two most on-topic guides: `claude-anthropic-guide` → `claude-mastery`, `openai-chatgpt-guide` → `chatgpt-mastery`

**Cross-linking — `data/learning-paths.ts`**
Each model-maker portal (claude, codex, chatgpt, gemini) now lists its three siblings in `relatedGuides`, so a visitor on any one portal can hop to the others.

## Test plan

- [x] `npm run type-check` → exit 0
- [x] `npm run lint` (changed files) → clean
- [x] `npm run learn:check` → 4 portals validated
- [x] `CI=true npm run build` → exit 0, all 1475 pages generated including `/guides/[slug]` and `/research/[slug]`; the inline MDX callout compiles
- [ ] Visual QA on preview: confirm the hub section renders at the bottom of guides/research and the inline callouts read naturally

## Notes

- **Zero dependencies added** (components use `lucide-react` + `next/link`, already present) — `package.json` / `pnpm-lock.yaml` untouched.
- Out of scope, flagged for follow-up: `content/guides/claude-anthropic-guide.mdx` still references "Claude Opus 4.5" (current is 4.8) — a pre-existing staleness I left alone per surgical-change discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtRsdxZZmsuUvZdRpP5PUy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Learn” recommendation sections to guide and research pages, with related content tailored to each topic.
  * Enabled new in-article callouts in guide content for quicker access to companion learning resources.
* **Content**
  * Expanded cross-links between related learning paths to help readers discover connected guides more easily.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->