### PR TITLE
ci(cost): skip Vercel preview builds on draft PRs

### DIFF
--- a/scripts/should-deploy.sh
+++ b/scripts/should-deploy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Vercel ignoreCommand — exit 0 SKIPS the build, non-zero PROCEEDS.
-# Skips when only docs/internal/research paths changed since the previous deploy.
+# Skips when (a) the triggering PR is a draft, or (b) only docs/internal/
+# research paths changed since the previous deploy.
 # Phase 3.5 of VERCEL-COST-MASSIVE-ACTION — cuts ~30-50% of preview-deploy spend
 # on docs-only commits without touching site behavior.
 #
@@ -21,6 +22,21 @@ set +e  # Don't auto-abort on non-zero — we control exit codes explicitly.
 #   VERCEL_ENV              = production | preview | development
 CURRENT_SHA="${VERCEL_GIT_COMMIT_SHA:-$(git rev-parse HEAD 2>/dev/null)}"
 PREVIOUS_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
+
+# 0. Draft PR check — cheapest possible skip, runs before any git work.
+#    VERCEL_GIT_PULL_REQUEST_ID is only set for PR-linked preview builds
+#    (empty for production and non-PR previews), so this never touches
+#    production. Repo is public — unauthenticated GitHub API call, no token.
+#    Fail-safe to PROCEED: any curl/parse hiccup falls through to the
+#    existing path-diff logic below rather than risking a false skip.
+if [ -n "${VERCEL_GIT_PULL_REQUEST_ID:-}" ] && [ -n "${VERCEL_GIT_REPO_OWNER:-}" ] && [ -n "${VERCEL_GIT_REPO_SLUG:-}" ]; then
+  PR_JSON=$(curl -sf --max-time 5 \
+    "https://api.github.com/repos/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}/pulls/${VERCEL_GIT_PULL_REQUEST_ID}" 2>/dev/null)
+  if [ -n "$PR_JSON" ] && echo "$PR_JSON" | grep -q '"draft"[[:space:]]*:[[:space:]]*true'; then
+    echo "[should-deploy] PR #${VERCEL_GIT_PULL_REQUEST_ID} is a draft — SKIPPING build."
+    exit 0
+  fi
+fi
 
 # 1. Env-var-only redeploy (Vercel dashboard "Redeploy"): same SHA twice.
 #    The user clicked redeploy precisely because something changed (env vars).


### PR DESCRIPTION
## Why
Real Vercel billing data (`vercel usage --group-by project`) shows this is the **actual #1 Build CPU Minutes cost in the whole account** — ~12 deploys/day at ~8min each (~96 build-min/day), more than arcanea-ai-app's Vercel cost. The existing `scripts/should-deploy.sh` (already well-engineered — skips docs-only path changes) has no concept of draft PRs. Recent merged PRs average 1-3 commits before merge; each commit to an open PR currently triggers a full preview build regardless of draft state.

## What
Added a cheap pre-check at the top of `should-deploy.sh`: if the build is PR-linked (`VERCEL_GIT_PULL_REQUEST_ID` set — never true for production) and that PR is a draft per GitHub's public API, skip immediately.

## Safety
- Repo is public, so this is an unauthenticated API call — no token/secret involved.
- `--max-time 5` caps the curl call; any failure (network, non-200, unexpected shape) falls through to the existing path-diff logic unchanged — matches the script's existing "fail safe to PROCEED" philosophy exactly.
- Verified: `bash -n` syntax check passes, and the grep pattern was tested live against a real (non-draft) PR from this repo's history to confirm correct parsing.
- Zero change to production build behavior — the check only fires for PR preview builds.

## Note
This complements, not replaces, the existing path-diff skip logic — both checks run (draft-check first since it's cheapest), either can trigger a skip.