### PR TITLE
obs(vercel-cost): weekly snapshot 2026-W28 — RED

### DIFF
--- a/data/observability/vercel-cost/2026-W28.json
+++ b/data/observability/vercel-cost/2026-W28.json
@@ -1,0 +1,45 @@
+{
+  "week": "2026-W28",
+  "generatedAt": "2026-07-06T07:06:07Z",
+  "projectId": "prj_NHVIKZtglNidOE1FJiq6eYx5QjIL",
+  "windowDays": 7,
+  "windowStart": "2026-06-29T07:06:07Z",
+  "windowEnd": "2026-07-06T07:06:07Z",
+  "metrics": {
+    "count_total": 128,
+    "count_production": 26,
+    "count_preview": 87,
+    "count_skipped": 8,
+    "count_error": 7,
+    "count_ready": 113,
+    "duration_p50_seconds": 510,
+    "duration_p95_seconds": 531,
+    "duration_max_seconds": 537,
+    "total_build_minutes": 961,
+    "duration_method": "readyAt_minus_buildingAt",
+    "ready_deploys_sampled": 8,
+    "ready_deploys_total": 113,
+    "duration_note": "8/113 READY deploys sampled via get_deployment (spanning Jun 29 – Jul 5); total_build_minutes extrapolated as avg(510.4s) × 113 = 961 min"
+  },
+  "deltas_vs_prior_week": {
+    "prior_week": "2026-W25",
+    "note": "W26 snapshot never created; W27 snapshot (PR#211) unmerged — comparing vs W25 (Jun 8–15). W27 unmerged data for context: count_total=107, p50=553s, total_build_minutes=824 min.",
+    "count_total": -5,
+    "count_total_pct": "-3.8%",
+    "count_production": -1,
+    "count_preview": -19,
+    "count_error": -15,
+    "count_error_pct": "-68.2%",
+    "count_skipped": -3,
+    "duration_p50_seconds": 79,
+    "duration_p50_pct": "+18.3%",
+    "total_build_minutes": 243,
+    "total_build_minutes_pct": "+33.8%"
+  },
+  "verdict": "RED",
+  "alerts": [
+    "duration_p50=510s > 360s RED threshold (was 431s W25, ~553s W27-unmerged). Build times remain elevated; Turbopack + Next.js with large book content library averaging ~510s per READY build.",
+    "count_error=7 ≥ 2 RED threshold. 7 build failures across the week (down significantly from 22 in W25 — a 68% improvement). Failures concentrated in feature branch iteration (ai-architecture PR#210 cluster Jul 1).",
+    "total_build_minutes=961 vs W25=718 (+33.8%, exceeds +30% RED threshold). Driver: avg build time up ~18% (510s vs 431s) with similar deploy count (128 vs 133). Absolute level (961 min) remains well below 1500-min RED ceiling. Comparison skewed by 3-week gap to W25 baseline."
+  ]
+}


### PR DESCRIPTION
## Vercel Cost Watch — 2026-W28 (Jun 29 → Jul 6)

**Verdict: 🔴 RED**

### Metrics

| Metric | W28 | W25 (prior merged) | Delta |
|--------|-----|--------------------|-------|
| Total deploys | 128 | 133 | −5 (−3.8%) |
| Production | 26 | 27 | −1 |
| Preview | 87 | 106 | −19 |
| Errors | 7 | 22 | −15 (−68.2%) ✅ |
| Skipped | 8 | 11 | −3 |
| p50 build time | 510s | 431s | +79s (+18.3%) |
| p95 build time | 531s | 494s | +37s |
| Max build time | 537s | 502s | +35s |
| Total build min | 961 min | 718 min | +243 (+33.8%) |

### RED Triggers

1. **p50=510s > 360s** — Build times remain elevated; Turbopack + Next.js with large book content library averaging ~510s/build.
2. **count_error=7 ≥ 2** — 7 build failures (down 68% from W25's 22; concentrated in ai-architecture PR#210 cluster on Jul 1).
3. **total_build_minutes +33.8% vs W25** — Exceeds +30% RED threshold. Note: comparison is vs W25 (3 weeks ago) since W26 was never snapshotted and W27 (PR#211) remains unmerged. Absolute level (961 min) is well below the 1500-min ceiling.

### Positive Trends
- Error rate dropped 68% (22→7) — biggest improvement since W23
- Deploy count stable/slightly down (128 vs 133)
- Build times down vs W27-unmerged (510s vs 553s) — slow directional improvement

### Baseline Note
W26 snapshot was never created. W27 snapshot (PR#211) was generated but never merged. This snapshot compares against W25 (Jun 8–15) as the most recent approved baseline. W27 unmerged context: count_total=107, p50=553s, total_build_minutes=824 min.

### Methodology
- Deployments fetched: 7 paginated calls covering full 7-day window; gap-checked at boundary (0 additional)
- Duration: `readyAt − buildingAt` via `get_deployment` on 8/113 READY samples spanning Jun 29–Jul 5
- Total build minutes: avg(510.4s) × 113 READY = 961 min (extrapolated)

---
*Automated by FrankX Cost Watch cron — Phase 3.4 · 2026-W28*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi2ESDrG9Wz5ez5vpjA1Bf)_