### PR TITLE
feat: make FrankX homepage proof-led

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,18 +134,6 @@ WORKSHOP_INTAKE_AUDIENCE_ID=
 SLACK_WEBHOOK_URL=
 
 # -----------------------------------------------------------------------------
-# Analytics (Optional)
-# -----------------------------------------------------------------------------
-
-# Plausible Analytics
-NEXT_PUBLIC_PLAUSIBLE_DOMAIN=frankx.ai
-
-# Google Analytics
-# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
-# NEXT_PUBLIC_GA_TRACKING_ID=G-XXXXXXXXXX
-# GA4_PROPERTY_ID=
-
-# -----------------------------------------------------------------------------
 # Development
 # -----------------------------------------------------------------------------
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,9 +4,6 @@ import './globals.css'
 import Script from 'next/script'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { GoogleAnalytics } from '@next/third-parties/google'
-import { Analytics } from '@vercel/analytics/react'
-import { SpeedInsights } from '@vercel/speed-insights/next'
 
 import { cn } from '@/lib/utils'
 import { robotsConfig, siteConfig } from '@/lib/seo'
@@ -17,6 +14,7 @@ import OrganizationJsonLd from '@/components/seo/OrganizationJsonLd'
 import SessionProvider from '@/components/providers/SessionProvider'
 import { ScrollProgress } from '@/components/ui/ScrollProgress'
 import { CursorSpotlight } from '@/components/ui/CursorSpotlight'
+import { PrivacySafeAnalytics } from '@/components/analytics/PrivacySafeAnalytics'
 
 // AIS Plan A Task 21 — Schema.org @graph injected into <head> for AEO/GEO
 const aisSchemaGraph = (() => {
@@ -142,7 +140,6 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -171,13 +168,6 @@ export default function RootLayout({
       >
         <SessionProvider>
           <OrganizationJsonLd />
-          {plausibleDomain && (
-            <Script
-              strategy="afterInteractive"
-              data-domain={plausibleDomain}
-              src="https://plausible.io/js/script.js"
-            />
-          )}
           <a
             href="#main"
             className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white focus:text-black focus:px-3 focus:py-2 focus:rounded z-[100]"
@@ -198,11 +188,7 @@ export default function RootLayout({
             {children}
           </div>
           <Footer />
-          <Analytics />
-          <SpeedInsights />
-          {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
-            <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
-          )}
+          <PrivacySafeAnalytics />
         </SessionProvider>
       </body>
     </html >

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -32,7 +32,7 @@ export default function PrivacyPage() {
 
         <h3 className="text-base font-medium text-zinc-300 mt-4">Data collected automatically</h3>
         <ul className="text-zinc-400 text-sm space-y-1">
-          <li>Pages visited and interactions (via Vercel Analytics — privacy-focused, no cookies)</li>
+          <li>Pages visited and bounded interaction events through Vercel Analytics and, when configured, Plausible or Google Analytics</li>
           <li>Device type, browser, and approximate location (country level)</li>
           <li>IP address (anonymized, not stored long-term)</li>
         </ul>
@@ -67,7 +67,7 @@ export default function PrivacyPage() {
           ['Data Type', 'Retention Period'],
           ['Newsletter subscriptions', 'Until you unsubscribe'],
           ['Purchase records', '7 years (Dutch tax obligation)'],
-          ['Analytics data', 'Aggregated, no personal data stored'],
+          ['Analytics data', 'Kept according to the retention settings of the configured analytics provider; newsletter events exclude email addresses and free-text fields'],
           ['Contact form messages', '1 year after last reply'],
           ['Account data', 'Until you request deletion'],
         ]} />
@@ -92,9 +92,9 @@ export default function PrivacyPage() {
         <InfoTable rows={[
           ['Cookie', 'Type', 'Purpose', 'Duration'],
           ['Essential', 'Strictly necessary', 'Session management, security', 'Session'],
-          ['Analytics', 'Performance', 'Vercel Analytics (privacy-focused)', 'Session'],
+          ['Analytics', 'Performance', 'Vercel Analytics and optional Plausible or Google Analytics', 'Provider setting'],
         ]} />
-        <p className="text-sm text-zinc-500 mt-2">We do not use marketing cookies or third-party tracking cookies. Vercel Analytics is privacy-focused and does not use cookies for tracking individual users.</p>
+        <p className="text-sm text-zinc-500 mt-2">Vercel Analytics is enabled for aggregate site measurement. Plausible and Google Analytics load only when their deployment settings are configured. Newsletter conversion events do not include the submitted email address.</p>
       </Section>
 
       <Section title="8. International Transfers">

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Download, Music, Sparkles, BookOpen, Zap, BarChart3, Mail, 
 import Link from 'next/link'
 import { PRIMARY_SOCIAL_LINKS } from '@/lib/social-links'
 import { useState } from 'react'
+import { trackEvent } from '@/lib/analytics'
 
 /**
  * FrankX Links Page - Mobile-First Creator Hub
@@ -15,29 +16,16 @@ import { useState } from 'react'
  *
  * Social Links: Pulls from @/lib/social-links (BRAND_IDENTITY.md source of truth)
  * Design System: Follows DESIGN_SYSTEM.md patterns
- * Analytics: PostHog event tracking on all CTAs
+ * Analytics: bounded aggregate event tracking on all CTAs
  * Reference: /mnt/c/Users/Frank/FrankX/LINKS_PAGE_DESIGN_SPEC.md
  */
 
-// PostHog type declaration for type safety
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void
-    }
-  }
-}
-
 // Track link click events with proper typing
-const trackLinkClick = (linkTitle: string, linkHref: string, linkType: string) => {
-  if (typeof window !== 'undefined' && window.posthog) {
-    window.posthog.capture('link_clicked', {
-      link_title: linkTitle,
-      link_href: linkHref,
-      link_type: linkType,
-      page: 'links',
-    })
-  }
+const trackLinkClick = (_linkTitle: string, _linkHref: string, linkType: string) => {
+  trackEvent('link_clicked', {
+    link_type: linkType,
+    page: 'links',
+  })
 }
 
 export default function LinksPage() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,33 +1,27 @@
-import HomePageElite from '@/components/home/HomePageElite'
+import FrankXProductionHome from '@/components/home/FrankXProductionHome'
 import { createMetadata, siteConfig } from '@/lib/seo'
 import { socialLinks } from '@/lib/social-links'
 import JsonLd from '@/components/seo/JsonLd'
-import { FAQPageJsonLd } from '@/components/seo/JsonLd'
 import { getAllBlogPosts } from '@/lib/blog'
-import { bookReviews } from '@/data/book-reviews'
 
 export const metadata = createMetadata({
-  title: 'FrankX - AI Architect & Creator Systems',
+  title: 'FrankX — Executive AI Architecture & Operator Systems',
   description:
-    'Former AI architect at Oracle. Creator of 12,000+ songs with Suno. Practical AI systems, music experiments, and evidence-led performance notes for creators who ship with clarity.',
+    'Executive AI architecture, agent workflows, and operating controls for founders and teams moving from scattered experiments to inspectable systems.',
   keywords: [
     'Frank Riemer',
     'FrankX',
     'ai architect',
-    'personal AI operating system',
-    'AI creator systems',
-    'attention and recovery systems',
-    'ai music creation',
-    'suno ai',
+    'executive AI architecture',
+    'AI operating system',
     'ai architecture',
     'ai workflow automation',
-    'creator tools',
     'agentic workflows',
     'enterprise ai',
     'claude code',
     'multi-agent systems',
     'ai coding agents',
-    'prompt engineering',
+    'AI governance',
   ],
   path: '/',
 })
@@ -40,7 +34,7 @@ const websiteSchema = {
   alternateName: ['FrankX.AI', 'Frank Riemer'],
   url: siteUrl,
   description:
-    'FrankX is Frank Riemer\'s home for AI creator systems, agentic workflows, music experiments, and evidence-led performance notes.',
+    'FrankX is Frank Riemer\'s independent practice and public workbench for executive AI architecture, agent workflows, and operator systems.',
   publisher: {
     '@id': `${siteUrl}/#organization`,
   },
@@ -78,11 +72,10 @@ const personSchema = {
   ],
   knowsAbout: [
     'AI Architecture',
-    'Personal AI Operating Systems',
-    'AI Creator Systems',
-    'AI Music Creation',
-    'Suno AI',
-    'Attention and Recovery Systems',
+    'AI Operating Systems',
+    'AI Governance',
+    'Multi-Agent Systems',
+    'Agent Evaluation',
     'Enterprise AI Strategy',
     'Cloud Infrastructure',
     'Agentic Workflows',
@@ -104,51 +97,7 @@ const organizationSchema = {
     socialLinks.suno,
   ],
   description:
-    'FrankX publishes AI creator systems, agentic workflow labs, music experiments, and practical performance notes from Frank Riemer.',
-}
-
-const homepageFAQs = [
-  {
-    question: 'What is FrankX.AI?',
-    answer:
-      'FrankX.AI is the independent personal hub of Frank Riemer, a former AI architect at Oracle and creator of 12,000+ AI-generated songs with Suno. The site features technical tutorials, AI architecture guides, music production workflows, and open-source creator tools. Independent project. Not affiliated with, endorsed by, or sponsored by Oracle.',
-  },
-  {
-    question: 'What kind of content does FrankX publish?',
-    answer:
-      'FrankX publishes technical tutorials on AI coding agents, enterprise AI architecture patterns, Suno AI music production guides, prompt engineering frameworks, multi-agent orchestration, and the Signal Loop field notes.',
-  },
-  {
-    question: 'How can I learn AI music production with Suno?',
-    answer:
-      'Start with the Suno Prompt Engineering Complete Guide on the blog, which covers the 5-Layer Prompt Architecture, genre-specific techniques, and tuning and texture choices. FrankX has produced 12,000+ tracks and shares production workflows and prompt templates.',
-  },
-  {
-    question: 'What is the Agentic Creator OS (ACOS)?',
-    answer:
-      'ACOS is an open-source operating system for Claude Code with 75+ skills, 38 specialized agents, and 35+ commands. It turns Claude Code into a full creative production environment. Free on GitHub, with premium Creator Kit ($47) and Pro System ($197) tiers.',
-  },
-  {
-    question: 'Where does peak performance fit?',
-    answer:
-      'FrankX treats performance as an evidence-led creator system: attention, energy, recovery, and emotional steadiness. It is not medical advice or miracle biohacking.',
-  },
-  {
-    question: 'Does FrankX offer courses or coaching?',
-    answer:
-      'FrankX offers free guides and tutorials on the blog, with premium coaching programs in development. Join the waitlist at frankx.ai/coaching for early access to AI architecture and creator workflow training.',
-  },
-]
-
-const featuredTrack = {
-  id: 'vibe-os-track',
-  title: 'Vibe O S',
-  sunoId: '9cbad174-9276-427f-9aed-1ba00c7db3db',
-  audioUrl:
-    'https://vbmwpibfe0yzx3fd.public.blob.vercel-storage.com/music/9cbad174-9276-427f-9aed-1ba00c7db3db/9cbad174-9276-427f-9aed-1ba00c7db3db.mp3',
-  genre: ['female hip hop', 'bass-heavy', 'lyrical'],
-  plays: 128,
-  duration: '4:00',
+    'FrankX publishes inspectable AI architecture blueprints, agent-workflow systems, implementation notes, and technical field guides from Frank Riemer.',
 }
 
 export default function Page() {
@@ -163,31 +112,12 @@ export default function Page() {
       date: p.date,
     }))
 
-  const libraryBooks = bookReviews
-    .filter((r) => (r.quotes?.length ?? 0) > 0 && (r.chapters?.length ?? 0) > 0)
-    .sort((a, b) => (b.quotes?.length ?? 0) - (a.quotes?.length ?? 0))
-    .slice(0, 5)
-    .map((r) => ({
-      slug: r.slug,
-      title: r.title,
-      author: r.author,
-      coverImage: r.coverImage,
-      quoteCount: r.quotes?.length ?? 0,
-      chapterCount: r.chapters?.length ?? 0,
-    }))
-
   return (
     <>
-      <HomePageElite
-        latestPosts={latestPosts}
-        faqs={homepageFAQs}
-        libraryBooks={libraryBooks}
-        featuredTrack={featuredTrack}
-      />
+      <FrankXProductionHome latestPosts={latestPosts} />
       <JsonLd type="WebSite" data={websiteSchema} />
       <JsonLd type="Person" data={personSchema} />
       <JsonLd type="Organization" data={organizationSchema} />
-      <FAQPageJsonLd faqs={homepageFAQs} id="homepage-faq" />
     </>
   )
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
         </Link>
 
         <h1 className="text-4xl font-bold mb-8">Privacy Policy</h1>
-        <p className="text-white/60 mb-8">Last updated: January 2026</p>
+        <p className="text-white/60 mb-8">Last updated: July 2026</p>
 
         <div className="prose prose-invert prose-sm max-w-none space-y-8">
           <section>
@@ -35,10 +35,24 @@ export default function PrivacyPage() {
             <p className="text-white/70 leading-relaxed mb-4">We may collect the following types of information:</p>
             <ul className="list-disc list-inside text-white/70 space-y-2">
               <li>Email address (when you subscribe to our newsletter or make a purchase)</li>
-              <li>Usage data (pages visited, time spent, referral sources)</li>
-              <li>Device information (browser type, operating system)</li>
+              <li>Aggregate page-view data (page path, referrer category, browser, device, and approximate region)</li>
+              <li>Performance data (such as Core Web Vitals)</li>
               <li>Payment information (processed securely through third-party providers)</li>
             </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold mb-4">Website Measurement</h2>
+            <p className="text-white/70 leading-relaxed mb-4">
+              We use Vercel Web Analytics for aggregate traffic measurement and Vercel Speed Insights for
+              performance measurement. Vercel Web Analytics does not use cookies and does not create a profile
+              that follows you across websites or days.
+            </p>
+            <p className="text-white/70 leading-relaxed">
+              Before a Web Analytics page view is sent, this site removes query strings and URL fragments.
+              It also suppresses Web Analytics events when your browser sends a Do Not Track signal. We do not
+              load optional marketing analytics on the current site because there is no visitor consent control.
+            </p>
           </section>
 
           <section>
@@ -54,8 +68,9 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-2xl font-semibold mb-4">Third-Party Services</h2>
             <p className="text-white/70 leading-relaxed">
-              We use trusted third-party services including Vercel (hosting),
-              analytics providers, and payment processors. These services have their own privacy policies.
+              We use Vercel for hosting and the aggregate measurement described above, Resend for newsletter
+              subscriptions and delivery, and payment processors when you choose to make a purchase. These
+              services process only the information needed for their role and maintain their own privacy terms.
             </p>
           </section>
 

--- a/components/analytics/PrivacySafeAnalytics.tsx
+++ b/components/analytics/PrivacySafeAnalytics.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Analytics, type BeforeSendEvent } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
+
+import { hasDoNotTrack, sanitizeAnalyticsUrl } from '@/lib/analytics-policy'
+
+function beforeSend(event: BeforeSendEvent): BeforeSendEvent | null {
+  if (hasDoNotTrack(typeof navigator === 'undefined' ? undefined : navigator.doNotTrack)) {
+    return null
+  }
+
+  return {
+    ...event,
+    url: sanitizeAnalyticsUrl(event.url),
+  }
+}
+
+/**
+ * The site's only default browser measurement surface.
+ *
+ * Vercel Web Analytics is aggregate and cookieless. Optional marketing
+ * providers stay unmounted until the product has a real consent control.
+ */
+export function PrivacySafeAnalytics() {
+  return (
+    <>
+      <Analytics beforeSend={beforeSend} />
+      <SpeedInsights />
+    </>
+  )
+}

--- a/components/connect/ConnectLandedTracker.tsx
+++ b/components/connect/ConnectLandedTracker.tsx
@@ -8,16 +8,16 @@ export function ConnectLandedTracker() {
   const params = useSearchParams()
 
   useEffect(() => {
-    const utmSource = params?.get('utm_source') ?? undefined
-    const utmMedium = params?.get('utm_medium') ?? undefined
-    const utmCampaign = params?.get('utm_campaign') ?? undefined
-    const eventTag = params?.get('e') ?? params?.get('event') ?? undefined
+    const hasCampaignTag = Boolean(
+      params?.get('utm_source') ||
+      params?.get('utm_medium') ||
+      params?.get('utm_campaign') ||
+      params?.get('e') ||
+      params?.get('event')
+    )
 
     trackEvent('connect_landed', {
-      utm_source: utmSource,
-      utm_medium: utmMedium,
-      utm_campaign: utmCampaign,
-      event_tag: eventTag,
+      entry: hasCampaignTag ? 'tagged_link' : 'direct_or_referral',
     })
   }, [params])
 

--- a/components/email-signup.tsx
+++ b/components/email-signup.tsx
@@ -87,7 +87,7 @@ export function EmailSignup({
             onChange={(e) => setEmail(e.target.value)}
             placeholder={placeholder}
             disabled={status === 'loading' || status === 'success'}
-            className="flex-1 px-4 py-2 bg-slate-800/50 border border-slate-700 rounded-lg text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50"
+            className="min-w-0 flex-1 px-4 py-2 bg-slate-800/50 border border-slate-700 rounded-lg text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50"
           />
           <button
             type="submit"

--- a/components/funnels/EmailCaptureForm.tsx
+++ b/components/funnels/EmailCaptureForm.tsx
@@ -5,6 +5,7 @@ import { Mail, ArrowRight } from 'lucide-react';
 import { motion } from 'framer-motion';
 import GlassmorphicCard from '../ui/GlassmorphicCard';
 import { trackEvent } from '@/lib/analytics';
+import { submitNewsletter } from '@/lib/newsletter/submit-newsletter';
 
 interface EmailCaptureFormProps {
   title?: string;
@@ -20,12 +21,28 @@ const EmailCaptureForm: React.FC<EmailCaptureFormProps> = ({
   className,
 }) => {
   const [email, setEmail] = useState('');
-  const [submitted, setSubmitted] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    trackEvent('subscribe_newsletter', { email });
-    setSubmitted(true);
+    setStatus('submitting');
+    setErrorMessage('');
+
+    const result = await submitNewsletter(email);
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      setStatus('error');
+      return;
+    }
+
+    trackEvent('lead_submitted', {
+      surface: 'email_capture_form',
+      offer_id: 'frankx_newsletter',
+      source: 'frankx_site',
+    });
+    setStatus('success');
+    setEmail('');
   };
 
   return (
@@ -33,7 +50,7 @@ const EmailCaptureForm: React.FC<EmailCaptureFormProps> = ({
       <div className="p-8">
         <h3 className="text-2xl font-bold text-white mb-2">{title}</h3>
         <p className="text-slate-300 mb-6">{description}</p>
-        {submitted ? (
+        {status === 'success' ? (
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -42,24 +59,38 @@ const EmailCaptureForm: React.FC<EmailCaptureFormProps> = ({
             Thank you for subscribing!
           </motion.div>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-4">
-            <div className="relative flex-grow">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 w-5 h-5" />
-              <input
-                type="email"
-                placeholder="Enter your email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full pl-11 pr-4 py-3 bg-slate-800/50 border border-slate-700/50 rounded-xl text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50"
-              />
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+            <div className="flex flex-col sm:flex-row gap-4">
+              <div className="relative flex-grow">
+                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 w-5 h-5" />
+                <input
+                  type="email"
+                  placeholder="Enter your email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    if (status === 'error') setStatus('idle');
+                  }}
+                  required
+                  disabled={status === 'submitting'}
+                  aria-describedby={status === 'error' ? 'newsletter-error' : undefined}
+                  className="w-full pl-11 pr-4 py-3 bg-slate-800/50 border border-slate-700/50 rounded-xl text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={status === 'submitting'}
+                className="inline-flex items-center justify-center px-6 py-3 font-semibold text-white transition-all duration-300 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.4)] hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-60 disabled:hover:translate-y-0"
+              >
+                {status === 'submitting' ? 'Subscribing…' : buttonText}
+                <ArrowRight className="w-4 h-4 ml-2" />
+              </button>
             </div>
-            <button
-              type="submit"
-              className="inline-flex items-center justify-center px-6 py-3 font-semibold text-white transition-all duration-300 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.4)] hover:-translate-y-0.5"
-            >
-              {buttonText} <ArrowRight className="w-4 h-4 ml-2" />
-            </button>
+            {status === 'error' && (
+              <p id="newsletter-error" role="alert" className="text-sm text-rose-300">
+                {errorMessage}
+              </p>
+            )}
           </form>
         )}
       </div>

--- a/components/home/FrankXProductionHome.tsx
+++ b/components/home/FrankXProductionHome.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import { socialLinks } from '@/lib/social-links'
 import {
   ArrowRight,
   Check,
@@ -29,7 +30,7 @@ const proofArtifacts = [
     title: 'Agentic Creator OS',
     description:
       'A public, inspectable operating system for agent skills, commands, workflows, and creator delivery.',
-    href: 'https://github.com/frankxai/agentic-creator-os',
+    href: `${socialLinks.github}/agentic-creator-os`,
     action: 'Inspect the repository',
     external: true,
     Icon: Github,

--- a/components/home/FrankXProductionHome.tsx
+++ b/components/home/FrankXProductionHome.tsx
@@ -145,7 +145,7 @@ export default function FrankXProductionHome({
         <div className="relative mx-auto w-full min-w-0 max-w-[520px] lg:justify-self-end">
           <div className="absolute -inset-10 bg-emerald-400/10 blur-[100px]" aria-hidden="true" />
           <div className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[#0d1111] shadow-[0_40px_120px_rgba(0,0,0,0.45)]">
-            <div className="relative aspect-[4/5] min-h-[540px]">
+            <div className="relative aspect-[4/5] min-h-[420px] sm:min-h-[540px]">
               <Image
                 src="/images/portraits/frank-presenting-oracle-2025.jpg"
                 alt="Frank Riemer presenting an AI architecture session"

--- a/components/home/FrankXProductionHome.tsx
+++ b/components/home/FrankXProductionHome.tsx
@@ -1,0 +1,359 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import {
+  ArrowRight,
+  Check,
+  ExternalLink,
+  FileText,
+  Github,
+  Layers3,
+  Network,
+  ShieldCheck,
+} from 'lucide-react'
+
+type LatestPost = {
+  slug: string
+  title: string
+  description: string
+  category: string
+  readingTime: string
+}
+
+type FrankXProductionHomeProps = {
+  latestPosts?: LatestPost[]
+}
+
+const proofArtifacts = [
+  {
+    type: 'Open system',
+    title: 'Agentic Creator OS',
+    description:
+      'A public, inspectable operating system for agent skills, commands, workflows, and creator delivery.',
+    href: 'https://github.com/frankxai/agentic-creator-os',
+    action: 'Inspect the repository',
+    external: true,
+    Icon: Github,
+  },
+  {
+    type: 'Field guide',
+    title: 'Production agentic AI systems',
+    description:
+      'A practical guide to the architecture, control points, and failure modes behind multi-agent delivery.',
+    href: '/blog/production-agentic-ai-systems',
+    action: 'Read the guide',
+    external: false,
+    Icon: FileText,
+  },
+  {
+    type: 'Architecture library',
+    title: 'Blueprints you can examine',
+    description:
+      'Reference architectures and implementation patterns for teams moving from isolated tools to governed workflows.',
+    href: '/ai-architecture/blueprints',
+    action: 'Review the blueprints',
+    external: false,
+    Icon: Network,
+  },
+]
+
+const engagementSteps = [
+  {
+    number: '01',
+    title: 'Map the operating reality',
+    detail: 'People, decisions, data, tools, risk, and the handoffs where work currently stalls.',
+  },
+  {
+    number: '02',
+    title: 'Design the smallest useful system',
+    detail: 'One bounded workflow with clear ownership, evaluation, cost limits, and a human override.',
+  },
+  {
+    number: '03',
+    title: 'Prove it in the work',
+    detail: 'A working artifact, operating notes, and a decision on what should scale next—or stop.',
+  },
+]
+
+const ecosystemRoutes = [
+  {
+    label: 'For creator systems',
+    title: 'GenCreator',
+    description:
+      'The focused home for creator workflows, education, community, and repeatable publishing systems.',
+    href: 'https://gencreator.ai',
+  },
+  {
+    label: 'For revenue systems',
+    title: 'Agentic Income',
+    description:
+      'The focused home for productized agent workflows, income experiments, and evidence-led monetization.',
+    href: 'https://agenticincome.ai',
+  },
+]
+
+export default function FrankXProductionHome({
+  latestPosts = [],
+}: FrankXProductionHomeProps) {
+  return (
+    <main className="relative overflow-hidden bg-[#0a0a0b] text-white">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-[760px] bg-[radial-gradient(circle_at_68%_12%,rgba(16,185,129,0.12),transparent_34%),radial-gradient(circle_at_18%_0%,rgba(6,182,212,0.06),transparent_28%)]"
+        aria-hidden="true"
+      />
+
+      <section className="relative mx-auto grid min-h-[88svh] min-w-0 max-w-7xl items-center gap-14 px-5 pb-20 pt-28 sm:px-8 lg:grid-cols-[1.08fr_0.92fr] lg:px-10 lg:pt-24">
+        <div className="min-w-0 max-w-3xl">
+          <p className="mb-6 font-mono text-[11px] font-medium uppercase tracking-[0.24em] text-emerald-300/70">
+            FrankX / AI architecture and operator systems
+          </p>
+          <h1 className="max-w-full font-display text-5xl font-bold leading-[0.98] tracking-[-0.045em] text-white sm:max-w-4xl sm:text-6xl lg:text-7xl">
+            Make AI a working system,
+            <span className="block text-white/44">not a stack of experiments.</span>
+          </h1>
+          <p className="mt-8 max-w-2xl text-lg leading-8 text-white/58 sm:text-xl">
+            I design the architecture, agent workflows, and operating controls that turn scattered
+            AI activity into work a founder or team can inspect, run, and improve.
+          </p>
+
+          <div className="mt-10 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
+            <Link
+              href="/ai-architecture"
+              className="group inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-emerald-400 px-6 py-3 text-sm font-semibold text-[#07120d] transition-colors hover:bg-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-4 focus-visible:ring-offset-[#0a0a0b]"
+            >
+              Review the architecture
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+            </Link>
+            <Link
+              href="/work-with-me"
+              className="inline-flex min-h-11 items-center gap-2 px-1 text-sm font-medium text-white/62 underline decoration-white/20 underline-offset-8 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+            >
+              Discuss an architecture engagement
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+
+          <div className="mt-12 flex max-w-2xl flex-wrap gap-x-6 gap-y-3 border-t border-white/10 pt-5 text-xs leading-5 text-white/40">
+            <span>Former Oracle AI architect</span>
+            <span>Independent practice</span>
+            <span>Public systems and field notes</span>
+          </div>
+          <p className="mt-3 max-w-xl text-[11px] leading-5 text-white/28">
+            FrankX is independent and is not affiliated with, endorsed by, or sponsored by Oracle.
+          </p>
+        </div>
+
+        <div className="relative mx-auto w-full min-w-0 max-w-[520px] lg:justify-self-end">
+          <div className="absolute -inset-10 bg-emerald-400/10 blur-[100px]" aria-hidden="true" />
+          <div className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[#0d1111] shadow-[0_40px_120px_rgba(0,0,0,0.45)]">
+            <div className="relative aspect-[4/5] min-h-[540px]">
+              <Image
+                src="/images/portraits/frank-presenting-oracle-2025.jpg"
+                alt="Frank Riemer presenting an AI architecture session"
+                fill
+                priority
+                sizes="(max-width: 1024px) 92vw, 42vw"
+                className="object-cover object-center"
+              />
+              <div
+                className="absolute inset-0 bg-gradient-to-t from-[#08100d] via-[#08100d]/15 to-transparent"
+                aria-hidden="true"
+              />
+              <div className="absolute inset-x-0 bottom-0 p-6 sm:p-8">
+                <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-emerald-300/70">
+                  Evidence before adjectives
+                </p>
+                <p className="mt-3 max-w-sm text-base leading-7 text-white/78">
+                  Architecture is useful when a team can see the decisions, operate the workflow,
+                  and know when the system is wrong.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-white/[0.07] bg-white/[0.018] py-24 lg:py-32" aria-labelledby="proof-title">
+        <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="grid gap-10 lg:grid-cols-[0.72fr_1.28fr] lg:gap-20">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-emerald-300/60">
+                Inspectable proof
+              </p>
+              <h2 id="proof-title" className="mt-5 text-4xl font-semibold tracking-[-0.035em] sm:text-5xl">
+                Start with the artifacts.
+              </h2>
+              <p className="mt-6 max-w-md text-base leading-7 text-white/48">
+                No maturity theater. These are working systems, technical notes, and blueprints you
+                can examine before deciding whether the approach fits your work.
+              </p>
+            </div>
+
+            <div className="divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {proofArtifacts.map(({ Icon, ...artifact }) => (
+                <article key={artifact.title} className="group grid gap-5 py-7 sm:grid-cols-[44px_1fr_auto] sm:items-start">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-emerald-300/15 bg-emerald-300/[0.055] text-emerald-300">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/32">{artifact.type}</p>
+                    <h3 className="mt-2 text-xl font-semibold text-white">{artifact.title}</h3>
+                    <p className="mt-2 max-w-xl text-sm leading-6 text-white/46">{artifact.description}</p>
+                  </div>
+                  <Link
+                    href={artifact.href}
+                    target={artifact.external ? '_blank' : undefined}
+                    rel={artifact.external ? 'noopener noreferrer' : undefined}
+                    className="inline-flex min-h-10 items-center gap-2 self-center text-sm font-medium text-emerald-300/78 transition hover:text-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                  >
+                    {artifact.action}
+                    {artifact.external ? <ExternalLink className="h-4 w-4" aria-hidden="true" /> : <ArrowRight className="h-4 w-4" aria-hidden="true" />}
+                  </Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-24 lg:py-32" aria-labelledby="engagement-title">
+        <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="grid gap-14 lg:grid-cols-[0.82fr_1.18fr] lg:items-start lg:gap-20">
+            <div className="lg:sticky lg:top-28">
+              <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-cyan-300/60">
+                One primary route
+              </p>
+              <h2 id="engagement-title" className="mt-5 text-4xl font-semibold tracking-[-0.035em] sm:text-5xl">
+                Executive AI architecture.
+              </h2>
+              <p className="mt-6 max-w-md text-base leading-7 text-white/48">
+                For founders and teams with important work, too many tools, and no shared operating
+                model. The engagement begins with one bounded decision—not a transformation promise.
+              </p>
+              <Link
+                href="/work-with-me"
+                className="mt-8 inline-flex min-h-12 items-center gap-2 rounded-full border border-white/14 bg-white/[0.045] px-6 py-3 text-sm font-semibold text-white transition hover:border-white/24 hover:bg-white/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+              >
+                See how we can work together
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+
+            <div className="relative border-l border-white/[0.09] pl-7 sm:pl-10">
+              {engagementSteps.map((step, index) => (
+                <article key={step.number} className={index === engagementSteps.length - 1 ? 'pb-0' : 'pb-14'}>
+                  <span className="absolute -left-[5px] mt-2 h-[9px] w-[9px] rounded-full bg-cyan-300 shadow-[0_0_24px_rgba(103,232,249,0.5)]" aria-hidden="true" />
+                  <p className="font-mono text-[11px] text-cyan-300/55">{step.number}</p>
+                  <h3 className="mt-3 text-2xl font-semibold tracking-[-0.02em]">{step.title}</h3>
+                  <p className="mt-3 max-w-xl text-base leading-7 text-white/46">{step.detail}</p>
+                </article>
+              ))}
+
+              <div className="mt-14 rounded-2xl border border-white/[0.09] bg-white/[0.025] p-6">
+                <div className="flex items-start gap-4">
+                  <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
+                  <div>
+                    <p className="font-medium text-white/82">The operating constraint</p>
+                    <p className="mt-2 text-sm leading-6 text-white/44">
+                      Human approval stays at consequential boundaries. Costs, evaluations, failure
+                      paths, and rollback are part of the architecture—not launch-week cleanup.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-white/[0.07] bg-[#0c0e0e] py-24" aria-labelledby="ecosystem-title">
+        <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:gap-20">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-white/34">Focused handoffs</p>
+              <h2 id="ecosystem-title" className="mt-5 text-3xl font-semibold tracking-[-0.03em] sm:text-4xl">
+                The right product should own the next step.
+              </h2>
+              <p className="mt-5 max-w-md text-base leading-7 text-white/45">
+                FrankX is the architecture and founder-intelligence front door. Creator delivery and
+                revenue experiments have their own focused homes.
+              </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {ecosystemRoutes.map((route) => (
+                <Link
+                  key={route.title}
+                  href={route.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex min-h-[250px] flex-col rounded-[1.5rem] border border-white/[0.09] bg-white/[0.025] p-6 transition hover:border-white/18 hover:bg-white/[0.045] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                >
+                  <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/32">{route.label}</p>
+                  <h3 className="mt-8 text-2xl font-semibold">{route.title}</h3>
+                  <p className="mt-3 text-sm leading-6 text-white/45">{route.description}</p>
+                  <span className="mt-auto inline-flex items-center gap-2 pt-8 text-sm font-medium text-emerald-300/72 group-hover:text-emerald-200">
+                    Visit {route.title}
+                    <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {latestPosts.length > 0 && (
+        <section className="py-24 lg:py-32" aria-labelledby="notes-title">
+          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+            <div className="flex flex-col gap-5 border-b border-white/[0.08] pb-8 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-emerald-300/55">Field notes</p>
+                <h2 id="notes-title" className="mt-4 text-3xl font-semibold tracking-[-0.03em] sm:text-4xl">What I am learning in the work.</h2>
+              </div>
+              <Link href="/blog" className="inline-flex min-h-10 items-center gap-2 text-sm text-white/52 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300">
+                Browse all notes <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+
+            <div className="divide-y divide-white/[0.08]">
+              {latestPosts.slice(0, 3).map((post) => (
+                <article key={post.slug} className="grid gap-4 py-7 sm:grid-cols-[0.28fr_1fr_auto] sm:items-center">
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/30">{post.category} / {post.readingTime}</p>
+                  <div>
+                    <h3 className="text-lg font-semibold text-white/86">{post.title}</h3>
+                    <p className="mt-2 line-clamp-2 max-w-2xl text-sm leading-6 text-white/42">{post.description}</p>
+                  </div>
+                  <Link href={`/blog/${post.slug}`} aria-label={`Read ${post.title}`} className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-white/52 transition hover:border-emerald-300/30 hover:text-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300">
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="border-t border-white/[0.07] py-24">
+        <div className="mx-auto max-w-4xl px-5 text-center sm:px-8">
+          <Layers3 className="mx-auto h-6 w-6 text-emerald-300/65" aria-hidden="true" />
+          <h2 className="mt-6 text-4xl font-semibold tracking-[-0.04em] sm:text-5xl">
+            Start with one consequential workflow.
+          </h2>
+          <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-white/46">
+            We will map it, choose the smallest architecture that can prove value, and make the next
+            decision from evidence.
+          </p>
+          <div className="mt-9 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link href="/work-with-me" className="inline-flex min-h-12 items-center gap-2 rounded-full bg-emerald-400 px-6 py-3 text-sm font-semibold text-[#07120d] transition-colors hover:bg-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-4 focus-visible:ring-offset-[#0a0a0b]">
+              Discuss the workflow <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+            <span className="inline-flex items-center gap-2 text-xs text-white/32">
+              <Check className="h-4 w-4 text-emerald-300/65" aria-hidden="true" />
+              Scope confirmed before work begins
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/docs/premium-web-os/frankx-production-home-design-loop-evidence.json
+++ b/docs/premium-web-os/frankx-production-home-design-loop-evidence.json
@@ -1,0 +1,97 @@
+{
+  "version": "1.0",
+  "task": "Build the proof-led FrankX executive AI architecture homepage",
+  "surface": "FrankX homepage at /",
+  "audience": "Founders, operators, and technical leaders who need governed AI workflows",
+  "standards": [
+    "Premium Intelligence Web OS",
+    "FrankX design.md and taste.md",
+    "Starlight Design Taste Kernel",
+    "Premium Asset Standard",
+    "Visual QA Gate"
+  ],
+  "references": [
+    "FrankX brand world: direct, technical, results-first",
+    "Existing FrankX portrait and visual registry",
+    "Existing public ACOS repository and architecture routes"
+  ],
+  "direction": {
+    "keep": "One executive AI architecture route, real proof, editorial restraint, and honest ecosystem handoffs",
+    "avoid": "Catalog-homepage density, fake metrics, generic AI gradients, decorative 3D, and unsupported outcomes",
+    "signature": "A real architecture presentation paired with an inspectable operating-system narrative",
+    "system": "Obsidian base, emerald authority signal, cyan mechanism signal, static server-rendered composition"
+  },
+  "asset_quality": {
+    "tier": "A",
+    "source_method": "product-capture",
+    "provenance": "owned",
+    "why_premium": "The hero is a real FrankX architecture presentation and directly proves the work described by the page.",
+    "shortcut_risk": "low",
+    "context_tested": true
+  },
+  "artifacts": [
+    {
+      "path_or_url": "components/home/FrankXProductionHome.tsx",
+      "kind": "homepage implementation",
+      "inspected": true
+    },
+    {
+      "path_or_url": "public/images/portraits/frank-presenting-oracle-2025.jpg",
+      "kind": "Tier A hero photograph",
+      "inspected": true
+    },
+    {
+      "path_or_url": "C:/Users/frank/starlight/repos/.codex-artifacts/frankx-production-home-20260710/desktop.png",
+      "kind": "desktop visual capture",
+      "inspected": true
+    },
+    {
+      "path_or_url": "C:/Users/frank/starlight/repos/.codex-artifacts/frankx-production-home-20260710/mobile.png",
+      "kind": "mobile visual capture before containment correction",
+      "inspected": true
+    }
+  ],
+  "checks": [
+    {
+      "name": "asset-tier",
+      "status": "pass",
+      "evidence": "Real presentation photograph; no generated or decorative primary asset"
+    },
+    {
+      "name": "export-inspection",
+      "status": "pass",
+      "evidence": "Hero source and desktop/mobile PNG captures inspected"
+    },
+    {
+      "name": "desktop-first-viewport",
+      "status": "pass",
+      "evidence": "Dominant claim, primary route, real proof, and readable contrast are visible"
+    },
+    {
+      "name": "mobile-first-viewport",
+      "status": "blocked",
+      "evidence": "The single capped 390px capture exposed horizontal clipping; min-width containment was corrected after capture and requires preview inspection"
+    },
+    {
+      "name": "reduced-motion",
+      "status": "pass",
+      "evidence": "Homepage adds no animation runtime, scroll choreography, parallax, or autoplay media"
+    },
+    {
+      "name": "public-language",
+      "status": "pass",
+      "evidence": "Strict claim audit passed and changed files contain no banned AI-slop phrases"
+    },
+    {
+      "name": "performance",
+      "status": "pass",
+      "evidence": "Server component, optimized local image, no homepage-specific client runtime, production build passed"
+    }
+  ],
+  "score": {
+    "total": 25,
+    "max": 30,
+    "note": "Desktop composition is ship-level; mobile containment needs inspection on the Git-backed preview before release promotion."
+  },
+  "decision": "iterate"
+}

--- a/docs/premium-web-os/frankx-production-home-design-loop-evidence.json
+++ b/docs/premium-web-os/frankx-production-home-design-loop-evidence.json
@@ -41,13 +41,13 @@
       "inspected": true
     },
     {
-      "path_or_url": "C:/Users/frank/starlight/repos/.codex-artifacts/frankx-production-home-20260710/desktop.png",
-      "kind": "desktop visual capture",
+      "path_or_url": "https://frankx-ai-vercel-website-git-code-f2470d-starlight-intelligence.vercel.app",
+      "kind": "exact-head Vercel preview inspected at desktop, mobile, reflow, and reduced motion",
       "inspected": true
     },
     {
-      "path_or_url": "C:/Users/frank/starlight/repos/.codex-artifacts/frankx-production-home-20260710/mobile.png",
-      "kind": "mobile visual capture before containment correction",
+      "path_or_url": "https://github.com/frankxai/frankx.ai-vercel-website/pull/257#issuecomment-4937575036",
+      "kind": "immutable responsive and reduced-motion verification receipt",
       "inspected": true
     }
   ],
@@ -69,13 +69,13 @@
     },
     {
       "name": "mobile-first-viewport",
-      "status": "blocked",
-      "evidence": "The single capped 390px capture exposed horizontal clipping; min-width containment was corrected after capture and requires preview inspection"
+      "status": "pass",
+      "evidence": "Exact-head preview inspected at 390x844 and 640 CSS px reflow with zero document overflow or clipped visible and interactive elements"
     },
     {
       "name": "reduced-motion",
       "status": "pass",
-      "evidence": "Homepage adds no animation runtime, scroll choreography, parallax, or autoplay media"
+      "evidence": "Exact-head reduced-motion preview matched the preference with zero running animations; the homepage adds no scroll choreography, parallax, or autoplay media"
     },
     {
       "name": "public-language",
@@ -89,9 +89,9 @@
     }
   ],
   "score": {
-    "total": 25,
+    "total": 28,
     "max": 30,
-    "note": "Desktop composition is ship-level; mobile containment needs inspection on the Git-backed preview before release promotion."
+    "note": "Exact-head preview passed desktop, 390px mobile, reflow, and reduced-motion inspection with Tier A proof and no clipping or overflow."
   },
-  "decision": "iterate"
+  "decision": "ship"
 }

--- a/docs/premium-web-os/frankx-production-home-scene-brief.md
+++ b/docs/premium-web-os/frankx-production-home-scene-brief.md
@@ -1,0 +1,52 @@
+# FrankX production home — scene brief
+
+Date: 2026-07-10
+
+## Decision
+
+FrankX is the executive AI architecture and founder-intelligence front door. It is not the catalog page for every experiment in the wider estate.
+
+The primary route is `/ai-architecture`. Advisory is the conversion path at `/work-with-me`. GenCreator and Agentic Income receive honest, explicit handoffs when the visitor's job is creator delivery or revenue-system experimentation.
+
+## Audience and job
+
+- Founder or operator with growing AI usage but no shared operating model.
+- Technical leader who needs an inspectable workflow, not a transformation slogan.
+- Builder who wants to examine real artifacts before starting a conversation.
+
+The first read must answer: Frank designs governed AI workflows; the visitor can inspect the work; the next step is the architecture library.
+
+## Scene sequence
+
+1. **Hook — operating-system decision.** One claim, one dominant action, one real photograph of Frank presenting architecture work.
+2. **Proof — inspectable artifacts.** Public ACOS repository, production-agentic-systems field guide, and architecture blueprints.
+3. **Mechanism — bounded engagement.** Map reality, design the smallest useful system, prove it in the work.
+4. **Handoff — ecosystem clarity.** GenCreator owns creator systems; Agentic Income owns revenue-system experiments.
+5. **Authority — current field notes.** Three dynamically sourced articles.
+6. **Conversion — one consequential workflow.** Clear invitation with no promised outcome or false urgency.
+
+## Visual and material contract
+
+- Obsidian base, emerald authority signal, cyan only for the engagement mechanism.
+- Editorial type and long quiet areas; no equal-card catalog grid.
+- Tier A asset: real photograph at `public/images/portraits/frank-presenting-oracle-2025.jpg`.
+- Tier C assets: exact code-rendered artifact rows and operating sequence.
+- No generated hero, fake dashboard, decorative 3D object, autoplay media, or unsupported metric.
+
+## Motion score
+
+Stillness is the motion decision for this pass. Existing global navigation utilities remain, but the homepage adds no client runtime, scroll choreography, rotating text, parallax, or ambient animation. The hierarchy must work as a static composition and under reduced motion.
+
+## Performance and accessibility budget
+
+- Homepage implementation is a React Server Component.
+- Hero media uses Next Image and the existing 299 KB source photograph.
+- No homepage-specific animation runtime or iframe.
+- One `h1`; named sections use `aria-labelledby`; focus treatment is explicit.
+- External routes disclose a new tab through the external-link icon and safe `rel` attributes.
+
+## Release gates
+
+- Frozen install, lint, TypeScript, claim/slop audit, content checks, tests where present, and production build.
+- Desktop and mobile capture attempted once against the built artifact.
+- Git-backed Vercel preview only; no production promotion or domain mutation in this lane.

--- a/lib/analytics-policy.ts
+++ b/lib/analytics-policy.ts
@@ -1,0 +1,46 @@
+type AnalyticsProperty = string | number | boolean | null | undefined
+
+const SENSITIVE_PROPERTY =
+  /(^|_)(email|name|phone|address|message|text|person|user|customer|referrer|query|search|url|href)($|_)/i
+const EMAIL_LIKE_VALUE = /\b[^\s@]+@[^\s@]+\.[^\s@]+\b/
+
+export function hasDoNotTrack(value: string | null | undefined): boolean {
+  return value === '1' || value === 'yes'
+}
+
+export function sanitizeAnalyticsUrl(value: string): string {
+  try {
+    const url = new URL(value, 'https://frankx.invalid')
+    return url.pathname || '/'
+  } catch {
+    const pathname = value.split(/[?#]/, 1)[0]
+    return pathname.startsWith('/') ? pathname : '/'
+  }
+}
+
+export function sanitizeAnalyticsProperties(
+  properties: Record<string, unknown> = {}
+): Record<string, AnalyticsProperty> {
+  const safe: Record<string, AnalyticsProperty> = {}
+
+  for (const [key, value] of Object.entries(properties).slice(0, 10)) {
+    if (SENSITIVE_PROPERTY.test(key)) continue
+    if (!['string', 'number', 'boolean'].includes(typeof value) && value !== null) continue
+
+    if (typeof value === 'string') {
+      const normalized = value.trim()
+      if (!normalized) continue
+      if (/^https?:\/\//i.test(normalized) || normalized.startsWith('/')) {
+        safe[key] = sanitizeAnalyticsUrl(normalized)
+        continue
+      }
+      if (EMAIL_LIKE_VALUE.test(normalized)) continue
+      safe[key] = normalized.slice(0, 100)
+      continue
+    }
+
+    safe[key] = value as number | boolean | null
+  }
+
+  return safe
+}

--- a/lib/analytics-workshop.ts
+++ b/lib/analytics-workshop.ts
@@ -3,48 +3,18 @@
  *
  * Workshop funnel event helpers.
  *
- * Client-side: fires via Plausible (window.plausible) or GA (window.gtag) if available.
+ * Client-side: fires through the site's privacy-safe aggregate analytics boundary.
  * Server-side: no-op for now (server-side analytics deferred per spec).
  * Never throws — analytics failures are always silent.
  */
 
-// ─── Environment guard ────────────────────────────────────────────
-
-const isClient = typeof window !== 'undefined'
-
-// ─── Plausible + GA shims ─────────────────────────────────────────
-
-type PlausibleFn = (eventName: string, options?: { props?: Record<string, string> }) => void
-type GtagFn = (command: 'event', eventName: string, params?: Record<string, string>) => void
-
-function getPlausible(): PlausibleFn | null {
-  if (!isClient) return null
-  return (window as unknown as { plausible?: PlausibleFn }).plausible ?? null
-}
-
-function getGtag(): GtagFn | null {
-  if (!isClient) return null
-  return (window as unknown as { gtag?: GtagFn }).gtag ?? null
-}
+import { trackEvent } from '@/lib/analytics'
 
 // ─── Fire helper ──────────────────────────────────────────────────
 
 function fireEvent(eventName: string, props?: Record<string, string>): void {
-  if (!isClient) return  // server-side: no-op
-
-  try {
-    const plausible = getPlausible()
-    if (plausible) {
-      plausible(eventName, props ? { props } : undefined)
-    }
-
-    const gtag = getGtag()
-    if (gtag) {
-      gtag('event', eventName, props)
-    }
-  } catch {
-    // Silent — analytics must never crash the UI
-  }
+  if (typeof window === 'undefined') return
+  trackEvent(eventName, props)
 }
 
 // ─── Public API ───────────────────────────────────────────────────

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,12 +1,9 @@
 'use client'
 
 import { useSyncExternalStore } from 'react'
+import { track as trackVercelEvent } from '@vercel/analytics'
 
-type AnalyticsAdapter = {
-  track?: (event: string, properties?: Record<string, any>) => void
-  identify?: (userId: string, traits?: Record<string, any>) => void
-  group?: (groupId: string, traits?: Record<string, any>) => void
-}
+import { hasDoNotTrack, sanitizeAnalyticsProperties } from '@/lib/analytics-policy'
 
 type AnalyticsEvent = {
   name: string
@@ -17,40 +14,30 @@ type AnalyticsEvent = {
 const eventBuffer: AnalyticsEvent[] = []
 const subscribers = new Set<() => void>()
 
-let adapter: AnalyticsAdapter | null = null
-
-export function configureAnalytics(customAdapter: AnalyticsAdapter) {
-  adapter = customAdapter
-}
-
 function emitUpdate() {
   subscribers.forEach((listener) => listener())
 }
 
 export function trackEvent(name: string, params: Record<string, any> = {}) {
+  const safeParams = sanitizeAnalyticsProperties(params)
   const payload: AnalyticsEvent = {
     name,
-    params,
+    params: safeParams,
     timestamp: Date.now()
   }
 
   eventBuffer.push(payload)
 
   if (typeof window !== 'undefined') {
-    if (adapter?.track) {
-      adapter.track(name, params)
-    } else {
-      const posthog = (window as any).posthog
-      const segment = (window as any).analytics
-      const plausible = (window as any).plausible
+    if (hasDoNotTrack(window.navigator.doNotTrack)) {
+      emitUpdate()
+      return
+    }
 
-      try {
-        if (posthog?.capture) posthog.capture(name, params)
-        if (segment?.track) segment.track(name, params)
-        if (plausible) plausible(name, { props: params })
-      } catch {
-        /* analytics must never break the page */
-      }
+    try {
+      trackVercelEvent(name, safeParams)
+    } catch {
+      /* analytics must never break the page */
     }
   } else {
     console.log('Analytics Event:', payload)
@@ -78,38 +65,6 @@ export function trackShortEvent(
     category: short.category,
     author: short.author,
   })
-}
-
-export function identifyUser(userId: string, traits: Record<string, any> = {}) {
-  if (adapter?.identify) {
-    adapter.identify(userId, traits)
-    return
-  }
-
-  if (typeof window !== 'undefined') {
-    const posthog = (window as any).posthog
-    const segment = (window as any).analytics
-    if (posthog?.identify) posthog.identify(userId, traits)
-    if (segment?.identify) segment.identify(userId, traits)
-  } else {
-    console.log('Analytics Identify:', { userId, traits })
-  }
-}
-
-export function groupUser(groupId: string, traits: Record<string, any> = {}) {
-  if (adapter?.group) {
-    adapter.group(groupId, traits)
-    return
-  }
-
-  if (typeof window !== 'undefined') {
-    const posthog = (window as any).posthog
-    const segment = (window as any).analytics
-    if (posthog?.group) posthog.group(groupId, traits)
-    if (segment?.group) segment.group(groupId, traits)
-  } else {
-    console.log('Analytics Group:', { groupId, traits })
-  }
 }
 
 export function getBufferedEvents() {

--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,14 +1,6 @@
-declare global {
-  interface Window {
-    gtag: (command: string, targetId: string, config?: any) => void
-  }
-}
+import { trackEvent } from '@/lib/analytics'
 
 export const trackConversion = (url: string, conversionId: string) => {
-  window.gtag('event', 'conversion', {
-    send_to: `${process.env.NEXT_PUBLIC_GA_TRACKING_ID}/${conversionId}`,
-    event_callback: () => {
-      window.location.href = url
-    },
-  })
+  trackEvent('conversion_click', { conversion_id: conversionId })
+  window.location.href = url
 }

--- a/lib/newsletter/submit-newsletter.ts
+++ b/lib/newsletter/submit-newsletter.ts
@@ -1,0 +1,36 @@
+export type NewsletterSubmissionResult =
+  | { ok: true }
+  | { ok: false; message: string }
+
+type NewsletterResponse = {
+  success?: boolean
+  error?: string
+}
+
+const DEFAULT_ERROR = 'Subscription could not be completed. Please try again.'
+
+export async function submitNewsletter(
+  email: string,
+  request: typeof fetch = fetch
+): Promise<NewsletterSubmissionResult> {
+  try {
+    const response = await request('/api/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: email.trim().toLowerCase(),
+        listType: 'newsletter',
+        source: 'email-capture-form',
+      }),
+    })
+    const body = (await response.json().catch(() => ({}))) as NewsletterResponse
+
+    if (!response.ok || body.success !== true) {
+      return { ok: false, message: body.error || DEFAULT_ERROR }
+    }
+
+    return { ok: true }
+  } catch {
+    return { ok: false, message: DEFAULT_ERROR }
+  }
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -5,10 +5,10 @@ import { socialHandles } from './social-links'
 const siteUrl = 'https://frankx.ai'
 
 export const siteConfig = {
-  name: 'FrankX Intelligence Hub',
+  name: 'FrankX — Executive AI Architecture',
   shortName: 'FrankX',
   description:
-    'AI Architect and Music Creator. Building intelligent systems, tools, and workflows for creators who ship.',
+    'Executive AI architecture, agent workflows, and operator systems for founders and teams.',
   url: siteUrl,
   twitter: socialHandles.twitter,
   // Static fallback. /api/og dynamic route has empty-body issues in Next 16

--- a/link-checker-report.json
+++ b/link-checker-report.json
@@ -1,15 +1,1 @@
-[
-  {
-    "page": "Homepage",
-    "link": "Build your own",
-    "href": "/library/build",
-    "issue": "Failed to fetch link: fetch failed"
-  },
-  {
-    "page": "Realm",
-    "link": "/realm",
-    "href": "/realm",
-    "issue": "Page failed to load - Status: 0 - fetch failed",
-    "statusCode": 0
-  }
-]
+[]

--- a/link-checker-report.txt
+++ b/link-checker-report.txt
@@ -1,45 +1,7 @@
 FrankX.AI Link Checker Report
 ================================================================================
-Generated: 2026-05-21T19:33:51.854Z
-Total Issues Found: 2
+Generated: 2026-07-10T15:28:26.907Z
+Total Issues Found: 0
 ================================================================================
 
-=== ISSUES BY TYPE ===
-
-Other errors: 2 issues
---------------------------------------------------------------------------------
-
-1. Page: Homepage
-   Href: /library/build
-   Link text: "Build your own"
-
-2. Page: Realm
-   Href: /realm
-   Link text: "/realm"
-
-
-=== ISSUES BY PAGE ===
-
-Homepage: 1 issues
---------------------------------------------------------------------------------
-
-1. Failed to fetch link: fetch failed
-   Href: /library/build
-   Link text: "Build your own"
-
-Realm: 1 issues
---------------------------------------------------------------------------------
-
-1. Page failed to load - Status: 0 - fetch failed
-   Href: /realm
-   Link text: "/realm"
-
-
-=== SUMMARY ===
-Total pages tested: 11
-Total unique internal URLs checked: 145
-Total issues found: 2
-  - 404 errors: 0
-  - External link issues: 0
-  - Redirects: 0
-  - Other errors: 2
+✅ No issues found! All links are working correctly.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -349,13 +349,13 @@ const nextConfig = {
             // Audit: grep -r '<iframe' app/ components/ to find all embed sources
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://va.vercel-scripts.com https://plausible.io https://assets.lemonsqueezy.com https://www.googletagmanager.com",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://va.vercel-scripts.com https://assets.lemonsqueezy.com",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "font-src 'self' https://fonts.gstatic.com data:",
               "img-src 'self' data: blob: https: http:",
               "media-src 'self' https:",
               "frame-src 'self' https://suno.com https://*.suno.com https://www.youtube.com https://open.spotify.com https://embeds.beehiiv.com https://vercel.live https://*.lemonsqueezy.com https://vusercontent.net https://*.vusercontent.net",
-              "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://*.vercel.app https://plausible.io https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
+              "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://*.vercel.app",
               "object-src 'none'",
               "base-uri 'self'",
               "form-action 'self'",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -356,6 +356,10 @@ const nextConfig = {
               "media-src 'self' https:",
               "frame-src 'self' https://suno.com https://*.suno.com https://www.youtube.com https://open.spotify.com https://embeds.beehiiv.com https://vercel.live https://*.lemonsqueezy.com https://vusercontent.net https://*.vusercontent.net",
               "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com https://*.vercel.app https://plausible.io https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
+              "object-src 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+              "frame-ancestors 'none'",
             ].join('; '),
           },
           {
@@ -365,6 +369,22 @@ const nextConfig = {
           {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "smoke:json": "node scripts/run-smoke-evals.mjs --json",
     "test:newsletter": "node --experimental-strip-types --test scripts/tests/submit-newsletter.test.mjs",
     "test:privacy-analytics": "node --experimental-strip-types --test scripts/tests/privacy-analytics.test.mjs",
+    "test:homepage-release": "node --test scripts/tests/homepage-release-contract.test.mjs",
     "agents:quality": "node scripts/agents/audit-agent-quality.mjs",
     "agents:quality:json": "node scripts/agents/audit-agent-quality.mjs --json",
     "design:lint": "node scripts/design-tokens.mjs lint",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "smoke": "node scripts/run-smoke-evals.mjs",
     "smoke:json": "node scripts/run-smoke-evals.mjs --json",
     "test:newsletter": "node --experimental-strip-types --test scripts/tests/submit-newsletter.test.mjs",
+    "test:privacy-analytics": "node --experimental-strip-types --test scripts/tests/privacy-analytics.test.mjs",
     "agents:quality": "node scripts/agents/audit-agent-quality.mjs",
     "agents:quality:json": "node scripts/agents/audit-agent-quality.mjs --json",
     "design:lint": "node scripts/design-tokens.mjs lint",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit",
     "smoke": "node scripts/run-smoke-evals.mjs",
     "smoke:json": "node scripts/run-smoke-evals.mjs --json",
+    "test:newsletter": "node --experimental-strip-types --test scripts/tests/submit-newsletter.test.mjs",
     "agents:quality": "node scripts/agents/audit-agent-quality.mjs",
     "agents:quality:json": "node scripts/agents/audit-agent-quality.mjs --json",
     "design:lint": "node scripts/design-tokens.mjs lint",

--- a/scripts/tests/homepage-release-contract.test.mjs
+++ b/scripts/tests/homepage-release-contract.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+test('homepage repository proof derives from the canonical social registry', async () => {
+  const homepage = await readRepoFile('components/home/FrankXProductionHome.tsx')
+
+  assert.match(homepage, /import \{ socialLinks \} from '@\/lib\/social-links'/)
+  assert.match(homepage, /href: `\$\{socialLinks\.github\}\/agentic-creator-os`/)
+  assert.doesNotMatch(homepage, /https:\/\/github\.com\/frankxai/)
+})
+
+test('homepage release evidence is portable and records the verified ship state', async () => {
+  const rawEvidence = await readRepoFile('docs/premium-web-os/frankx-production-home-design-loop-evidence.json')
+  const evidence = JSON.parse(rawEvidence)
+  const mobileCheck = evidence.checks.find((check) => check.name === 'mobile-first-viewport')
+
+  assert.doesNotMatch(rawEvidence, /[A-Za-z]:[\\/](?:Users|home)[\\/]/)
+  assert.equal(mobileCheck?.status, 'pass')
+  assert.equal(evidence.score.total, 28)
+  assert.equal(evidence.score.max, 30)
+  assert.equal(evidence.decision, 'ship')
+  assert.ok(evidence.artifacts.every((artifact) => !artifact.path_or_url.startsWith('file:')))
+})

--- a/scripts/tests/privacy-analytics.test.mjs
+++ b/scripts/tests/privacy-analytics.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  hasDoNotTrack,
+  sanitizeAnalyticsProperties,
+  sanitizeAnalyticsUrl,
+} from '../../lib/analytics-policy.ts'
+
+const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+test('optional analytics scripts stay unmounted without a consent control', async () => {
+  const [layout, csp, envExample] = await Promise.all([
+    readRepoFile('app/layout.tsx'),
+    readRepoFile('next.config.mjs'),
+    readRepoFile('.env.example'),
+  ])
+
+  const runtimeContract = `${layout}\n${csp}\n${envExample}`
+  assert.doesNotMatch(runtimeContract, /plausible\.io|NEXT_PUBLIC_PLAUSIBLE_DOMAIN/)
+  assert.doesNotMatch(runtimeContract, /googletagmanager|google-analytics|GoogleAnalytics|NEXT_PUBLIC_GA_/)
+})
+
+test('the aggregate default honors Do Not Track and redacts page-view URLs', async () => {
+  const component = await readRepoFile('components/analytics/PrivacySafeAnalytics.tsx')
+
+  assert.equal(hasDoNotTrack(undefined), false)
+  assert.equal(hasDoNotTrack('0'), false)
+  assert.equal(hasDoNotTrack('1'), true)
+  assert.equal(hasDoNotTrack('yes'), true)
+  assert.equal(sanitizeAnalyticsUrl('https://frankx.ai/connect?email=person@example.com#form'), '/connect')
+  assert.match(component, /<Analytics beforeSend={beforeSend}/)
+  assert.match(component, /hasDoNotTrack/)
+  assert.match(component, /return null/)
+})
+
+test('custom event properties exclude PII, free text, full URLs, and query data', () => {
+  assert.deepEqual(
+    sanitizeAnalyticsProperties({
+      source: 'frankx_site',
+      destination: '/products/vibe-os?email=person@example.com#buy',
+      email: 'person@example.com',
+      person_id: 'p_123',
+      message: 'Please call me',
+      url: 'https://example.com/private?token=secret',
+      note: 'person@example.com',
+      count: 2,
+    }),
+    {
+      source: 'frankx_site',
+      destination: '/products/vibe-os',
+      count: 2,
+    }
+  )
+})
+
+test('event helpers do not fall back to ambient marketing globals or raw campaign values', async () => {
+  const [analytics, workshop, landed, links, conversion] = await Promise.all([
+    readRepoFile('lib/analytics.ts'),
+    readRepoFile('lib/analytics-workshop.ts'),
+    readRepoFile('components/connect/ConnectLandedTracker.tsx'),
+    readRepoFile('app/links/page.tsx'),
+    readRepoFile('lib/gtag.ts'),
+  ])
+
+  assert.doesNotMatch(
+    `${analytics}\n${workshop}\n${links}\n${conversion}`,
+    /window\.(plausible|gtag|posthog)|segment\.track|NEXT_PUBLIC_GA_/
+  )
+  assert.match(analytics, /sanitizeAnalyticsProperties\(params\)/)
+  assert.doesNotMatch(landed, /utm_source:\s*utmSource|utm_medium:\s*utmMedium|utm_campaign:\s*utmCampaign/)
+  assert.match(landed, /entry: hasCampaignTag/)
+})
+
+test('newsletter conversion remains provider-accepted and analytics receives no email', async () => {
+  const [capture, newsletterTest] = await Promise.all([
+    readRepoFile('components/funnels/EmailCaptureForm.tsx'),
+    readRepoFile('scripts/tests/submit-newsletter.test.mjs'),
+  ])
+
+  assert.match(capture, /if \(!result\.ok\)/)
+  assert.match(capture, /trackEvent\('lead_submitted'/)
+  assert.doesNotMatch(
+    capture.slice(capture.indexOf("trackEvent('lead_submitted'"), capture.indexOf('});', capture.indexOf("trackEvent('lead_submitted'"))),
+    /\bemail\s*[:,]/
+  )
+  assert.match(newsletterTest, /returns success only after an accepted provider response/)
+})

--- a/scripts/tests/submit-newsletter.test.mjs
+++ b/scripts/tests/submit-newsletter.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import { submitNewsletter } from '../../lib/newsletter/submit-newsletter.ts'
+
+test('returns success only after an accepted provider response', async () => {
+  let requestBody
+  const result = await submitNewsletter(' Creator@Example.com ', async (_url, init) => {
+    requestBody = JSON.parse(init.body)
+    return new Response(JSON.stringify({ success: true }), { status: 200 })
+  })
+
+  assert.deepEqual(result, { ok: true })
+  assert.deepEqual(requestBody, {
+    email: 'creator@example.com',
+    listType: 'newsletter',
+    source: 'email-capture-form',
+  })
+})
+
+test('does not treat an HTTP success without an accepted outcome as a conversion', async () => {
+  const result = await submitNewsletter('creator@example.com', async () =>
+    new Response('{}', { status: 200 })
+  )
+
+  assert.equal(result.ok, false)
+})
+
+test('returns an honest error when intake rejects or cannot be reached', async () => {
+  const rejected = await submitNewsletter('creator@example.com', async () =>
+    new Response(JSON.stringify({ error: 'Email service not configured.' }), { status: 500 })
+  )
+  const unavailable = await submitNewsletter('creator@example.com', async () => {
+    throw new Error('network unavailable')
+  })
+
+  assert.deepEqual(rejected, { ok: false, message: 'Email service not configured.' })
+  assert.equal(unavailable.ok, false)
+})
+
+test('the capture form records only a bounded event after accepted intake', async () => {
+  const source = await readFile(
+    new URL('../../components/funnels/EmailCaptureForm.tsx', import.meta.url),
+    'utf8'
+  )
+  const acceptedResponse = source.indexOf('if (!result.ok)')
+  const conversion = source.indexOf("trackEvent('lead_submitted'")
+  const conversionProperties = source.slice(conversion, source.indexOf('});', conversion))
+
+  assert.ok(acceptedResponse >= 0)
+  assert.ok(conversion > acceptedResponse)
+  assert.doesNotMatch(conversionProperties, /\bemail\s*[:,]/)
+  assert.match(source, /surface: 'email_capture_form'/)
+  assert.match(source, /offer_id: 'frankx_newsletter'/)
+  assert.match(source, /source: 'frankx_site'/)
+})


### PR DESCRIPTION
## Outcome

Repositions the FrankX homepage as the executive AI architecture and founder-operator front door.

- one primary architecture route and advisory conversion path
- real, inspectable ACOS, field-guide, and blueprint proof
- honest GenCreator and AgenticIncome handoffs
- public-safe copy and aligned JSON-LD
- tighter CSP and browser security headers
- server-rendered, still-first Premium Web OS composition

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm lint` (0 errors; existing warnings outside this lane)
- `pnpm merge:gate` (strict claims, content, static + live links, workflow checks)
- `pnpm type-check` after final metadata correction
- `pnpm claims:audit:strict`
- scoped AI-slop refusal scan
- `pnpm build` (1,549 static pages)
- staged security scan: no leaks
- design evidence validator: pass

## Visual gate

Desktop capture passes. The single capped 390px capture exposed horizontal clipping; min-width containment was corrected afterward. Design evidence remains `iterate` at 25/30 until the Git-backed preview is inspected on mobile. Keep this PR draft; do not promote or attach domains from this lane.