### PR TITLE
Add FrankX signal route selector

### DIFF
--- a/components/home/HomePageElite.tsx
+++ b/components/home/HomePageElite.tsx
@@ -11,6 +11,7 @@ import { EmailSignup } from '@/components/email-signup'
 import { GlowCard } from '@/components/ui/glow-card'
 import { FrankOmegaAvatar } from '@/components/FrankOmega'
 import TrustedByBlock from '@/components/social-proof/TrustedByBlock'
+import { SignalRouteSelector } from '@/components/home/SignalRouteSelector'
 
 // ============================================================================
 // TYPES
@@ -1371,6 +1372,9 @@ export default function HomePageElite({
 
         {/* 4b. AI Stack — tool logos with guide links */}
         <TrustedByBlock />
+
+        {/* 4c. Signal route selector — homepage decision layer */}
+        <SignalRouteSelector />
 
         {/* 5. Products & Tools — moved up, expanded to 6 cards */}
         <ProductsTools />

--- a/components/home/SignalRouteSelector.tsx
+++ b/components/home/SignalRouteSelector.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  ArrowRight,
+  Bot,
+  Building2,
+  GitBranch,
+  Music,
+  ShieldCheck,
+  type LucideIcon,
+} from 'lucide-react'
+
+import { trackEvent } from '@/lib/analytics'
+
+type Accent = 'emerald' | 'cyan' | 'amber'
+
+type SignalRoute = {
+  id: string
+  label: string
+  audience: string
+  title: string
+  description: string
+  proof: string
+  href: string
+  cta: string
+  icon: LucideIcon
+  accent: Accent
+  checks: string[]
+}
+
+const routeAccents: Record<
+  Accent,
+  {
+    icon: string
+    text: string
+    border: string
+    surface: string
+    rail: string
+    focus: string
+  }
+> = {
+  emerald: {
+    icon: 'bg-emerald-500/10 text-emerald-300 border-emerald-400/20',
+    text: 'text-emerald-300',
+    border: 'hover:border-emerald-300/35',
+    surface: 'from-emerald-500/10 via-transparent to-cyan-500/5',
+    rail: 'from-emerald-400 to-cyan-400',
+    focus: 'focus-visible:ring-emerald-400/50',
+  },
+  cyan: {
+    icon: 'bg-cyan-500/10 text-cyan-300 border-cyan-400/20',
+    text: 'text-cyan-300',
+    border: 'hover:border-cyan-300/35',
+    surface: 'from-cyan-500/10 via-transparent to-emerald-500/5',
+    rail: 'from-cyan-400 to-emerald-400',
+    focus: 'focus-visible:ring-cyan-400/50',
+  },
+  amber: {
+    icon: 'bg-amber-500/10 text-amber-300 border-amber-400/20',
+    text: 'text-amber-300',
+    border: 'hover:border-amber-300/35',
+    surface: 'from-amber-500/10 via-transparent to-emerald-500/5',
+    rail: 'from-amber-300 to-emerald-400',
+    focus: 'focus-visible:ring-amber-300/50',
+  },
+}
+
+const signalRoutes: SignalRoute[] = [
+  {
+    id: 'creator-systems',
+    label: 'Creator Systems',
+    audience: 'Musicians, creators, and builders turning output into a repeatable release rhythm.',
+    title: 'Make the next song, guide, or product shippable.',
+    description:
+      'Start with the creative operating system: Suno workflows, prompt patterns, launch rituals, and public proof from the studio.',
+    proof: '12,000+ AI songs produced with Suno.',
+    href: '/products/vibe-os',
+    cta: 'Open Vibe OS',
+    icon: Music,
+    accent: 'emerald',
+    checks: ['Suno workflow', 'Prompt library', 'Release ritual'],
+  },
+  {
+    id: 'builder-systems',
+    label: 'Builder Systems',
+    audience: 'Developers and technical creators who want reusable agents, skills, and productized workflows.',
+    title: 'Fork the system behind the work.',
+    description:
+      'Move from tool experiments to a working creator stack: ACOS, prompts, templates, agent patterns, and build notes.',
+    proof: '630+ AI skills shipped across the operating system.',
+    href: '/acos',
+    cta: 'Explore ACOS',
+    icon: Bot,
+    accent: 'cyan',
+    checks: ['Agent skills', 'Templates', 'Build notes'],
+  },
+  {
+    id: 'architecture-systems',
+    label: 'Architecture Systems',
+    audience: 'Founders, operators, and teams that need practical AI architecture before they scale.',
+    title: 'Design the workflow before the tooling spreads.',
+    description:
+      'Use the enterprise AI architecture lane for agent workflows, MCP patterns, governance, and production delivery notes.',
+    proof: 'Former AI architect at Oracle; independent project.',
+    href: '/ai-architecture',
+    cta: 'Review Architecture',
+    icon: Building2,
+    accent: 'amber',
+    checks: ['Agent workflow', 'MCP patterns', 'Delivery map'],
+  },
+]
+
+const proofSignals = [
+  {
+    label: 'Proof',
+    value: 'Output before claims',
+    detail: 'Songs, repos, guides, and systems stay visible before sales language.',
+  },
+  {
+    label: 'Route',
+    value: 'One next move',
+    detail: 'Each audience gets one primary path instead of a wall of equal CTAs.',
+  },
+  {
+    label: 'Loop',
+    value: 'Build, publish, verify',
+    detail: 'The homepage points to assets that can be used, forked, or audited.',
+  },
+]
+
+export function SignalRouteSelector() {
+  return (
+    <section
+      id="signal-route-selector"
+      aria-labelledby="signal-route-selector-title"
+      className="relative border-t border-white/5 py-24 lg:py-32"
+    >
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="grid gap-10 lg:grid-cols-[0.86fr_1.14fr] lg:items-end">
+          <div className="max-w-2xl">
+            <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/50">
+              Signal Router
+            </p>
+            <h2
+              id="signal-route-selector-title"
+              className="text-3xl font-bold tracking-tight text-white md:text-4xl"
+            >
+              Choose the signal, then ship.
+            </h2>
+            <p className="mt-4 text-base leading-relaxed text-white/50 md:text-lg">
+              FrankX has music, agents, templates, architecture, and field notes. This is the
+              front-door decision layer: pick the route that matches the work you want to move
+              this week.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            {proofSignals.map((signal) => (
+              <div
+                key={signal.label}
+                className="rounded-2xl border border-white/[0.08] bg-white/[0.035] p-4 [backdrop-filter:blur(24px)_saturate(150%)]"
+              >
+                <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-white/35">
+                  {signal.label}
+                </p>
+                <p className="mt-3 text-sm font-semibold text-white">{signal.value}</p>
+                <p className="mt-2 text-xs leading-relaxed text-white/45">{signal.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-12 grid gap-4 lg:grid-cols-3">
+          {signalRoutes.map((route, index) => {
+            const Icon = route.icon
+            const accent = routeAccents[route.accent]
+
+            return (
+              <article
+                key={route.id}
+                className={`group relative flex min-h-[420px] flex-col overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.04] p-5 transition duration-300 [backdrop-filter:blur(28px)_saturate(155%)] [box-shadow:0_14px_50px_-30px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.055)] hover:-translate-y-0.5 ${accent.border}`}
+              >
+                <div
+                  className={`pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b ${accent.surface} opacity-90`}
+                  aria-hidden="true"
+                />
+                <div
+                  className={`pointer-events-none absolute left-5 right-5 top-0 h-px bg-gradient-to-r ${accent.rail} opacity-45`}
+                  aria-hidden="true"
+                />
+
+                <div className="relative flex flex-1 flex-col">
+                  <div className="flex items-start justify-between gap-4">
+                    <div
+                      className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border ${accent.icon}`}
+                    >
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </div>
+                    <span className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${accent.text}`}>
+                      {route.label}
+                    </span>
+                  </div>
+
+                  <p className="mt-6 min-h-[48px] text-sm leading-relaxed text-white/45">
+                    {route.audience}
+                  </p>
+                  <h3 className="mt-6 text-2xl font-semibold tracking-tight text-white">
+                    {route.title}
+                  </h3>
+                  <p className="mt-4 text-sm leading-relaxed text-white/52">
+                    {route.description}
+                  </p>
+
+                  <div className="mt-6 rounded-2xl border border-white/[0.07] bg-[#0a0a0b]/45 p-4">
+                    <div className="flex items-start gap-3">
+                      <ShieldCheck className={`mt-0.5 h-4 w-4 shrink-0 ${accent.text}`} aria-hidden="true" />
+                      <p className="text-sm leading-relaxed text-white/62">{route.proof}</p>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {route.checks.map((check) => (
+                      <span
+                        key={check}
+                        className="rounded-full border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-[11px] font-medium text-white/45"
+                      >
+                        {check}
+                      </span>
+                    ))}
+                  </div>
+
+                  <Link
+                    href={route.href}
+                    onClick={() =>
+                      trackEvent('frankx_route_selected', {
+                        route: route.id,
+                        href: route.href,
+                        surface: 'homepage_signal_route_selector',
+                      })
+                    }
+                    className={`mt-8 inline-flex h-12 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.06] px-5 text-sm font-semibold text-white transition hover:bg-white/[0.1] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] ${accent.focus}`}
+                  >
+                    {route.cta}
+                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                  </Link>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 rounded-2xl border border-white/[0.08] bg-white/[0.03] p-4 text-xs text-white/42 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-4 w-4 text-emerald-300/70" aria-hidden="true" />
+            <span>Routing contract: creator output, builder systems, team architecture.</span>
+          </div>
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-white/30">
+            tracked as frankx_route_selected
+          </span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/home/SignalRouteSelector.tsx
+++ b/components/home/SignalRouteSelector.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 
 import { trackEvent } from '@/lib/analytics'
+import { FRANKX_VOICE } from '@/lib/voice/frankx-voice'
 
 type Accent = 'emerald' | 'cyan' | 'amber'
 
@@ -66,6 +67,8 @@ const routeAccents: Record<
   },
 }
 
+const architectureProof = `${FRANKX_VOICE.identity.role}. ${FRANKX_VOICE.identity.disclaimer}`
+
 const signalRoutes: SignalRoute[] = [
   {
     id: 'creator-systems',
@@ -102,7 +105,7 @@ const signalRoutes: SignalRoute[] = [
     title: 'Design the workflow before the tooling spreads.',
     description:
       'Use the enterprise AI architecture lane for agent workflows, MCP patterns, governance, and production delivery notes.',
-    proof: 'Former AI architect at Oracle; independent project.',
+    proof: architectureProof,
     href: '/ai-architecture',
     cta: 'Review Architecture',
     icon: Building2,
@@ -159,7 +162,7 @@ export function SignalRouteSelector() {
             {proofSignals.map((signal) => (
               <div
                 key={signal.label}
-                className="rounded-2xl border border-white/[0.08] bg-white/[0.035] p-4 [backdrop-filter:blur(24px)_saturate(150%)]"
+                className="rounded-2xl border border-white/[0.08] bg-white/[0.035] p-4 backdrop-blur-[24px] backdrop-saturate-[150%]"
               >
                 <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-white/35">
                   {signal.label}
@@ -179,7 +182,7 @@ export function SignalRouteSelector() {
             return (
               <article
                 key={route.id}
-                className={`group relative flex min-h-[420px] flex-col overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.04] p-5 transition duration-300 [backdrop-filter:blur(28px)_saturate(155%)] [box-shadow:0_14px_50px_-30px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.055)] hover:-translate-y-0.5 ${accent.border}`}
+                className={`group relative flex min-h-[420px] flex-col overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.04] p-5 transition duration-300 backdrop-blur-[28px] backdrop-saturate-[155%] [box-shadow:0_14px_50px_-30px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.055)] hover:-translate-y-0.5 ${accent.border}`}
               >
                 <div
                   className={`pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b ${accent.surface} opacity-90`}

--- a/components/home/SignalRouteSelector.tsx
+++ b/components/home/SignalRouteSelector.tsx
@@ -11,6 +11,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 
+import { GlowCard, type GlowColor } from '@/components/ui/glow-card'
 import { trackEvent } from '@/lib/analytics'
 import { FRANKX_VOICE } from '@/lib/voice/frankx-voice'
 
@@ -39,6 +40,7 @@ const routeAccents: Record<
     surface: string
     rail: string
     focus: string
+    glow: GlowColor
   }
 > = {
   emerald: {
@@ -48,6 +50,7 @@ const routeAccents: Record<
     surface: 'from-emerald-500/10 via-transparent to-cyan-500/5',
     rail: 'from-emerald-400 to-cyan-400',
     focus: 'focus-visible:ring-emerald-400/50',
+    glow: 'emerald',
   },
   cyan: {
     icon: 'bg-cyan-500/10 text-cyan-300 border-cyan-400/20',
@@ -56,6 +59,7 @@ const routeAccents: Record<
     surface: 'from-cyan-500/10 via-transparent to-emerald-500/5',
     rail: 'from-cyan-400 to-emerald-400',
     focus: 'focus-visible:ring-cyan-400/50',
+    glow: 'cyan',
   },
   amber: {
     icon: 'bg-amber-500/10 text-amber-300 border-amber-400/20',
@@ -64,6 +68,7 @@ const routeAccents: Record<
     surface: 'from-amber-500/10 via-transparent to-emerald-500/5',
     rail: 'from-amber-300 to-emerald-400',
     focus: 'focus-visible:ring-amber-300/50',
+    glow: 'amber',
   },
 }
 
@@ -180,9 +185,10 @@ export function SignalRouteSelector() {
             const accent = routeAccents[route.accent]
 
             return (
-              <article
+              <GlowCard
                 key={route.id}
-                className={`group relative flex min-h-[420px] flex-col overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.04] p-5 transition duration-300 backdrop-blur-[28px] backdrop-saturate-[155%] [box-shadow:0_14px_50px_-30px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.055)] hover:-translate-y-0.5 ${accent.border}`}
+                color={accent.glow}
+                className={`min-h-[420px] p-5 hover:-translate-y-0.5 ${accent.border}`}
               >
                 <div
                   className={`pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b ${accent.surface} opacity-90`}
@@ -193,7 +199,7 @@ export function SignalRouteSelector() {
                   aria-hidden="true"
                 />
 
-                <div className="relative flex flex-1 flex-col">
+                <div className="relative flex min-h-[380px] flex-col">
                   <div className="flex items-start justify-between gap-4">
                     <div
                       className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border ${accent.icon}`}
@@ -248,7 +254,7 @@ export function SignalRouteSelector() {
                     <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
                   </Link>
                 </div>
-              </article>
+              </GlowCard>
             )
           })}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,11 @@
       "name": "frankx",
       "version": "0.2.0",
       "dependencies": {
+        "@gsap/react": "^2.1.2",
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
         "@mdx-js/loader": "^3.1.0",
-        "@mdx-js/mdx": "3.1.1",
+        "@mdx-js/mdx": "^3.1.1",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^16.1.1",
         "@next/third-parties": "^16.1.6",
@@ -36,6 +37,7 @@
         "chokidar": "^4.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "d3": "^7.9.0",
         "d3-geo": "^3.1.1",
         "dotenv": "^17.2.3",
         "framer-motion": "^11.15.0",
@@ -43,9 +45,11 @@
         "glob": "^10.5.0",
         "gray-matter": "^4.0.3",
         "isomorphic-dompurify": "^2.35.0",
+        "lenis": "^1.1.18",
         "lucide-react": "^0.468.0",
         "lunr": "^2.3.9",
         "marked": "12.0.2",
+        "mermaid": "^11.16.0",
         "next": "^16.1.6",
         "next-auth": "^5.0.0-beta.30",
         "next-mdx-remote": "^6.0.0",
@@ -76,18 +80,20 @@
       },
       "devDependencies": {
         "@google/design.md": "^0.1.1",
+        "@gsap/react": "^2.1.2",
         "@mermaid-js/mermaid-cli": "^11.12.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@nivo/sunburst": "^0.99.0",
         "@terrastruct/d2": "^0.1.33",
         "@types/bcryptjs": "^2.4.6",
+        "@types/d3": "^7.4.3",
         "@types/d3-geo": "^3.1.0",
         "@types/lunr": "^2.3.7",
         "@types/node": "^22.10.2",
         "@types/qrcode": "^1.5.5",
         "@types/react": "^18.3.17",
         "@types/react-dom": "^18.3.5",
-        "@types/three": "0.182.0",
+        "@types/three": "^0.184.1",
         "@types/topojson-client": "^3.1.5",
         "animejs": "^4.3.6",
         "eslint": "^9.17.0",
@@ -211,7 +217,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
       "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "package-manager-detector": "^1.3.0",
@@ -594,65 +599,12 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
-      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
-      "dev": true,
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
@@ -1122,6 +1074,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "dev": true,
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
+      }
+    },
     "node_modules/@headlessui/react": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
@@ -1242,14 +1205,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
       "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
@@ -2012,13 +1973,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-      "integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "langium": "3.3.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -6515,6 +6475,21 @@
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
     },
+    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
+      "optional": true
+    },
     "node_modules/@ruvector/ruvllm/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -7402,7 +7377,6 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
       "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-array": "*",
@@ -7441,14 +7415,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-axis": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
       "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -7458,7 +7430,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
       "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -7468,7 +7439,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
       "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -7481,7 +7451,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
       "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-array": "*",
@@ -7492,14 +7461,12 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-dispatch": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
       "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
@@ -7515,21 +7482,18 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
       "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-fetch": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
       "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-dsv": "*"
@@ -7539,21 +7503,18 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
       "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-format": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
       "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-geo": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
       "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -7563,7 +7524,6 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
       "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -7579,35 +7539,30 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-polygon": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
       "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-quadtree": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
       "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-random": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
       "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
@@ -7617,7 +7572,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-selection": {
@@ -7630,7 +7584,6 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -7640,21 +7593,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-time-format": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
       "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -7710,7 +7660,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -7883,18 +7832,17 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.182.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
-      "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": ">=0.5.17",
-        "@webgpu/types": "*",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.22.0"
+        "meshoptimizer": "~1.1.1"
       }
     },
     "node_modules/@types/topojson-client": {
@@ -8485,6 +8433,16 @@
         "win32"
       ]
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@upstash/core-analytics": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
@@ -8644,12 +8602,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
-      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@xenova/transformers": {
       "version": "2.17.2",
@@ -9582,7 +9534,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
       "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -9608,7 +9559,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
       "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -9619,7 +9569,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -9630,7 +9579,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
       "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -9653,7 +9601,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -10122,41 +10069,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^11.0.0"
-      }
-    },
-    "node_modules/chevrotain/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -10559,7 +10471,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
@@ -10646,7 +10557,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
       "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
@@ -10839,10 +10749,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
-      "dev": true,
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -10852,7 +10761,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
       "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cose-base": "^1.0.0"
@@ -10865,7 +10773,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
       "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cose-base": "^2.2.0"
@@ -10878,7 +10785,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
       "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "layout-base": "^2.0.0"
@@ -10888,14 +10794,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
       "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "3",
@@ -10949,7 +10853,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
       "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -10959,7 +10862,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
       "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -10976,7 +10878,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
       "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -10998,7 +10899,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
       "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "^3.2.0"
@@ -11011,7 +10911,6 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -11046,7 +10945,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
       "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -11072,7 +10970,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -11082,7 +10979,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -11104,7 +11000,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
       "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -11117,7 +11012,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
       "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -11132,7 +11026,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -11154,7 +11047,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -11176,7 +11068,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -11186,7 +11077,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
       "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -11196,7 +11086,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -11206,7 +11095,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
       "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -11216,7 +11104,6 @@
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
       "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "1 - 2",
@@ -11227,7 +11114,6 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "internmap": "^1.0.0"
@@ -11237,14 +11123,12 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-sankey/node_modules/d3-shape": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "1"
@@ -11254,14 +11138,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -11278,7 +11160,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -11301,7 +11182,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "^3.1.0"
@@ -11314,7 +11194,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -11327,7 +11206,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -11381,10 +11259,9 @@
       }
     },
     "node_modules/dagre-d3-es": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
-      "integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
-      "dev": true,
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -11476,10 +11353,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "dev": true,
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -11637,7 +11513,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
       "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -11791,9 +11666,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12120,7 +11995,6 @@
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -13690,7 +13564,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/has-bigints": {
@@ -15539,10 +15412,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.28",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
-      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
-      "dev": true,
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -15559,7 +15431,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -15578,8 +15449,7 @@
     "node_modules/khroma": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
-      "dev": true
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -15588,23 +15458,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/langium": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-      "integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "~11.0.3",
-        "chevrotain-allstar": "~0.3.0",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.0.8"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -15631,7 +15484,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/leac": {
@@ -15641,6 +15493,37 @@
       "license": "MIT",
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/lenis": {
+      "version": "1.3.25",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.25.tgz",
+      "integrity": "sha512-mOKxayErlaONK8fm4LN3XNd99Qu4plTpn9h9qf8wxzjGrJDzuD84FYzZ81HCd6ZsWp++VWVwOzL286Pf2s2u4A==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "playground",
+        "playground/*"
+      ],
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkroomengineering"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "react": ">=17.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/levn": {
@@ -15832,10 +15715,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -16582,39 +16464,38 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.12.2",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.2.tgz",
-      "integrity": "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==",
-      "dev": true,
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
-        "@iconify/utils": "^3.0.1",
-        "@mermaid-js/parser": "^0.6.3",
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
-        "cytoscape": "^3.29.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.13",
-        "dayjs": "^1.11.18",
-        "dompurify": "^3.2.5",
-        "katex": "^0.16.22",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.21",
-        "marked": "^16.2.1",
+        "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
       "version": "16.4.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
       "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -16627,7 +16508,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
       "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -16647,9 +16527,9 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
-      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
     },
     "node_modules/micromark": {
@@ -17522,7 +17402,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
       "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -18393,7 +18272,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pako": {
@@ -18508,7 +18386,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -18565,7 +18442,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
@@ -18699,7 +18575,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.1.8",
@@ -18727,14 +18602,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
       "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/points-on-path": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
       "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-data-parser": "0.1.0",
@@ -20565,7 +20438,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rope-sequence": {
@@ -20578,7 +20450,6 @@
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
       "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hachure-fill": "^0.5.2",
@@ -20758,7 +20629,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
@@ -21843,7 +21713,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sucrase": {
@@ -22282,7 +22151,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -22515,7 +22383,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
@@ -22775,7 +22642,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {
@@ -23193,61 +23059,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",


### PR DESCRIPTION
## Summary
- Adds a FrankX homepage Signal Router section with three proof-led audience paths: Creator Systems, Builder Systems, and Architecture Systems.
- Places the selector after `TrustedByBlock` and before the product grid so visitors get one clear next route.
- Refreshes `package-lock.json` to match dependencies already declared in `package.json`, keeping `npm ci`/preview builds aligned.

## Verification
- `npm run type-check`
- `npx eslint --config eslint.config.js components/home/HomePageElite.tsx components/home/SignalRouteSelector.tsx --max-warnings=0`
- `C:\Users\frank\starlight\repos\security\Invoke-RepoSecurityScan.ps1 -Path . -Staged -SkipDependencyScan`
- `CI=1 PUPPETEER_SKIP_DOWNLOAD=1 npm run build`
- Local Chrome visual QA: desktop, mobile, and reduced-motion screenshots; three routes present, no horizontal overflow, no clipping, no card overlap.

## Evidence
- Scene brief: `C:\Users\frank\starlight\repos\_intelligence\specs\god-mode-2026-07-05\frankx-route-selector-scene-brief-2026-07-05.md`
- Design evidence: `C:\Users\frank\starlight\repos\_visual-qa\god-mode-visual-audit-2026-07-05\frankx-route-selector-20260705\design-loop-evidence-frankx-route-selector-2026-07-05.json`

## Known Residuals
- Full repo security wrapper reports pre-existing findings outside changed source; staged scan for this PR passed.
- Local QA shows pre-existing `/api/auth/session` 500 responses and an existing reduced-motion hero hydration warning; `selectorInHydrationWarning` is false.
- Production promotion is intentionally out of scope until preview verification and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Signal Router” section on the homepage.
  * Introduced selectable route cards with icons, descriptions, proof points, and call-to-action links.
  * Added a supporting proof area and a routing contract banner to clarify the available paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->