### PR TITLE
Fix narrow homepage portrait proof overlay

### DIFF
--- a/components/home/FrankXProductionHome.tsx
+++ b/components/home/FrankXProductionHome.tsx
@@ -159,15 +159,18 @@ export default function FrankXProductionHome({
                 className="absolute inset-0 bg-gradient-to-t from-[#08100d] via-[#08100d]/15 to-transparent"
                 aria-hidden="true"
               />
-              <div className="absolute inset-x-0 bottom-0 p-6 sm:p-8">
-                <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-emerald-300/70">
-                  Evidence before adjectives
-                </p>
-                <p className="mt-3 max-w-sm text-base leading-7 text-white/78">
-                  Architecture is useful when a team can see the decisions, operate the workflow,
-                  and know when the system is wrong.
-                </p>
-              </div>
+            </div>
+            <div
+              data-home-proof-overlay
+              className="absolute inset-x-0 bottom-0 min-w-0 max-w-full p-5 min-[360px]:p-6 sm:p-8"
+            >
+              <p className="max-w-full font-mono text-[10px] uppercase tracking-[0.22em] text-emerald-300/70">
+                Evidence before adjectives
+              </p>
+              <p className="mt-3 max-w-full text-base leading-7 text-white/78 sm:max-w-sm">
+                Architecture is useful when a team can see the decisions, operate the workflow,
+                and know when the system is wrong.
+              </p>
             </div>
           </div>
         </div>

--- a/scripts/tests/homepage-release-contract.test.mjs
+++ b/scripts/tests/homepage-release-contract.test.mjs
@@ -24,3 +24,14 @@ test('homepage release evidence is portable and records the verified ship state'
   assert.equal(evidence.decision, 'ship')
   assert.ok(evidence.artifacts.every((artifact) => !artifact.path_or_url.startsWith('file:')))
 })
+
+test('portrait proof overlay is bounded by the card at narrow widths', async () => {
+  const homepage = await readRepoFile('components/home/FrankXProductionHome.tsx')
+
+  assert.match(homepage, /data-home-proof-overlay/)
+  assert.match(
+    homepage,
+    /absolute inset-x-0 bottom-0 min-w-0 max-w-full p-5 min-\[360px\]:p-6 sm:p-8/,
+  )
+  assert.match(homepage, /max-w-full text-base leading-7 text-white\/78 sm:max-w-sm/)
+})

--- a/scripts/tests/homepage-release-contract.test.mjs
+++ b/scripts/tests/homepage-release-contract.test.mjs
@@ -27,11 +27,25 @@ test('homepage release evidence is portable and records the verified ship state'
 
 test('portrait proof overlay is bounded by the card at narrow widths', async () => {
   const homepage = await readRepoFile('components/home/FrankXProductionHome.tsx')
+  const overlayMarkup = homepage.match(/data-home-proof-overlay[\s\S]*?<\/div>/)?.[0]
+  const overlayClasses = overlayMarkup?.match(/className="([^"]+)"/)?.[1].split(/\s+/) ?? []
+  const copyClasses = [...(overlayMarkup?.matchAll(/<p className="([^"]+)">/g) ?? [])]
+    .map((match) => match[1].split(/\s+/))
+    .find((classes) => classes.includes('text-base'))
 
-  assert.match(homepage, /data-home-proof-overlay/)
-  assert.match(
-    homepage,
-    /absolute inset-x-0 bottom-0 min-w-0 max-w-full p-5 min-\[360px\]:p-6 sm:p-8/,
-  )
-  assert.match(homepage, /max-w-full text-base leading-7 text-white\/78 sm:max-w-sm/)
+  assert.ok(overlayMarkup, 'proof overlay must remain addressable')
+  for (const token of [
+    'absolute',
+    'inset-x-0',
+    'bottom-0',
+    'min-w-0',
+    'max-w-full',
+    'p-5',
+    'min-[360px]:p-6',
+    'sm:p-8',
+  ]) {
+    assert.ok(overlayClasses.includes(token), `proof overlay must retain ${token}`)
+  }
+  assert.ok(copyClasses?.includes('max-w-full'), 'proof copy must stay bounded at narrow widths')
+  assert.ok(copyClasses?.includes('sm:max-w-sm'), 'proof copy must preserve its desktop measure')
 })

--- a/scripts/tests/homepage-release-contract.test.mjs
+++ b/scripts/tests/homepage-release-contract.test.mjs
@@ -3,6 +3,26 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+const OVERLAY_OPEN_TAG_PATTERN = /<div\b(?=[^>]*\bdata-home-proof-overlay\b)[^>]*>/
+const DIV_TAG_PATTERN = /<\/?div\b[^>]*>/g
+const CLASS_NAME_PATTERN = /\bclassName="([^"]+)"/
+const PARAGRAPH_TAG_PATTERN = /<p\b[^>]*>/g
+const WHITESPACE_PATTERN = /\s+/
+
+const extractElementSource = (source, openingPattern) => {
+  const openingMatch = source.match(openingPattern)
+  if (openingMatch?.index === undefined) return undefined
+
+  let depth = 0
+  DIV_TAG_PATTERN.lastIndex = openingMatch.index
+
+  for (let tag = DIV_TAG_PATTERN.exec(source); tag; tag = DIV_TAG_PATTERN.exec(source)) {
+    depth += tag[0].startsWith('</') ? -1 : 1
+    if (depth === 0) return source.slice(openingMatch.index, DIV_TAG_PATTERN.lastIndex)
+  }
+
+  return undefined
+}
 
 test('homepage repository proof derives from the canonical social registry', async () => {
   const homepage = await readRepoFile('components/home/FrankXProductionHome.tsx')
@@ -27,13 +47,12 @@ test('homepage release evidence is portable and records the verified ship state'
 
 test('portrait proof overlay is bounded by the card at narrow widths', async () => {
   const homepage = await readRepoFile('components/home/FrankXProductionHome.tsx')
-  const overlayMarkup = homepage.match(
-    /<div\b(?=[^>]*\bdata-home-proof-overlay\b)[^>]*>[\s\S]*?<\/div>/,
-  )?.[0]
-  const overlayOpenTag = overlayMarkup?.match(/^<div\b[^>]*>/)?.[0]
-  const overlayClasses = overlayOpenTag?.match(/\bclassName="([^"]+)"/)?.[1].split(/\s+/) ?? []
-  const copyClasses = [...(overlayMarkup?.matchAll(/<p\b[^>]*\bclassName="([^"]+)"[^>]*>/g) ?? [])]
-    .map((match) => match[1].split(/\s+/))
+  const overlayMarkup = extractElementSource(homepage, OVERLAY_OPEN_TAG_PATTERN)
+  const overlayOpenTag = overlayMarkup?.match(OVERLAY_OPEN_TAG_PATTERN)?.[0]
+  const overlayClasses = overlayOpenTag?.match(CLASS_NAME_PATTERN)?.[1].split(WHITESPACE_PATTERN) ?? []
+  const copyClasses = Array.from(overlayMarkup?.matchAll(PARAGRAPH_TAG_PATTERN) ?? [], (match) =>
+    (match[0].match(CLASS_NAME_PATTERN)?.[1] ?? '').split(WHITESPACE_PATTERN),
+  )
     .find((classes) => classes.includes('text-base'))
 
   assert.ok(overlayMarkup, 'proof overlay must remain addressable')
@@ -51,4 +70,18 @@ test('portrait proof overlay is bounded by the card at narrow widths', async () 
   }
   assert.ok(copyClasses?.includes('max-w-full'), 'proof copy must stay bounded at narrow widths')
   assert.ok(copyClasses?.includes('sm:max-w-sm'), 'proof copy must preserve its desktop measure')
+})
+
+test('overlay source extraction includes nested divs and stops at the matching close', () => {
+  const source = `<section>
+    <div className="proof" data-home-proof-overlay>
+      <p className="copy">Proof</p>
+      <div className="nested"><p>Nested detail</p></div>
+    </div>
+    <div>Unrelated sibling</div>
+  </section>`
+  const overlayMarkup = extractElementSource(source, OVERLAY_OPEN_TAG_PATTERN)
+
+  assert.match(overlayMarkup, /Nested detail/)
+  assert.doesNotMatch(overlayMarkup, /Unrelated sibling/)
 })

--- a/scripts/tests/homepage-release-contract.test.mjs
+++ b/scripts/tests/homepage-release-contract.test.mjs
@@ -27,9 +27,12 @@ test('homepage release evidence is portable and records the verified ship state'
 
 test('portrait proof overlay is bounded by the card at narrow widths', async () => {
   const homepage = await readRepoFile('components/home/FrankXProductionHome.tsx')
-  const overlayMarkup = homepage.match(/data-home-proof-overlay[\s\S]*?<\/div>/)?.[0]
-  const overlayClasses = overlayMarkup?.match(/className="([^"]+)"/)?.[1].split(/\s+/) ?? []
-  const copyClasses = [...(overlayMarkup?.matchAll(/<p className="([^"]+)">/g) ?? [])]
+  const overlayMarkup = homepage.match(
+    /<div\b(?=[^>]*\bdata-home-proof-overlay\b)[^>]*>[\s\S]*?<\/div>/,
+  )?.[0]
+  const overlayOpenTag = overlayMarkup?.match(/^<div\b[^>]*>/)?.[0]
+  const overlayClasses = overlayOpenTag?.match(/\bclassName="([^"]+)"/)?.[1].split(/\s+/) ?? []
+  const copyClasses = [...(overlayMarkup?.matchAll(/<p\b[^>]*\bclassName="([^"]+)"[^>]*>/g) ?? [])]
     .map((match) => match[1].split(/\s+/))
     .find((classes) => classes.includes('text-base'))
 

--- a/scripts/tests/homepage-release-contract.test.mjs
+++ b/scripts/tests/homepage-release-contract.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test'
 
 const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
 const OVERLAY_OPEN_TAG_PATTERN = /<div\b(?=[^>]*\bdata-home-proof-overlay\b)[^>]*>/
-const DIV_TAG_PATTERN = /<\/?div\b[^>]*>/g
+const DIV_TAG_PATTERN = /<\/?div\b[^>]*>/
 const CLASS_NAME_PATTERN = /\bclassName="([^"]+)"/
 const PARAGRAPH_TAG_PATTERN = /<p\b[^>]*>/g
 const WHITESPACE_PATTERN = /\s+/
@@ -14,11 +14,17 @@ const extractElementSource = (source, openingPattern) => {
   if (openingMatch?.index === undefined) return undefined
 
   let depth = 0
-  DIV_TAG_PATTERN.lastIndex = openingMatch.index
+  let cursor = openingMatch.index
 
-  for (let tag = DIV_TAG_PATTERN.exec(source); tag; tag = DIV_TAG_PATTERN.exec(source)) {
+  while (cursor < source.length) {
+    const tag = source.slice(cursor).match(DIV_TAG_PATTERN)
+    if (tag?.index === undefined) break
+
+    const tagStart = cursor + tag.index
+    const tagEnd = tagStart + tag[0].length
     depth += tag[0].startsWith('</') ? -1 : 1
-    if (depth === 0) return source.slice(openingMatch.index, DIV_TAG_PATTERN.lastIndex)
+    if (depth === 0) return source.slice(openingMatch.index, tagEnd)
+    cursor = tagEnd
   }
 
   return undefined
@@ -84,4 +90,13 @@ test('overlay source extraction includes nested divs and stops at the matching c
 
   assert.match(overlayMarkup, /Nested detail/)
   assert.doesNotMatch(overlayMarkup, /Unrelated sibling/)
+})
+
+test('overlay source extraction has no shared state between calls', () => {
+  const firstSource = '<div data-home-proof-overlay><p>First</p></div>'
+  const secondSource = '<div data-home-proof-overlay><div><p>Second</p></div></div>'
+
+  assert.match(extractElementSource(firstSource, OVERLAY_OPEN_TAG_PATTERN), /First/)
+  assert.match(extractElementSource(secondSource, OVERLAY_OPEN_TAG_PATTERN), /Second/)
+  assert.match(extractElementSource(firstSource, OVERLAY_OPEN_TAG_PATTERN), /First/)
 })


### PR DESCRIPTION
## Release intent

Contain the homepage portrait proof overlay at 320px and desktop-UA reflow without global overflow masking. Preserve the accepted 390px/desktop composition, reduced-motion route, SEO, DNT analytics policy, and newsletter behavior.

## Change

- Anchor the proof overlay to the real card instead of the aspect/min-height inner frame.
- Bound the overlay and copy to the card width.
- Use 20px narrow padding, preserving 24px at 360+ and 32px at sm+.
- Add a release contract for the narrow-width containment classes.

## Local proof

- homepage release contract: 3/3
- privacy/DNT analytics: 5/5
- newsletter: 4/4
- targeted ESLint: pass
- TypeScript: pass
- optimized build: pass (410.7s)
- staged gitleaks: 0 findings
- Chrome CDP: 1440, 390, 320, desktop-UA 320 reflow, reduced-motion all pass
- 320: overlay x=21..299 inside card x=20..300; text x=41..279
- document overflow: 0; broken images: 0; runtime errors: 0

## Evidence

Local release evidence: C:/Users/frank/starlight/repos/_visual-qa/releases/2026-07-11/frankx-home-overlay-hotfix-local

Draft until the exact Vercel preview and heavy checks are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing and text width for the homepage’s portrait overlay, especially on narrow screens.

* **Tests**
  * Added coverage to verify the overlay remains properly positioned and bounded across responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->