### PR TITLE
feat(learn/ux): activate the category-grouped listing + front-door polish

### DIFF
--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -124,9 +124,12 @@ function VideoPlayer({ video, color }: { video: VideoResource; color: string }) 
                 {video.level}
               </span>
             </div>
-            <div className="absolute bottom-4 right-4 px-2 py-1 rounded bg-black/70 text-white text-sm">
-              {video.duration}
-            </div>
+            {/* Only show a real duration — the "See YouTube" placeholder read as unfinished. */}
+            {video.duration && video.duration !== 'See YouTube' && (
+              <div className="absolute bottom-4 right-4 px-2 py-1 rounded bg-black/70 text-white text-sm">
+                {video.duration}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,157 +1,10 @@
-'use client'
-
-import { motion } from 'framer-motion'
-import Image from 'next/image'
-import Link from 'next/link'
-import { useState } from 'react'
-import {
-  ArrowRight,
-  Brain,
-  Music2,
-  Zap,
-  ImageIcon,
-  Sparkles,
-  Clock,
-  BookOpen,
-  Play,
-  ExternalLink,
-  GraduationCap,
-} from 'lucide-react'
-import { learningPaths, featuredCreators, type LearningPath, type VideoResource } from '@/data/learning-paths'
+import { learningPaths } from '@/data/learning-paths'
 import JsonLd from '@/components/seo/JsonLd'
+import LearnShell from '@/components/learn/LearnShell'
 
-const iconMap: Record<string, React.ComponentType<{className?: string}>> = {
-  brain: Brain,
-  music: Music2,
-  zap: Zap,
-  image: ImageIcon,
-  sparkles: Sparkles,
-}
-
-const colorMap: Record<string, string> = {
-  emerald: 'from-emerald-500/20 to-emerald-500/5 border-emerald-500/20 text-emerald-400',
-  cyan: 'from-cyan-500/20 to-cyan-500/5 border-cyan-500/20 text-cyan-400',
-  amber: 'from-amber-500/20 to-amber-500/5 border-amber-500/20 text-amber-400',
-  violet: 'from-violet-500/20 to-violet-500/5 border-violet-500/20 text-violet-400',
-  sky: 'from-sky-500/20 to-blue-500/5 border-sky-500/20 text-sky-400',
-}
-
-const playButtonBgMap: Record<string, string> = {
-  emerald: 'bg-emerald-500/80 group-hover:bg-emerald-500',
-  cyan: 'bg-cyan-500/80 group-hover:bg-cyan-500',
-  amber: 'bg-amber-500/80 group-hover:bg-amber-500',
-  violet: 'bg-violet-500/80 group-hover:bg-violet-500',
-  sky: 'bg-sky-500/80 group-hover:bg-sky-500',
-}
-
-function PathCard({ path }: { path: LearningPath }) {
-  const Icon = iconMap[path.icon] || BookOpen
-  const colors = colorMap[path.color]
-
-  return (
-    <Link
-      href={`/learn/${path.slug}`}
-      className={`group relative block p-6 rounded-2xl border bg-gradient-to-br ${colors} hover:border-white/20 transition-all hover:-translate-y-1`}
-    >
-      <div className="flex items-start justify-between mb-4">
-        <div className={`p-3 rounded-xl bg-white/5`}>
-          <Icon className="w-6 h-6" />
-        </div>
-        <span className="text-xs font-medium px-2 py-1 rounded-full bg-white/10 text-white/60 capitalize">
-          {path.difficulty}
-        </span>
-      </div>
-
-      <h3 className="text-xl font-bold text-white mb-2 group-hover:text-white/90">
-        {path.title}
-      </h3>
-      <p className="text-sm text-white/50 mb-4 line-clamp-2">
-        {path.description}
-      </p>
-
-      <div className="flex items-center gap-4 text-xs text-white/40">
-        <div className="flex items-center gap-1.5">
-          <Clock className="w-3.5 h-3.5" />
-          {path.estimatedHours} hours
-        </div>
-        <div className="flex items-center gap-1.5">
-          <Play className="w-3.5 h-3.5" />
-          {path.videos.length} videos
-        </div>
-      </div>
-
-      <ArrowRight className="absolute bottom-6 right-6 w-5 h-5 text-white/20 group-hover:text-white/60 group-hover:translate-x-1 transition-all" />
-    </Link>
-  )
-}
-
-function VideoCard({ video, pathColor }: { video: VideoResource; pathColor: string }) {
-  const [isPlaying, setIsPlaying] = useState(false)
-  const playBtnClasses = playButtonBgMap[pathColor] || playButtonBgMap.emerald
-
-  return (
-    <div className="bg-white/[0.02] border border-white/10 rounded-xl overflow-hidden">
-      {/* Video Thumbnail / Player */}
-      <div className="relative aspect-video bg-black/50">
-        {isPlaying ? (
-          <iframe
-            src={`https://www.youtube.com/embed/${video.youtubeId}?autoplay=1`}
-            className="absolute inset-0 w-full h-full"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            title={video.title}
-          />
-        ) : (
-          <>
-            <Image
-              src={`https://img.youtube.com/vi/${video.youtubeId}/maxresdefault.jpg`}
-              alt={video.title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              className="object-cover"
-            />
-            <button
-              onClick={() => setIsPlaying(true)}
-              className="absolute inset-0 flex items-center justify-center bg-black/40 hover:bg-black/30 transition-colors group"
-            >
-              <div className={`p-4 rounded-full transition-colors ${playBtnClasses}`}>
-                <Play className="w-8 h-8 text-white fill-white" />
-              </div>
-            </button>
-            <div className="absolute bottom-2 right-2 px-2 py-1 rounded bg-black/70 text-white text-xs">
-              {video.duration}
-            </div>
-          </>
-        )}
-      </div>
-
-      {/* Video Info */}
-      <div className="p-4">
-        <div className="flex items-center gap-2 mb-2">
-          <span className={`text-xs px-2 py-0.5 rounded-full bg-white/10 capitalize text-white/60`}>
-            {video.level}
-          </span>
-        </div>
-        <h4 className="font-semibold text-white mb-1 line-clamp-2">
-          {video.title}
-        </h4>
-        <p className="text-sm text-white/50 mb-3 line-clamp-2">
-          {video.description}
-        </p>
-        <a
-          href={video.creatorChannel}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs text-white/40 hover:text-white/70 transition-colors"
-        >
-          {video.creator}
-          <ExternalLink className="w-3 h-3" />
-        </a>
-      </div>
-    </div>
-  )
-}
-
+// The listing UI lives in components/learn/LearnShell.tsx (category-grouped).
+// This page owns the structured data and renders the shell — the flat inline
+// grid that used to live here was superseded by LearnShell and is gone.
 export default function LearnPage() {
   const learningPathSchema = {
     name: 'FrankX AI Learning Portals',
@@ -167,7 +20,8 @@ export default function LearnPage() {
         description: path.description,
         url: `https://frankx.ai/learn/${path.slug}`,
         provider: { '@type': 'Organization', name: 'FrankX.AI', url: 'https://frankx.ai' },
-        educationalLevel: path.difficulty === 'beginner' ? 'Beginner' : path.difficulty === 'intermediate' ? 'Intermediate' : 'Advanced',
+        educationalLevel:
+          path.difficulty === 'beginner' ? 'Beginner' : path.difficulty === 'intermediate' ? 'Intermediate' : 'Advanced',
         learningResourceType: 'Course',
         timeRequired: `PT${path.estimatedHours}H`,
         offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
@@ -175,7 +29,6 @@ export default function LearnPage() {
     })),
   }
 
-  // Breadcrumb so the listing has an explicit place in the site graph.
   const breadcrumbSchema = {
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://frankx.ai' },
@@ -184,98 +37,10 @@ export default function LearnPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[#0a0a0b]">
+    <>
       <JsonLd type="ItemList" data={learningPathSchema} />
       <JsonLd type="BreadcrumbList" data={breadcrumbSchema} />
-      {/* Hero */}
-      <section className="relative pt-24 pb-16 overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/10 via-transparent to-violet-500/10" />
-
-        <div className="relative max-w-6xl mx-auto px-6">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="text-center mb-12"
-          >
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm font-medium mb-6">
-              <GraduationCap className="w-4 h-4" />
-              Curated Learning Paths
-            </div>
-
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-              Learn AI the{' '}
-              <span className="bg-gradient-to-r from-emerald-400 to-cyan-400 bg-clip-text text-transparent">
-                Right Way
-              </span>
-            </h1>
-
-            <p className="text-xl text-white/60 max-w-2xl mx-auto">
-              Free resources from the best creators on the internet.
-              Curated paths that actually get you results.
-            </p>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Learning Paths Grid */}
-      <section className="max-w-6xl mx-auto px-6 pb-16">
-        <div className="grid md:grid-cols-2 gap-6">
-          {learningPaths.map((path, i) => (
-            <motion.div
-              key={path.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: i * 0.1 }}
-            >
-              <PathCard path={path} />
-            </motion.div>
-          ))}
-        </div>
-      </section>
-
-      {/* Featured Creators */}
-      <section className="max-w-6xl mx-auto px-6 pb-16">
-        <div className="text-center mb-8">
-          <h2 className="text-2xl font-bold text-white mb-2">Featured Creators</h2>
-          <p className="text-white/50">Learn from the best in the AI education space</p>
-        </div>
-
-        <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
-          {featuredCreators.map((creator) => (
-            <a
-              key={creator.name}
-              href={creator.channel}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="p-4 rounded-xl border border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.04] hover:border-white/20 transition-all text-center"
-            >
-              <h3 className="font-semibold text-white mb-1">{creator.name}</h3>
-              <p className="text-xs text-white/50 mb-2">{creator.specialty}</p>
-              <p className="text-xs text-emerald-400">{creator.subscribers} subscribers</p>
-            </a>
-          ))}
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="max-w-4xl mx-auto px-6 pb-24">
-        <div className="bg-gradient-to-br from-emerald-500/10 to-violet-500/10 rounded-3xl border border-white/10 p-8 md:p-12 text-center">
-          <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
-            Want Structured Guidance?
-          </h2>
-          <p className="text-white/60 mb-8 max-w-xl mx-auto">
-            Free resources are great for exploration.
-            For a structured path with hands-on projects, check out our guides.
-          </p>
-          <Link
-            href="/guides"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-white text-black font-medium rounded-xl hover:bg-white/90 transition-colors"
-          >
-            Explore Guides
-            <ArrowRight className="w-4 h-4" />
-          </Link>
-        </div>
-      </section>
-    </div>
+      <LearnShell />
+    </>
   )
 }

--- a/components/learn/LearnShell.tsx
+++ b/components/learn/LearnShell.tsx
@@ -126,6 +126,11 @@ export default function LearnShell() {
         <div className="space-y-12">
           {CATEGORY_ORDER.map((cat) => {
             const inCat = learningPaths.filter((p) => p.category === cat)
+            // Skip an empty category entirely UNLESS it's consumer — the only
+            // one with a known roadmap roster (upcomingPortals are all consumer).
+            // This stops the in-build chips showing under the wrong header if a
+            // model-maker/cloud category ever empties.
+            if (inCat.length === 0 && cat !== 'consumer') return null
             const meta = categoryLabels[cat]
             return (
               <div key={cat}>

--- a/components/learn/LearnShell.tsx
+++ b/components/learn/LearnShell.tsx
@@ -1,15 +1,12 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import Image from 'next/image'
 import Link from 'next/link'
-import { useState } from 'react'
 import {
   ArrowRight,
   Clock,
   BookOpen,
   Play,
-  ExternalLink,
   GraduationCap,
 } from 'lucide-react'
 import {
@@ -17,15 +14,12 @@ import {
   featuredCreators,
   type LearningPath,
   type LearningPathCategory,
-  type VideoResource,
 } from '@/data/learning-paths'
-import { iconMap, colorMap, playButtonBgMap } from '@/lib/learn/portal-display'
+import { iconMap, colorMap } from '@/lib/learn/portal-display'
 
+// Genuinely not-yet-built portals. AWS Bedrock, Azure AI Foundry, Oracle OCI
+// GenAI, and ChatGPT already shipped — they must not appear here as "coming".
 const upcomingPortals: string[] = [
-  'AWS Bedrock',
-  'Azure AI Foundry',
-  'Oracle OCI GenAI',
-  'OpenAI / ChatGPT',
   'Suno AI Music',
   'Midjourney',
   'NotebookLM Deep Work',
@@ -55,7 +49,7 @@ function PathCard({ path }: { path: LearningPath }) {
   return (
     <Link
       href={`/learn/${path.slug}`}
-      className={`group relative block p-6 rounded-2xl border bg-gradient-to-br ${colors} hover:border-white/20 transition-all hover:-translate-y-1`}
+      className={`group relative block p-6 rounded-2xl border bg-gradient-to-br ${colors} hover:border-white/20 transition-all hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]`}
     >
       <div className="flex items-start justify-between mb-4">
         <div className={`p-3 rounded-xl bg-white/5`}>
@@ -89,79 +83,13 @@ function PathCard({ path }: { path: LearningPath }) {
   )
 }
 
-function VideoCard({ video, pathColor }: { video: VideoResource; pathColor: string }) {
-  const [isPlaying, setIsPlaying] = useState(false)
-  const playBtnClasses = playButtonBgMap[pathColor] || playButtonBgMap.emerald
-
-  return (
-    <div className="bg-white/[0.02] border border-white/10 rounded-xl overflow-hidden">
-      {/* Video Thumbnail / Player */}
-      <div className="relative aspect-video bg-black/50">
-        {isPlaying ? (
-          <iframe
-            src={`https://www.youtube.com/embed/${video.youtubeId}?autoplay=1`}
-            className="absolute inset-0 w-full h-full"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            title={video.title}
-          />
-        ) : (
-          <>
-            <Image
-              src={`https://img.youtube.com/vi/${video.youtubeId}/hqdefault.jpg`}
-              alt={video.title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              className="object-cover"
-            />
-            <button
-              onClick={() => setIsPlaying(true)}
-              className="absolute inset-0 flex items-center justify-center bg-black/40 hover:bg-black/30 transition-colors group"
-            >
-              <div className={`p-4 rounded-full transition-colors ${playBtnClasses}`}>
-                <Play className="w-8 h-8 text-white fill-white" />
-              </div>
-            </button>
-            <div className="absolute bottom-2 right-2 px-2 py-1 rounded bg-black/70 text-white text-xs">
-              {video.duration}
-            </div>
-          </>
-        )}
-      </div>
-
-      {/* Video Info */}
-      <div className="p-4">
-        <div className="flex items-center gap-2 mb-2">
-          <span className={`text-xs px-2 py-0.5 rounded-full bg-white/10 capitalize text-white/60`}>
-            {video.level}
-          </span>
-        </div>
-        <h4 className="font-semibold text-white mb-1 line-clamp-2">
-          {video.title}
-        </h4>
-        <p className="text-sm text-white/50 mb-3 line-clamp-2">
-          {video.description}
-        </p>
-        <a
-          href={video.creatorChannel}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs text-white/40 hover:text-white/70 transition-colors"
-        >
-          {video.creator}
-          <ExternalLink className="w-3 h-3" />
-        </a>
-      </div>
-    </div>
-  )
-}
 
 export default function LearnShell() {
   return (
     <div className="min-h-screen bg-[#0a0a0b]">
       {/* Hero */}
       <section className="relative pt-24 pb-16 overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/10 via-transparent to-violet-500/10" />
+        <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/10 via-transparent to-cyan-500/10" />
 
         <div className="relative max-w-6xl mx-auto px-6">
           <motion.div
@@ -186,6 +114,9 @@ export default function LearnShell() {
               official launches, the sharpest expert walkthroughs, and the structure to move
               from first prompt to production.
             </p>
+            <p className="mt-5 text-sm text-white/50">
+              Pick a portal · watch the free path · ship the first project. No account, no cost.
+            </p>
           </motion.div>
         </div>
       </section>
@@ -195,7 +126,6 @@ export default function LearnShell() {
         <div className="space-y-12">
           {CATEGORY_ORDER.map((cat) => {
             const inCat = learningPaths.filter((p) => p.category === cat)
-            if (inCat.length === 0) return null
             const meta = categoryLabels[cat]
             return (
               <div key={cat}>
@@ -203,45 +133,40 @@ export default function LearnShell() {
                   <h2 className="text-2xl font-bold text-white mb-1">{meta.title}</h2>
                   <p className="text-sm text-white/50">{meta.blurb}</p>
                 </div>
-                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {inCat.map((path, i) => (
-                    <motion.div
-                      key={path.id}
-                      initial={{ opacity: 0, y: 20 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: Math.min(i, 4) * 0.05 }}
-                    >
-                      <PathCard path={path} />
-                    </motion.div>
-                  ))}
-                </div>
+                {inCat.length > 0 ? (
+                  <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {inCat.map((path, i) => (
+                      <motion.div
+                        key={path.id}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: Math.min(i, 4) * 0.05 }}
+                      >
+                        <PathCard path={path} />
+                      </motion.div>
+                    ))}
+                  </div>
+                ) : (
+                  // Visible in-build state — a roadmap signal, not a dead gap.
+                  <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.02] p-6">
+                    <p className="text-sm text-white/50 mb-3">
+                      In build — {upcomingPortals.length} portals, same depth and curation.
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {upcomingPortals.map((portal) => (
+                        <span
+                          key={portal}
+                          className="text-xs font-medium px-3 py-1.5 rounded-full bg-white/5 text-white/60 border border-white/5"
+                        >
+                          {portal}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             )
           })}
-        </div>
-      </section>
-
-      {/* Coming Soon */}
-      <section className="max-w-6xl mx-auto px-6 pb-16">
-        <div className="rounded-2xl border border-white/[0.08] bg-white/[0.02] p-6">
-          <div className="flex items-center justify-between flex-wrap gap-4">
-            <div>
-              <p className="text-sm font-semibold text-white mb-1">More portals in build</p>
-              <p className="text-sm text-white/50">
-                Same depth, same curation. Subscribe to the newsletter to be notified when each lands.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {upcomingPortals.map((portal) => (
-                <span
-                  key={portal}
-                  className="text-xs font-medium px-3 py-1.5 rounded-full bg-white/5 text-white/60 border border-white/5"
-                >
-                  {portal}
-                </span>
-              ))}
-            </div>
-          </div>
         </div>
       </section>
 
@@ -259,7 +184,7 @@ export default function LearnShell() {
               href={creator.channel}
               target="_blank"
               rel="noopener noreferrer"
-              className="p-4 rounded-xl border border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.04] hover:border-white/20 transition-all text-center"
+              className="p-4 rounded-xl border border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.04] hover:border-white/20 transition-all text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
               <h3 className="font-semibold text-white mb-1">{creator.name}</h3>
               <p className="text-xs text-white/50 mb-2">{creator.specialty}</p>
@@ -271,7 +196,7 @@ export default function LearnShell() {
 
       {/* CTA */}
       <section className="max-w-4xl mx-auto px-6 pb-24">
-        <div className="rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl bg-gradient-to-br from-emerald-500/10 to-violet-500/10 p-8 md:p-12 text-center">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur-xl bg-gradient-to-br from-emerald-500/10 to-cyan-500/10 p-8 md:p-12 text-center">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-white mb-4">
             Want Structured Guidance?
           </h2>


### PR DESCRIPTION
## Why — PR 2 of the /learn buildout (learner experience)

The audit found the category-grouped listing I built earlier was **dead code**: the live `/learn` rendered a **flat wall of 8 cards** from `app/learn/page.tsx`, while `components/learn/LearnShell.tsx` (grouped, with empty-state + creators) was never mounted. This activates it and applies the front-door polish. Net **−307 lines** (removed the duplicate grid + a dead `VideoCard`).

## What changed

**Activation**
- `app/learn/page.tsx` now renders `<LearnShell/>` (grouped: *frontier model makers · cloud AI surfaces · consumer & creative*) and keeps the structured data. The duplicate flat inline grid + its helpers are gone — it's a lean server component now.

**Correctness**
- The "coming soon" list was **stale** — it advertised AWS Bedrock, Azure AI Foundry, Oracle OCI GenAI, and ChatGPT as upcoming, but all four are **live**. Trimmed to the genuinely-unbuilt three (Suno, Midjourney, NotebookLM).

**UX polish (from the ui-ux audit, against `taste.md`)**
- The empty **"consumer" category used to vanish** (`return null`) — a dead gap. Now its header renders a visible "In build — 3 portals" state (roadmap signal, not a void), replacing the separate redundant Coming Soon section.
- **Orientation line** under the hero: *"Pick a portal · watch the free path · ship the first project. No account, no cost."*
- **Dropped the violet** half of the hero + CTA gradients (taste.md: one spectrum on a tech surface → emerald→cyan).
- **Focus-visible rings** on portal cards + creator links (keyboard a11y — only the final CTA had one).
- Detail page: the **`"See YouTube"` placeholder** (on 44/45 cards) read as unfinished; the badge now only renders a real duration.

## Deferred to PR 3
localStorage progress ("3/8 watched", resume) + numbered video tracks — the "make it a journey" depth, which needs a `VideoResource` data-model change (`order`/`track`).

## Test plan
- [x] `npm run type-check` → 0
- [x] `npm run lint` (changed files) → 0
- [x] `CI=true npm run build` → exit 0
- [ ] Preview QA: `/learn` shows 3 category sections + visible in-build consumer state; keyboard-tab shows focus rings; a portal detail no longer shows "See YouTube"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtRsdxZZmsuUvZdRpP5PUy)_