### PR TITLE
feat(learn): video-intelligence content layer — the AEO/SEO moat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ link-checker-report.txt
 # Starlight/ACOS temporary files
 .starlight/
 .gemini/
+
+# /learn video-intelligence pipeline draft outputs (review artifacts)
+data/learn-enrichment/

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -156,6 +156,35 @@ function VideoPlayer({ video, color }: { video: VideoResource; color: string }) 
             ))}
           </div>
         </div>
+
+        {/* Video-intelligence enrichment — the indexable substance + the take */}
+        {((video.keyTakeaways && video.keyTakeaways.length > 0) || video.architectNote) && (
+          <div className="mt-4 pt-4 border-t border-white/10 space-y-4">
+            {video.keyTakeaways && video.keyTakeaways.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-2">
+                  Key takeaways
+                </p>
+                <ul className="space-y-1.5">
+                  {video.keyTakeaways.map((takeaway, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm text-white/70">
+                      <CheckCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-white/30" />
+                      {takeaway}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {video.architectNote && (
+              <div className={`rounded-xl border ${colors.border} bg-white/[0.02] p-3`}>
+                <p className={`text-xs font-semibold uppercase tracking-wider ${colors.text} mb-1`}>
+                  The AI Architect&apos;s take
+                </p>
+                <p className="text-sm text-white/70 leading-relaxed">{video.architectNote}</p>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )
@@ -309,6 +338,25 @@ export default function LearningPathPage() {
                 {paragraph}
               </p>
             ))}
+          </div>
+        </section>
+      )}
+
+      {/* The AI Architect's Distillation — the unique, citable synthesis */}
+      {path.distillation && (
+        <section id="distillation" className="max-w-4xl mx-auto px-6 pb-16">
+          <div className={`rounded-2xl border ${colors.border} bg-white/[0.02] p-6 md:p-8`}>
+            <div className="flex items-center gap-3 mb-5">
+              <Sparkles className={`w-5 h-5 ${colors.text}`} />
+              <h2 className="text-xl md:text-2xl font-bold text-white">The AI Architect&apos;s Distillation</h2>
+            </div>
+            <div className="prose prose-invert max-w-none text-white/75 leading-relaxed">
+              {path.distillation.split('\n\n').map((paragraph, i) => (
+                <p key={i} className="mb-4">
+                  {paragraph}
+                </p>
+              ))}
+            </div>
           </div>
         </section>
       )}

--- a/data/learning-paths.ts
+++ b/data/learning-paths.ts
@@ -12,6 +12,16 @@ export interface VideoResource {
   level: 'beginner' | 'intermediate' | 'advanced'
   description: string
   tags: string[]
+  // ── Video-intelligence enrichment (optional; renders only when present) ──
+  // The unique, indexable text that turns an embed list into a citable
+  // resource. Populated by scripts/learn/enrich-videos.mjs (transcript →
+  // drafted takeaways) then edited into Frank's voice.
+  /** 3-5 transcript-grounded key points a viewer takes away. */
+  keyTakeaways?: string[]
+  /** Frank's AI-Architect commentary — the differentiator no one can copy. */
+  architectNote?: string
+  /** Public transcript URL, when available, for VideoObject.transcript schema. */
+  transcriptUrl?: string
 }
 
 export interface EcosystemTool {
@@ -71,6 +81,13 @@ export interface LearningPath {
   // Optional richer portal sections — render conditionally when populated.
   heroEyebrow?: string
   longIntro?: string
+  /**
+   * The AI Architect's Distillation — an original, long-form synthesis of what
+   * this portal's videos teach, in Frank's voice. The unique, citable content
+   * that makes the portal rank and become the paid-curriculum backbone.
+   * Markdown paragraphs separated by \n\n.
+   */
+  distillation?: string
   ctaTitle?: string
   ctaBody?: string
   ecosystem?: EcosystemTool[]
@@ -96,6 +113,8 @@ export const learningPaths: LearningPath[] = [
     heroEyebrow: 'Updated June 10, 2026 · Reflects Claude 4.X family + MCP general availability',
     longIntro:
       "Anthropic ships fast: Opus 4.8 leads the family for the hardest reasoning, Sonnet 4.6 is the everyday default, and Haiku 4.5 is the cheap-and-fast tier — all sharing the same agent harness, tool-use surface, and Claude Code IDE. This portal pulls Anthropic's official walkthroughs and the sharpest independent walkthroughs into one path so you can move from your first claude.ai conversation to shipping agents on Bedrock or Vertex without sifting noise.\n\nThink of it as a map: the model line (Opus / Sonnet / Haiku) is the brain, the Claude API is the surface, Claude Code is the IDE companion, the Agent SDK is for building autonomous loops, and MCP is the connector protocol that lets all of them reach your data and tools. Computer Use and Skills are the newer abilities on top.\n\nStart with Foundations (videos 1–3) for the prompt and model layer, then branch into the track that fits — Builder (Claude Code, Agent SDK, MCP), Architect (Bedrock / Vertex / production patterns), or Operator (Skills, Computer Use, daily workflows). The Ecosystem grid, announcements timeline, and FAQ give you the lay of the land in one screen.",
+    distillation:
+      "Here is the honest shape of learning Claude in 2026, from someone who has watched enterprise AI up close: the model is no longer the hard part. Opus, Sonnet, and Haiku are all good enough that your results are decided by everything around the model — how you frame the work, what context you give it, and how much of the loop you let it run. The videos in this portal are worth your time in that order: get the prompt-and-context fundamentals first, then the harness, then the production surface. Skip that order and you will build a fast agent that ships the wrong thing.\n\nThe single mental model that pays off: Claude is a reasoning engine, and the ecosystem is how you feed and fence it. Prompting is how you frame the task. The Claude API is the raw surface. Claude Code is that same engine wired into your repo with an approval model. The Agent SDK is Claude Code's primitives exposed so you can build your own loops. MCP is the wire that lets any of them reach your data and tools. Skills are reusable capabilities you compose on top. Once you see it as one engine with concentric layers — not seven separate products — the learning order picks itself.\n\nThe most useful shift in the last year is captured by the 'don't build agents, build skills' idea: the payoff is not in a bigger autonomous loop, it is in small, sharp, reusable units of capability that a human still directs. That is the difference between a demo and a system you trust in production. When you watch the Claude Code and Agent SDK material, watch for where the human stays in the loop — the approval gates, the CLAUDE.md instructions, the verification step — because that is what separates people who ship with Claude from people who post screenshots of it.\n\nWhere I would spend your first week: run Claude Code on one real, small task in a repo you care about, add a CLAUDE.md, and force yourself to review every change. Then write one MCP server against a data source you actually use. Everything else in this portal — Computer Use, Bedrock/Vertex deployment, the model-selection tradeoffs — is a branch you take once that spine is solid. The goal is not to know Claude; it is to reliably direct it to a working, defensible result. That skill compounds.",
     ctaTitle: 'Ready to ship with Claude?',
     ctaBody:
       'Pair this portal with our written walkthrough and architecture playbooks. Build an agent, ship an MCP-backed app, or compare Claude head-to-head against Gemini.',

--- a/scripts/check-learning-paths.mjs
+++ b/scripts/check-learning-paths.mjs
@@ -263,6 +263,7 @@ for (const e of entries) {
     field(e.body, 'description'),
     field(e.body, 'heroEyebrow'),
     field(e.body, 'longIntro'),
+    field(e.body, 'distillation'),
     field(e.body, 'ctaTitle'),
     field(e.body, 'ctaBody'),
     fieldList(e.body, 'outcomes'),
@@ -273,7 +274,7 @@ for (const e of entries) {
 
   for (const word of FORBIDDEN) {
     if (flaggable.includes(word.toLowerCase())) {
-      fail(`[${e.id}] forbidden hype word "${word}" in authored copy (description / heroEyebrow / longIntro / ctaTitle / ctaBody / outcomes)`)
+      fail(`[${e.id}] forbidden hype word "${word}" in authored copy (description / heroEyebrow / longIntro / distillation / ctaTitle / ctaBody / outcomes)`)
     }
   }
 }

--- a/scripts/learn/enrich-videos.mjs
+++ b/scripts/learn/enrich-videos.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * enrich-videos.mjs — the video-intelligence pipeline for /learn portals.
+ *
+ * Turns each curated video into indexable substance: fetches the transcript,
+ * drafts 3-5 key takeaways + a Frank-voice "AI Architect's take", and writes a
+ * REVIEW FILE for Frank to edit before it lands in data/learning-paths.ts.
+ *
+ * WHY IT LIVES HERE BUT RUNS ELSEWHERE
+ *   The site's CI/build sandbox has no YouTube network access (verified: HTTP
+ *   000). Run this in an environment with network — Frank's Claude Code /
+ *   Antigravity — not in the Vercel build.
+ *
+ * USAGE
+ *   OPENROUTER_API_KEY=... node scripts/learn/enrich-videos.mjs <portal-slug>
+ *   e.g. node scripts/learn/enrich-videos.mjs claude-mastery
+ *
+ * OUTPUT
+ *   data/learn-enrichment/<slug>.draft.json — { [videoId]: { keyTakeaways,
+ *   architectNote, transcriptUrl } }. Review, edit into Frank's voice, then
+ *   paste the fields onto the matching videos in data/learning-paths.ts.
+ *   Nothing is written to the live data file automatically — the human voice
+ *   pass is the point.
+ *
+ * DESIGN NOTES
+ *   - LLM route = OpenRouter per ~/.claude/CLAUDE.md (OPENROUTER_API_KEY +
+ *     OPENROUTER_BASE_URL). Swap MODEL below as desired.
+ *   - Transcript fetch uses YouTube's public timedtext endpoint; if a video
+ *     has no public captions it is skipped and logged (not fabricated).
+ *   - The architect-note prompt encodes Frank's voice constraints (results
+ *     over claims, no hype) so drafts start on-brand.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const OUT_DIR = path.join(ROOT, 'data', 'learn-enrichment')
+const MODEL = process.env.ENRICH_MODEL || 'anthropic/claude-opus-4-8'
+const OPENROUTER_BASE = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1'
+
+const FORBIDDEN = [
+  'revolutionary', 'transformative', 'unlock', 'harness', 'leverage',
+  'game-changing', 'next-generation', 'cutting-edge', 'seamless',
+]
+
+const slug = process.argv[2]
+if (!slug) {
+  console.error('Usage: node scripts/learn/enrich-videos.mjs <portal-slug>')
+  process.exit(1)
+}
+if (!process.env.OPENROUTER_API_KEY) {
+  console.error('Set OPENROUTER_API_KEY (this drafts the takeaways + architect notes).')
+  process.exit(1)
+}
+
+// ── Load the portal's videos by regex-reading the data file (no TS import
+//    needed; keeps this runnable as plain node). ────────────────────────────
+function loadVideos(portalSlug) {
+  const src = fs.readFileSync(path.join(ROOT, 'data', 'learning-paths.ts'), 'utf8')
+  const start = src.indexOf(`slug: '${portalSlug}'`)
+  if (start === -1) throw new Error(`Portal '${portalSlug}' not found in data/learning-paths.ts`)
+  // Grab the videos: [...] array within this entry (until the next top-level field after it).
+  const videosIdx = src.indexOf('videos: [', start)
+  const block = src.slice(videosIdx, src.indexOf('\n    ],', videosIdx))
+  const videos = []
+  const re = /id:\s*'([^']+)'[\s\S]*?youtubeId:\s*'([^']+)'[\s\S]*?title:\s*(?:'([^']*)'|"([^"]*)")/g
+  let m
+  while ((m = re.exec(block)) !== null) {
+    videos.push({ id: m[1], youtubeId: m[2], title: m[3] || m[4] || '' })
+  }
+  return videos
+}
+
+// ── Transcript via YouTube timedtext (public captions only). ────────────────
+async function fetchTranscript(youtubeId) {
+  const listUrl = `https://www.youtube.com/api/timedtext?type=list&v=${youtubeId}`
+  const list = await fetch(listUrl).then((r) => r.text()).catch(() => '')
+  const langMatch = list.match(/lang_code="([^"]+)"/)
+  const lang = langMatch ? langMatch[1] : 'en'
+  const trackUrl = `https://www.youtube.com/api/timedtext?lang=${lang}&v=${youtubeId}`
+  const xml = await fetch(trackUrl).then((r) => r.text()).catch(() => '')
+  if (!xml) return null
+  const text = xml
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;#39;/g, "'")
+    .replace(/&amp;quot;/g, '"')
+    .replace(/&amp;amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text || null
+}
+
+// ── Draft takeaways + architect-note in Frank's voice. ──────────────────────
+async function draft(video, transcript) {
+  const system = [
+    'You are drafting learning-portal enrichment in the voice of Frank (FrankX) — an AI Architect.',
+    'Voice: results over claims, precise and technical, humble excellence, show don\'t tell.',
+    'HARD BAN on hype words: ' + FORBIDDEN.join(', ') + ', and any spiritual/grandiose language.',
+    'Return STRICT JSON only: { "keyTakeaways": string[3..5], "architectNote": string }.',
+    'keyTakeaways: concrete points a viewer actually takes away from THIS video, grounded in the transcript.',
+    'architectNote: 2-3 sentences of Frank\'s own judgment — what matters, what he\'d do differently, where the leverage is. Never repeat the takeaways.',
+  ].join('\n')
+  const user = `Video: "${video.title}"\n\nTranscript (may be truncated):\n${transcript.slice(0, 12000)}`
+
+  const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0.4,
+    }),
+  })
+  if (!res.ok) throw new Error(`LLM ${res.status}: ${await res.text()}`)
+  const json = await res.json()
+  const content = json.choices?.[0]?.message?.content ?? '{}'
+  return JSON.parse(content)
+}
+
+async function main() {
+  const videos = loadVideos(slug)
+  console.log(`[enrich] ${slug}: ${videos.length} videos`)
+  const out = {}
+  for (const v of videos) {
+    process.stdout.write(`  · ${v.title.slice(0, 60)} … `)
+    const transcript = await fetchTranscript(v.youtubeId)
+    if (!transcript) {
+      console.log('no public transcript — skipped')
+      continue
+    }
+    try {
+      const drafted = await draft(v, transcript)
+      out[v.id] = {
+        ...drafted,
+        transcriptUrl: `https://www.youtube.com/watch?v=${v.youtubeId}`,
+      }
+      console.log('drafted')
+    } catch (e) {
+      console.log(`draft failed: ${e.message}`)
+    }
+  }
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+  const outPath = path.join(OUT_DIR, `${slug}.draft.json`)
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2))
+  console.log(`\n[enrich] wrote ${outPath}`)
+  console.log('[enrich] Review + edit into your voice, then paste keyTakeaways/architectNote onto the matching videos in data/learning-paths.ts.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## The insight (your steer)

A hub of *embedded videos* has almost **no unique text** — nothing for Google or the answer engines to index or cite; anyone can embed the same video. The moat is original, text-rich substance per portal: **transcript-grounded takeaways + your AI-Architect judgment on top.** This lands the data model, rendering, pipeline, and a flagship proof.

## What's in this PR

**Data model** (`data/learning-paths.ts`) — all optional, render only when populated (zero change to un-enriched portals):
- `VideoResource`: `keyTakeaways?`, `architectNote?`, `transcriptUrl?`
- `LearningPath`: `distillation?` — an original, long-form synthesis of what the portal teaches, in your voice. **The unique, citable content** that ranks and becomes the paid-curriculum backbone.

**Rendering** (`app/learn/[slug]/page.tsx`):
- "The AI Architect's Distillation" section, placed to frame the videos (high on the page for AEO lift).
- Per-video "Key takeaways" + "The AI Architect's take" under each card.

**Pipeline** (`scripts/learn/enrich-videos.mjs`, new — **you run it**):
- fetch transcript → draft takeaways + a your-voice architect-note (LLM via OpenRouter) → write `data/learn-enrichment/<slug>.draft.json` for your voice pass.
- Runs in **your** networked environment — the build sandbox has no YouTube access (verified HTTP 000). No transcript → video skipped, **never fabricated**. Draft outputs gitignored.

**Quality gate** — `distillation` is now hype-word-scanned (it caught "leverage" in my own first draft; reworded).

## Flagship proof
Seeded `claude-mastery` with a genuine, from-first-principles **distillation in your voice** — platform-level expertise (how to actually learn Claude in 2026), *not* fabricated video summaries. It's the template for the other 7 portals, and it's yours to edit/own.

## The workflow this unlocks
1. You run `node scripts/learn/enrich-videos.mjs claude-mastery` in your env → drafts land.
2. You edit into your voice, paste onto the videos.
3. Each portal becomes a deep, uniquely-yours, citable resource — and the same content is the paid curriculum later.

## Test plan
- [x] `npm run learn:check` → 8/8 (distillation scanned)
- [x] `npm run type-check` → 0
- [x] `npm run lint` → 0
- [x] `CI=true npm run build` → exit 0
- [ ] Preview: `/learn/claude-mastery` shows the Distillation section; other portals unchanged

## Note
This is the SEO/AEO content moat and the bridge to the Agentic Learning OS (the distillation = the paid-curriculum backbone). Certification MVP still awaits your pricing/legal calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtRsdxZZmsuUvZdRpP5PUy)_