### PR TITLE
fix(learn/seo): per-portal metadata + canonical, sitemap, schema, interlink wiring

### DIFF
--- a/app/learn/[slug]/layout.tsx
+++ b/app/learn/[slug]/layout.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next'
+import { learningPaths } from '@/data/learning-paths'
+import { createMetadata } from '@/lib/seo'
+
+// Server layout that gives each /learn/[slug] portal its OWN metadata.
+//
+// The page itself is a client component (`'use client'`) for the interactive
+// video players + motion, so it can't export generateMetadata. Without this
+// layout every portal inherited app/learn/layout.tsx verbatim — identical
+// <title>, description, AND a canonical pointing at /learn — which told Google
+// to consolidate all 8 portal pages into the listing and drop the details.
+// This restores unique title / description / canonical / OG per portal.
+
+export function generateStaticParams() {
+  return learningPaths.map((p) => ({ slug: p.slug }))
+}
+
+/** Parse the "Updated July 6, 2026 · …" heroEyebrow into an ISO date for the recency signal. */
+function latestUpdate(heroEyebrow?: string): string | undefined {
+  if (!heroEyebrow) return undefined
+  const m = heroEyebrow.match(/([A-Z][a-z]+ \d{1,2}, \d{4})/)
+  if (!m) return undefined
+  const d = new Date(m[1])
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const path = learningPaths.find((p) => p.slug === slug)
+
+  if (!path) {
+    return createMetadata({
+      title: 'Learning Portal | FrankX',
+      description: 'Curated, free learning portals for the AI platforms that matter.',
+      path: `/learn/${slug}`,
+    })
+  }
+
+  // Portal-specific OG image from the first curated video's YouTube thumbnail.
+  const ogImage = path.videos[0]
+    ? `https://img.youtube.com/vi/${path.videos[0].youtubeId}/maxresdefault.jpg`
+    : undefined
+
+  return createMetadata({
+    title: `${path.title} — Free Learning Portal | FrankX`,
+    description: path.description,
+    path: `/learn/${path.slug}`,
+    keywords: [
+      path.title.toLowerCase(),
+      `learn ${path.title.toLowerCase()}`,
+      'ai learning path',
+      'free ai course',
+      ...path.videos.slice(0, 3).flatMap((v) => v.tags),
+    ],
+    ...(ogImage ? { image: ogImage } : {}),
+    updatedTime: latestUpdate(path.heroEyebrow),
+  })
+}
+
+export default function LearnSlugLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -178,7 +178,8 @@ export default function LearningPathPage() {
   // Recency signal for AI answer engines: parse the "Updated <Month DD, YYYY>"
   // heroEyebrow into an ISO date. This is the strongest freshness cue we have.
   const eyebrowDate = path.heroEyebrow?.match(/([A-Z][a-z]+ \d{1,2}, \d{4})/)?.[1]
-  const dateModified = eyebrowDate ? new Date(eyebrowDate).toISOString() : undefined
+  const parsedDate = eyebrowDate ? new Date(eyebrowDate) : null
+  const dateModified = parsedDate && !Number.isNaN(parsedDate.getTime()) ? parsedDate.toISOString() : undefined
   const heroThumb = path.videos[0]
     ? `https://img.youtube.com/vi/${path.videos[0].youtubeId}/maxresdefault.jpg`
     : undefined

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -175,11 +175,24 @@ export default function LearningPathPage() {
   // otherwise `colors.gradientFrom` throws (the 500 #219 fixed).
   const colors = colorMap[path.color] || defaultColors
 
+  // Recency signal for AI answer engines: parse the "Updated <Month DD, YYYY>"
+  // heroEyebrow into an ISO date. This is the strongest freshness cue we have.
+  const eyebrowDate = path.heroEyebrow?.match(/([A-Z][a-z]+ \d{1,2}, \d{4})/)?.[1]
+  const dateModified = eyebrowDate ? new Date(eyebrowDate).toISOString() : undefined
+  const heroThumb = path.videos[0]
+    ? `https://img.youtube.com/vi/${path.videos[0].youtubeId}/maxresdefault.jpg`
+    : undefined
+  // Entity coverage — the tools this portal actually teaches, as named Things.
+  const aboutEntities = (path.ecosystem ?? []).slice(0, 8).map((t) => ({ '@type': 'Thing', name: t.name }))
+
   const courseSchema = {
     name: path.title,
     description: path.description,
     provider: { '@type': 'Organization', name: 'FrankX.AI', url: 'https://frankx.ai' },
     url: `https://frankx.ai/learn/${path.slug}`,
+    ...(heroThumb ? { image: heroThumb } : {}),
+    ...(dateModified ? { dateModified } : {}),
+    ...(aboutEntities.length > 0 ? { about: aboutEntities } : {}),
     educationalLevel:
       path.difficulty === 'beginner' ? 'Beginner' : path.difficulty === 'intermediate' ? 'Intermediate' : 'Advanced',
     learningResourceType: 'Course',

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -154,28 +154,39 @@ function VideoCard({ video, pathColor }: { video: VideoResource; pathColor: stri
 
 export default function LearnPage() {
   const learningPathSchema = {
-    name: 'FrankX AI Learning Paths',
-    description: 'Curated video learning paths covering AI architecture, music production with AI, prompt engineering, and creative AI workflows.',
+    name: 'FrankX AI Learning Portals',
+    description:
+      'Curated, free learning portals for the AI platforms that matter — Claude, Gemini, ChatGPT, Codex, and Antigravity, plus the enterprise clouds (AWS Bedrock, Azure AI Foundry, Oracle OCI GenAI). Each bundles the best videos, official docs, and expert channels.',
     numberOfItems: learningPaths.length,
     itemListElement: learningPaths.map((path, index) => ({
       '@type': 'ListItem',
       position: index + 1,
       item: {
-        '@type': 'LearningResource',
+        '@type': 'Course',
         name: path.title,
         description: path.description,
         url: `https://frankx.ai/learn/${path.slug}`,
-        provider: { '@type': 'Organization', name: 'FrankX.AI' },
+        provider: { '@type': 'Organization', name: 'FrankX.AI', url: 'https://frankx.ai' },
         educationalLevel: path.difficulty === 'beginner' ? 'Beginner' : path.difficulty === 'intermediate' ? 'Intermediate' : 'Advanced',
-        learningResourceType: 'Video',
-        numberOfItems: path.videos.length,
+        learningResourceType: 'Course',
+        timeRequired: `PT${path.estimatedHours}H`,
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
       },
     })),
+  }
+
+  // Breadcrumb so the listing has an explicit place in the site graph.
+  const breadcrumbSchema = {
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://frankx.ai' },
+      { '@type': 'ListItem', position: 2, name: 'Learn', item: 'https://frankx.ai/learn' },
+    ],
   }
 
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
       <JsonLd type="ItemList" data={learningPathSchema} />
+      <JsonLd type="BreadcrumbList" data={breadcrumbSchema} />
       {/* Hero */}
       <section className="relative pt-24 pb-16 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/10 via-transparent to-violet-500/10" />

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter'
 import { researchDomains } from '@/lib/research/domains'
 import { siteConfig } from '@/lib/seo'
 import { listPartners } from '@/content/partnerships'
+import { learningPaths } from '@/data/learning-paths'
 
 const BASE_URL = siteConfig.url
 
@@ -553,6 +554,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: currentDate,
       changeFrequency: page.changeFrequency,
       priority: page.priority,
+    })
+  })
+
+  // Learn portal detail pages (/learn/[slug]) — dynamic route, not caught by the
+  // static route-index, so enumerate them explicitly. Recency from heroEyebrow.
+  learningPaths.forEach((path) => {
+    const m = path.heroEyebrow?.match(/([A-Z][a-z]+ \d{1,2}, \d{4})/)
+    const parsed = m ? new Date(m[1]) : null
+    const lastModified = parsed && !Number.isNaN(parsed.getTime()) ? parsed.toISOString() : currentDate
+    entries.push({
+      url: `${BASE_URL}/learn/${path.slug}`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.8,
     })
   })
 

--- a/lib/learn/related-portals.ts
+++ b/lib/learn/related-portals.ts
@@ -7,17 +7,25 @@
  * of model-maker portals (the hub as a whole), and LearnHubSection silently
  * drops any portal slug that no longer resolves — so a rename can't break a page.
  *
- * When Phase 3 adds cloud (aws-bedrock, azure-ai-foundry, oracle-oci-genai) and
- * creative (suno-music, midjourney, notebooklm) portals, add their slugs to the
- * relevant guide/research entries here (e.g. midjourney-guide → midjourney).
+ * When creative (suno-music, midjourney, notebooklm) portals ship, add their
+ * slugs to the relevant guide/research entries here (e.g. midjourney-guide →
+ * midjourney).
  */
 
-/** The four model-maker portals live today. Order is the display order. */
+/** The five model-maker portals live today. Order is the display order. */
 export const MODEL_MAKER_PORTALS = [
   'claude-mastery',
   'codex-mastery',
   'chatgpt-mastery',
   'gemini-mastery',
+  'antigravity-mastery',
+] as const
+
+/** The three cloud portals. Surface these on cloud/production-architecture pages. */
+export const CLOUD_PORTALS = [
+  'aws-bedrock-mastery',
+  'azure-ai-foundry-mastery',
+  'oracle-oci-genai-mastery',
 ] as const
 
 /** content/guides/<slug>.mdx → portal slugs. Omitted guides get the default set. */
@@ -27,11 +35,12 @@ const GUIDE_PORTALS: Record<string, string[]> = {
   'openai-chatgpt-guide': ['chatgpt-mastery'],
   'image-generation-mastery': ['gemini-mastery'],
   'ai-writing-system': ['claude-mastery', 'chatgpt-mastery'],
-  'first-agent-primer': ['claude-mastery', 'codex-mastery'],
+  'first-agent-primer': ['claude-mastery', 'codex-mastery', 'antigravity-mastery'],
   'agent-collective-operating-system': ['claude-mastery'],
   'top-50-ai-prompts': ['chatgpt-mastery', 'claude-mastery'],
   'skills-library-playbook': ['claude-mastery'],
   'frankx-skill-creation-methodology': ['claude-mastery'],
+  'founder-ai-stack-2026': ['claude-mastery', 'chatgpt-mastery', 'gemini-mastery'],
 }
 
 /** lib/research/domains.ts <slug> → portal slugs. Omitted domains get the default set. */
@@ -40,14 +49,16 @@ const RESEARCH_PORTALS: Record<string, string[]> = {
   'model-arena': ['claude-mastery', 'codex-mastery', 'chatgpt-mastery', 'gemini-mastery'],
   'agent-benchmarks': ['claude-mastery', 'codex-mastery', 'chatgpt-mastery', 'gemini-mastery'],
   'coding-assistants': ['claude-mastery', 'codex-mastery', 'gemini-mastery'],
-  'agent-frameworks': ['claude-mastery', 'codex-mastery', 'gemini-mastery'],
-  'ai-agent-config': ['claude-mastery', 'codex-mastery'],
-  'multi-agent-systems': ['claude-mastery', 'gemini-mastery'],
+  'ai-agent-config': ['claude-mastery', 'codex-mastery', 'antigravity-mastery'],
+  'multi-agent-systems': ['claude-mastery', 'gemini-mastery', 'antigravity-mastery'],
   'prompt-engineering': ['claude-mastery', 'chatgpt-mastery'],
   'context-engineering': ['claude-mastery'],
-  'production-patterns': ['claude-mastery'],
-  'mcp-ecosystem': ['claude-mastery'],
+  // Production / cloud-deployment domains surface the cloud portals.
+  'production-patterns': ['claude-mastery', 'aws-bedrock-mastery', 'azure-ai-foundry-mastery', 'oracle-oci-genai-mastery'],
+  'mcp-ecosystem': ['claude-mastery', 'aws-bedrock-mastery'],
+  'enterprise-ai': ['aws-bedrock-mastery', 'azure-ai-foundry-mastery', 'oracle-oci-genai-mastery'],
   'ai-creative-tools': ['gemini-mastery'],
+  'agent-frameworks': ['claude-mastery', 'codex-mastery', 'gemini-mastery', 'antigravity-mastery'],
 }
 
 /** Portals to surface at the bottom of a guide page. */


### PR DESCRIPTION
## Why — a live deindexing bug + discoverability gaps

From a 3-agent superintelligence audit of `/learn`. This is the **highest-impact** slice: it fixes a bug that's actively costing rankings.

### 🔴 Critical: the canonical/title bug
`/learn/[slug]` is a `'use client'` component, so it can't export `generateMetadata`. Every one of the **8 portal pages** inherited `app/learn/layout.tsx` verbatim:
- identical `<title>` ("Learn | AI Architecture & Creative Systems | FrankX")
- identical description
- **`<link rel="canonical" href="https://frankx.ai/learn">`** ← every portal canonicalized to the *listing*

Google was consolidating all 8 detail pages into `/learn` and dropping them — wasting the 7 inbound blog links and suppressing every Course/FAQ/Video rich result.

**Fix:** new server layout `app/learn/[slug]/layout.tsx` with `generateMetadata` → unique title / description / self-canonical / OG image (first video thumbnail) / keywords / `updatedTime` per portal, + `generateStaticParams`.

### Sitemap
The 8 `/learn/[slug]` URLs were never in `sitemap.xml` (dynamic route, missed by the static route-index). Added an explicit loop (priority 0.8, `lastModified` from each `heroEyebrow` date).

### Course schema enrichment (`app/learn/[slug]/page.tsx`)
Added `dateModified` (parsed from `heroEyebrow` — the top recency signal for AI answer engines), `image`, and `about[]` entity coverage (the ecosystem tools the portal teaches).

### Listing schema (`app/learn/page.tsx`)
Description was stale ("AI music production…" — predated the 8 portals). Rewrote it, upgraded items `LearningResource → Course` (matching detail pages) with price/timeRequired, added `BreadcrumbList`.

### Interlink wiring (`lib/learn/related-portals.ts`)
The 4 portals added since this file was written (antigravity + 3 cloud) were in **no** guide/research mapping — no page surfaced them. Added them (CLOUD_PORTALS const; cloud → production-patterns/enterprise-ai/mcp-ecosystem; antigravity → agent domains).

## Test plan
- [x] `npm run type-check` → 0
- [x] `npm run lint` (touched files) → 0
- [x] `CI=true npm run build` → exit 0
- [ ] After merge: verify each `/learn/[slug]` emits its own `<title>` + self-canonical (view-source), and Rich Results Test on one portal

## Scope note
This is **PR 1 of the /learn buildout** (SEO foundation). Coming next: PR 2 (learner experience — activate the category-grouped listing which is currently dead code, localStorage progress, numbered tracks, kill the "See YouTube" placeholder, focus rings), and a separate **Agentic Learning OS strategy doc** for your decisions (tiers/pricing/certification/web3). No URL renamed, no page deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtRsdxZZmsuUvZdRpP5PUy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated learning portal pages with richer page metadata, better search visibility, and improved link previews.
  * Enhanced learning portal listings with breadcrumb data and course-style structured information.
  * Expanded sitemap coverage so individual learning portal pages are easier to discover.

* **Bug Fixes**
  * Improved date handling for “updated” labels so pages show more accurate modification timestamps.
  * Updated related portal recommendations to surface more relevant learning paths, including the new Antigravity-focused portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->