### PR TITLE
feat(ai-coe-readiness): AI CoE Readiness Assessment — enterprise scorecard twin

### DIFF
--- a/app/ai-coe-readiness/AiCoeReadinessClient.tsx
+++ b/app/ai-coe-readiness/AiCoeReadinessClient.tsx
@@ -1,0 +1,665 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+import clsx from 'clsx'
+import Link from 'next/link'
+import { useReducedMotion } from 'framer-motion'
+import { gsap } from 'gsap'
+import { useGSAP } from '@gsap/react'
+import { ArrowRight, ArrowLeft, Lock, ShieldCheck, ShieldAlert, Building2, CheckCircle2 } from 'lucide-react'
+
+import { QUESTIONS, scoreReadiness, type ReadinessResult } from '@/lib/ai-coe-readiness/engine'
+import { CTA_BY_TIER } from '@/lib/ai-coe-readiness/cta'
+import { DimensionRadar } from '@/components/scorecard/DimensionRadar'
+
+type Stage = 'intro' | 'question' | 'reveal' | 'report'
+
+const ACCENT = '#22d3ee' // cyan-400 — enterprise register, distinct from the Operator Scorecard's emerald
+
+// The AI CoE Readiness Assessment is the enterprise twin of the Operator Scorecard, reusing
+// its scoring engine pattern and GSAP choreography. The register here is deliberately more
+// restrained: no hover hints, no playful asides — a director reading this on a laptop before
+// a board meeting should feel this was built by someone who has run this in production.
+//
+// State changes fire immediately and synchronously — GSAP only ever decorates the entrance of
+// whatever just became true (see OperatorScorecardClient.tsx's decorator-not-driver pattern;
+// this file does not reintroduce the rAF-gated-state bug that pattern fixed).
+export default function AiCoeReadinessClient() {
+  const prefersReducedMotion = Boolean(useReducedMotion())
+  const [stage, setStage] = useState<Stage>('intro')
+  const [step, setStep] = useState(0)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [email, setEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [gateError, setGateError] = useState<string | null>(null)
+  const [revealBeat, setRevealBeat] = useState(0) // 0 none, 1 score, 2 +radar, 3 +tier/gate
+
+  const totalQuestions = QUESTIONS.length
+  const activeQuestion = QUESTIONS[step]
+  const chosenOptionId = activeQuestion ? answers[activeQuestion.id] : undefined
+
+  const result: ReadinessResult = useMemo(() => scoreReadiness(answers), [answers])
+
+  // ---- Cross-stage transitions ("one camera-like movement") -------------
+  const stageRef = useRef<HTMLDivElement>(null)
+
+  useGSAP(
+    () => {
+      if (prefersReducedMotion || !stageRef.current) return
+      gsap.fromTo(stageRef.current, { opacity: 0, y: 10 }, { opacity: 1, y: 0, duration: 0.3, ease: 'power3.out' })
+    },
+    { dependencies: [stage, prefersReducedMotion] },
+  )
+
+  // ---- Question-to-question transitions ----------------------------------
+  const questionRef = useRef<HTMLDivElement>(null)
+  const directionRef = useRef<1 | -1>(1)
+
+  useGSAP(
+    () => {
+      if (stage !== 'question' || prefersReducedMotion || !questionRef.current) return
+      const direction = directionRef.current
+      gsap.fromTo(
+        questionRef.current,
+        { opacity: 0, x: direction * 18 },
+        { opacity: 1, x: 0, duration: 0.24, ease: 'power3.out' },
+      )
+    },
+    { dependencies: [step, stage, prefersReducedMotion] },
+  )
+
+  function selectAnswer(optionId: string) {
+    if (!activeQuestion) return
+    setAnswers((prev) => ({ ...prev, [activeQuestion.id]: optionId }))
+  }
+
+  function goNext() {
+    if (!chosenOptionId) return
+    if (step < totalQuestions - 1) {
+      directionRef.current = 1
+      setStep((s) => s + 1)
+    } else {
+      setStage('reveal')
+    }
+  }
+
+  function goBack() {
+    if (step === 0) return
+    directionRef.current = -1
+    setStep((s) => s - 1)
+  }
+
+  // ---- Keyboard nav: arrows + enter + number-key shortcuts (1-4) ---------
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  useEffect(() => {
+    optionRefs.current = []
+  }, [step])
+
+  useEffect(() => {
+    if (stage !== 'question' || !activeQuestion) return
+
+    function focusOption(idx: number) {
+      optionRefs.current[idx]?.focus()
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      const options = activeQuestion!.options
+      const currentIndex = options.findIndex((o) => o.id === answers[activeQuestion!.id])
+
+      if (e.key >= '1' && e.key <= '4') {
+        const idx = Number(e.key) - 1
+        if (idx < options.length) {
+          e.preventDefault()
+          selectAnswer(options[idx].id)
+          focusOption(idx)
+        }
+        return
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+        e.preventDefault()
+        const next = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length
+        selectAnswer(options[next].id)
+        focusOption(next)
+        return
+      }
+      if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+        e.preventDefault()
+        const prev = currentIndex < 0 ? options.length - 1 : (currentIndex - 1 + options.length) % options.length
+        selectAnswer(options[prev].id)
+        focusOption(prev)
+        return
+      }
+      if (e.key === 'Enter') {
+        if (answers[activeQuestion!.id]) {
+          e.preventDefault()
+          goNext()
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stage, activeQuestion, answers, step])
+
+  // ---- Selected state: a quick, non-bouncy "switch engaging" pulse -------
+  const dotRefs = useRef<Map<string, HTMLSpanElement>>(new Map())
+
+  useGSAP(
+    () => {
+      if (!chosenOptionId || prefersReducedMotion) return
+      const dot = dotRefs.current.get(chosenOptionId)
+      if (!dot) return
+      gsap.fromTo(dot, { scale: 0.55 }, { scale: 1, duration: 0.16, ease: 'power3.out' })
+    },
+    { dependencies: [chosenOptionId, prefersReducedMotion] },
+  )
+
+  // ---- Intro: one choreographed staggered entrance -----------------------
+  const introRef = useRef<HTMLDivElement>(null)
+
+  useGSAP(
+    () => {
+      if (stage !== 'intro' || prefersReducedMotion || !introRef.current) return
+      const items = introRef.current.querySelectorAll('[data-intro-item]')
+      gsap.fromTo(
+        items,
+        { opacity: 0, y: 14 },
+        { opacity: 1, y: 0, duration: 0.5, ease: 'power3.out', stagger: 0.08 },
+      )
+    },
+    { dependencies: [stage, prefersReducedMotion] },
+  )
+
+  // ---- Reveal: the held moment (beats 1-3, then the gate) -----------------
+  useEffect(() => {
+    if (stage !== 'reveal') {
+      setRevealBeat(0)
+      return
+    }
+    if (prefersReducedMotion) {
+      setRevealBeat(3)
+      return
+    }
+    setRevealBeat(0)
+    const t1 = window.setTimeout(() => setRevealBeat(1), 20)
+    const t2 = window.setTimeout(() => setRevealBeat(2), 1300)
+    const t3 = window.setTimeout(() => setRevealBeat(3), 2500)
+    return () => {
+      window.clearTimeout(t1)
+      window.clearTimeout(t2)
+      window.clearTimeout(t3)
+    }
+  }, [stage, prefersReducedMotion])
+
+  const scoreRef = useRef<HTMLSpanElement>(null)
+
+  useGSAP(
+    () => {
+      if (stage !== 'reveal' || revealBeat < 1 || !scoreRef.current) return
+      if (prefersReducedMotion) {
+        scoreRef.current.textContent = String(result.totalScore)
+        return
+      }
+      const proxy = { val: 0 }
+      gsap.to(proxy, {
+        val: result.totalScore,
+        duration: 1.2,
+        ease: 'power2.out',
+        onUpdate: () => {
+          if (scoreRef.current) scoreRef.current.textContent = String(Math.round(proxy.val))
+        },
+      })
+    },
+    { dependencies: [stage, revealBeat, result.totalScore, prefersReducedMotion] },
+  )
+
+  const tierBlockRef = useRef<HTMLDivElement>(null)
+  const gateBlockRef = useRef<HTMLDivElement>(null)
+
+  useGSAP(
+    () => {
+      if (revealBeat < 3 || prefersReducedMotion) return
+      if (tierBlockRef.current) {
+        gsap.fromTo(tierBlockRef.current, { opacity: 0, y: 14 }, { opacity: 1, y: 0, duration: 0.5, ease: 'power3.out' })
+      }
+      if (gateBlockRef.current) {
+        gsap.fromTo(
+          gateBlockRef.current,
+          { opacity: 0, y: 14 },
+          { opacity: 1, y: 0, duration: 0.5, ease: 'power3.out', delay: 0.15 },
+        )
+      }
+    },
+    { dependencies: [revealBeat, prefersReducedMotion] },
+  )
+
+  // ---- Report: the ceiling named with weight, then the risk exposure -----
+  const ceilingNameRef = useRef<HTMLHeadingElement>(null)
+  const ceilingDescRef = useRef<HTMLParagraphElement>(null)
+  const riskBlockRef = useRef<HTMLDivElement>(null)
+  const actionItemRefs = useRef<(HTMLLIElement | null)[]>([])
+  const reportRestRef = useRef<HTMLDivElement>(null)
+
+  useGSAP(
+    () => {
+      if (stage !== 'report' || prefersReducedMotion || !ceilingNameRef.current) return
+      const tl = gsap.timeline()
+      tl.fromTo(
+        ceilingNameRef.current,
+        { opacity: 0, y: 12 },
+        { opacity: 1, y: 0, duration: 0.45, ease: 'power3.out' },
+      )
+      if (ceilingDescRef.current) {
+        tl.fromTo(
+          ceilingDescRef.current,
+          { opacity: 0, y: 10 },
+          { opacity: 1, y: 0, duration: 0.4, ease: 'power3.out' },
+          '-=0.2',
+        )
+      }
+      if (riskBlockRef.current) {
+        tl.fromTo(
+          riskBlockRef.current,
+          { opacity: 0, y: 10 },
+          { opacity: 1, y: 0, duration: 0.4, ease: 'power3.out' },
+          '-=0.15',
+        )
+      }
+      const items = actionItemRefs.current.filter((i): i is HTMLLIElement => i !== null)
+      if (items.length) {
+        tl.fromTo(
+          items,
+          { opacity: 0, y: 8 },
+          { opacity: 1, y: 0, duration: 0.35, stagger: 0.12, ease: 'power3.out' },
+          '-=0.1',
+        )
+      }
+      if (reportRestRef.current) {
+        tl.fromTo(
+          reportRestRef.current,
+          { opacity: 0, y: 14 },
+          { opacity: 1, y: 0, duration: 0.45, ease: 'power3.out' },
+          '+=0.1',
+        )
+      }
+    },
+    { dependencies: [stage, prefersReducedMotion, result.ceiling.dimension] },
+  )
+
+  async function submitEmail(e: FormEvent) {
+    e.preventDefault()
+    setGateError(null)
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setGateError('Enter a valid email address.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          listType: 'ai-architect',
+          source: 'ai-coe-readiness',
+        }),
+      })
+
+      if (res.ok) {
+        setStage('report')
+        return
+      }
+
+      const data = await res.json().catch(() => ({}))
+      // Graceful dev fallback: if the email service simply isn't configured
+      // locally (no RESEND_API_KEY), don't block the report behind a 500 —
+      // only block on real validation errors (bad email, already subscribed).
+      if (res.status === 500 && /not configured/i.test(data?.error ?? '')) {
+        setStage('report')
+        return
+      }
+
+      setGateError(data?.error ?? 'Could not save your email. Please try again.')
+    } catch {
+      // Network failure in local dev — same graceful fallback.
+      setStage('report')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function restart() {
+    setStage('intro')
+    setStep(0)
+    setAnswers({})
+    setGateError(null)
+    setEmail('')
+    setRevealBeat(0)
+  }
+
+  return (
+    <div className="min-h-screen bg-[#05070a] text-white">
+      <div className="mx-auto max-w-4xl px-6 pb-24 pt-32">
+        <div ref={stageRef}>
+          {stage === 'intro' && (
+            <div ref={introRef} className="space-y-10 text-center">
+              <span
+                data-intro-item
+                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 font-mono text-xs uppercase tracking-[0.3em] text-cyan-300"
+              >
+                <Building2 className="h-3.5 w-3.5" aria-hidden="true" />
+                AI CoE Readiness Assessment
+              </span>
+              <h1 data-intro-item className="text-balance text-4xl font-semibold leading-tight md:text-5xl">
+                Your AI strategy was written by people who&apos;ve never run an agent overnight.
+                <br />
+                Find out where yours actually stands.
+              </h1>
+              <p data-intro-item className="mx-auto max-w-xl text-base text-white/70 md:text-lg">
+                12 questions across the six dimensions that separate a strategy deck from a governed,
+                in-production AI Center of Excellence.
+              </p>
+              <div data-intro-item className="flex flex-col items-center gap-4">
+                <button
+                  type="button"
+                  onClick={() => setStage('question')}
+                  className="inline-flex min-h-[44px] items-center gap-2 rounded-xl bg-cyan-400 px-8 py-4 text-sm font-semibold text-slate-950 transition hover:-translate-y-0.5 hover:bg-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#05070a]"
+                >
+                  Assess our AI CoE readiness
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <p className="font-mono text-xs uppercase tracking-[0.25em] text-white/40">
+                  ~6 minutes &middot; free instant result &middot; 5 maturity levels
+                </p>
+              </div>
+            </div>
+          )}
+
+          {stage === 'question' && activeQuestion && (
+            <div className="space-y-4">
+              <div className="flex justify-between font-mono text-xs uppercase tracking-[0.25em] text-white/50" aria-live="polite">
+                <span>
+                  Question {step + 1} of {totalQuestions}
+                </span>
+              </div>
+
+              <div ref={questionRef} className="space-y-5 rounded-2xl border border-white/10 bg-white/[0.03] p-7 md:p-9">
+                <div className="flex flex-col items-start gap-5 sm:flex-row sm:items-start sm:justify-between">
+                  <h2 id={`question-${activeQuestion.id}`} className="text-xl font-semibold text-white md:text-2xl">
+                    {activeQuestion.prompt}
+                  </h2>
+                  <div aria-hidden="true" className="shrink-0 self-center sm:self-start" style={{ width: 72, height: 72 }}>
+                    <DimensionRadar
+                      scores={result.dimensionScores}
+                      mode="mini"
+                      size={72}
+                      color={ACCENT}
+                      reducedMotion={prefersReducedMotion}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-3" role="radiogroup" aria-labelledby={`question-${activeQuestion.id}`}>
+                  {activeQuestion.options.map((option, idx) => {
+                    const isSelected = chosenOptionId === option.id
+                    return (
+                      <button
+                        type="button"
+                        key={option.id}
+                        ref={(el) => {
+                          optionRefs.current[idx] = el
+                        }}
+                        onClick={() => selectAnswer(option.id)}
+                        role="radio"
+                        aria-checked={isSelected}
+                        tabIndex={isSelected || (chosenOptionId === undefined && idx === 0) ? 0 : -1}
+                        className={clsx(
+                          'w-full min-h-[44px] rounded-xl border border-white/10 bg-white/[0.02] p-4 text-left text-sm transition-[color,background-color,border-color,box-shadow,transform] duration-150 hover:-translate-y-0.5 hover:border-cyan-400/40 hover:bg-white/[0.05] hover:shadow-[0_8px_24px_-12px_rgba(34,211,238,0.35)] focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300',
+                          isSelected && 'border-cyan-400/60 bg-cyan-400/10',
+                        )}
+                      >
+                        <div className="flex items-start gap-3">
+                          <span
+                            className={clsx(
+                              'mt-0.5 inline-flex h-4 w-4 shrink-0 origin-center items-center justify-center rounded-full border border-white/30 transition-colors duration-150',
+                              isSelected && 'border-cyan-300 bg-cyan-300',
+                            )}
+                            ref={(el) => {
+                              if (el) dotRefs.current.set(option.id, el)
+                            }}
+                          >
+                            {isSelected ? <CheckCircle2 className="h-3.5 w-3.5 text-slate-950" aria-hidden="true" /> : null}
+                          </span>
+                          <span className="text-white/85">{option.label}</span>
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+
+                <div className="flex items-center justify-between pt-2">
+                  <button
+                    type="button"
+                    onClick={goBack}
+                    disabled={step === 0}
+                    className={clsx(
+                      'inline-flex min-h-[44px] items-center gap-1.5 text-sm font-medium text-white/50 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300',
+                      step === 0 && 'invisible',
+                    )}
+                  >
+                    <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                    Back
+                  </button>
+                  <button
+                    type="button"
+                    onClick={goNext}
+                    disabled={!chosenOptionId}
+                    className={clsx(
+                      'inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-cyan-400 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300',
+                      !chosenOptionId && 'cursor-not-allowed opacity-40',
+                    )}
+                  >
+                    {step < totalQuestions - 1 ? 'Next' : 'See our readiness level'}
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </div>
+
+                <p className="text-center font-mono text-[10px] uppercase tracking-widest text-white/25">
+                  &uarr;&darr; choose &middot; 1&ndash;4 jump &middot; enter continue
+                </p>
+              </div>
+            </div>
+          )}
+
+          {stage === 'reveal' && (
+            <div className="space-y-10">
+              <div className="space-y-4 text-center">
+                <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 font-mono text-xs uppercase tracking-[0.3em] text-cyan-300">
+                  <Building2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  Free read — no email required
+                </span>
+                <div className="flex items-end justify-center gap-4">
+                  <span
+                    ref={scoreRef}
+                    className="font-mono text-6xl font-bold tabular-nums text-white md:text-7xl"
+                  >
+                    0
+                  </span>
+                  <span className="mb-2 font-mono text-lg text-white/40">/100</span>
+                </div>
+              </div>
+
+              {revealBeat >= 2 && (
+                <div>
+                  <DimensionRadar
+                    scores={result.dimensionScores}
+                    color={ACCENT}
+                    strokeReveal
+                    reducedMotion={prefersReducedMotion}
+                  />
+                </div>
+              )}
+
+              {revealBeat >= 3 && (
+                <>
+                  <div ref={tierBlockRef} className="space-y-3 text-center">
+                    <h2 className="text-2xl font-semibold text-white md:text-3xl">{result.tier.label}</h2>
+                    <p className="mx-auto max-w-xl text-sm text-white/60 md:text-base">{result.tier.tierLine}</p>
+                  </div>
+
+                  <div
+                    ref={gateBlockRef}
+                    className="rounded-2xl border border-cyan-400/25 bg-cyan-400/5 p-7 md:p-9"
+                  >
+                    <div className="flex items-center gap-2 font-mono text-xs uppercase tracking-[0.25em] text-cyan-300">
+                      <Lock className="h-3.5 w-3.5" aria-hidden="true" />
+                      Full readiness report
+                    </div>
+                    <h3 className="mt-3 text-xl font-semibold text-white md:text-2xl">
+                      Your full readiness report is ready — where should it live?
+                    </h3>
+                    <p className="mt-2 max-w-xl text-sm text-white/70">
+                      One dimension is capping every other score, and it carries a named risk exposure.
+                      The report has both, plus the three moves that close it fastest.
+                    </p>
+
+                    <form onSubmit={submitEmail} className="mt-6 flex flex-col gap-3 sm:flex-row">
+                      <label htmlFor="ai-coe-readiness-email" className="sr-only">
+                        Work email address
+                      </label>
+                      <input
+                        id="ai-coe-readiness-email"
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="you@company.com"
+                        className="min-h-[44px] flex-1 rounded-lg border border-white/15 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-white/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                      />
+                      <button
+                        type="submit"
+                        disabled={submitting}
+                        className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-cyan-400 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {submitting ? 'Unlocking…' : 'Send my report'}
+                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    </form>
+                    {gateError ? <p className="mt-2 text-sm text-red-400">{gateError}</p> : null}
+                    <p className="mt-3 flex items-center gap-1.5 text-xs text-white/40">
+                      <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                      No spam. One report email, then the AI Architect dispatch. Unsubscribe anytime.
+                    </p>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {stage === 'report' && (
+            <div className="space-y-10">
+              <div className="space-y-3 text-center">
+                <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 font-mono text-xs uppercase tracking-[0.3em] text-cyan-300">
+                  <Building2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  Your result
+                </span>
+                <div className="flex items-end justify-center gap-3">
+                  <span className="font-mono text-4xl font-bold tabular-nums text-white">{result.totalScore}</span>
+                  <span className="mb-1 font-mono text-base text-white/40">/100</span>
+                </div>
+                <p className="text-lg font-semibold text-white">{result.tier.label}</p>
+                <p className="mx-auto max-w-xl text-sm text-white/60">{result.tier.description}</p>
+              </div>
+
+              <div className="rounded-2xl border border-amber-500/25 bg-amber-500/5 p-7 md:p-9">
+                <div className="font-mono text-xs uppercase tracking-[0.25em] text-amber-300">Your named ceiling — fix this first</div>
+                <h3 ref={ceilingNameRef} className="mt-3 text-xl font-semibold text-white md:text-2xl">
+                  {result.ceiling.name}
+                </h3>
+                <p ref={ceilingDescRef} className="mt-2 text-sm leading-relaxed text-white/70">
+                  {result.ceiling.description}
+                </p>
+
+                <div ref={riskBlockRef} className="mt-5 flex gap-3 rounded-lg border border-rose-500/25 bg-rose-500/[0.06] p-4">
+                  <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-rose-300" aria-hidden="true" />
+                  <p className="text-sm leading-relaxed text-rose-100/90">{result.ceiling.riskExposure}</p>
+                </div>
+
+                <ol className="mt-6 space-y-3">
+                  {result.ceiling.actions.map((action, i) => (
+                    <li
+                      key={action}
+                      ref={(el) => {
+                        actionItemRefs.current[i] = el
+                      }}
+                      className="flex gap-3 rounded-lg border border-white/10 bg-black/20 p-4 text-sm text-white/80"
+                    >
+                      <span className="font-mono text-amber-300">{i + 1}</span>
+                      <span>{action}</span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              <div ref={reportRestRef} className="space-y-10">
+                <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-7 md:p-9">
+                  <h3 className="font-mono text-xs uppercase tracking-[0.25em] text-white/50">
+                    Your six-dimension breakdown
+                  </h3>
+                  <div className="mt-6">
+                    <DimensionRadar scores={result.dimensionScores} color={ACCENT} reducedMotion={prefersReducedMotion} />
+                  </div>
+                </div>
+
+                <TierCtaCard tierId={result.tier.id} />
+
+                <div className="flex flex-col items-center gap-3 pt-2 text-center">
+                  <button
+                    type="button"
+                    onClick={restart}
+                    className="min-h-[44px] text-sm font-medium text-white/50 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                  >
+                    Retake the assessment
+                  </button>
+                  <p className="max-w-md text-xs text-white/35">
+                    Assessing this for a peer or a partner team? Send them this benchmark — the fastest way
+                    to see whether their program has a real operating model behind it.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TierCtaCard({ tierId }: { tierId: keyof typeof CTA_BY_TIER }) {
+  const cta = CTA_BY_TIER[tierId]
+  return (
+    <div className="rounded-2xl border border-cyan-400/25 bg-gradient-to-br from-cyan-400/10 to-transparent p-7 md:p-9">
+      <div className="font-mono text-xs uppercase tracking-[0.25em] text-cyan-300">{cta.eyebrow}</div>
+      <h3 className="mt-3 text-xl font-semibold text-white md:text-2xl">{cta.headline}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-white/70">{cta.body}</p>
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+        <Link
+          href={cta.ctaHref}
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-cyan-400 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+        >
+          {cta.ctaLabel}
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </Link>
+        <Link
+          href={cta.secondaryHref}
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-white/15 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+        >
+          {cta.secondaryLabel}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/ai-coe-readiness/page.tsx
+++ b/app/ai-coe-readiness/page.tsx
@@ -1,0 +1,20 @@
+import { createMetadata } from '@/lib/seo'
+import AiCoeReadinessClient from './AiCoeReadinessClient'
+
+export const metadata = createMetadata({
+  title: 'AI CoE Readiness Assessment — Enterprise AI Center of Excellence Benchmark',
+  path: '/ai-coe-readiness',
+  description:
+    'Answer 12 questions across exec sponsorship, data & architecture, use-case maturity, talent & op model, governance & risk, and ROI discipline. Get your AI CoE maturity level free, plus the one named risk exposure holding your program back.',
+  keywords: [
+    'ai center of excellence readiness assessment',
+    'ai coe maturity model',
+    'enterprise ai readiness scorecard',
+    'ai governance assessment',
+    'ai coe assessment frankx',
+  ],
+})
+
+export default function AiCoeReadinessPage() {
+  return <AiCoeReadinessClient />
+}

--- a/components/scorecard/DimensionRadar.tsx
+++ b/components/scorecard/DimensionRadar.tsx
@@ -4,10 +4,19 @@ import { useRef } from 'react'
 import { gsap } from 'gsap'
 import { useGSAP } from '@gsap/react'
 
-import type { DimensionScore } from '@/lib/scorecard/engine'
+// Deliberately not imported from a specific product's engine (operator-scorecard,
+// ai-coe-readiness, or any future one) — this component only ever reads `dimension` as an
+// opaque React key, so it stays product-agnostic and structurally accepts any of them.
+interface DimensionScoreLike {
+  dimension: string
+  label: string
+  raw: number
+  max: number
+  pct: number
+}
 
 interface DimensionRadarProps {
-  scores: DimensionScore[]
+  scores: DimensionScoreLike[]
   size?: number
   color?: string
   /**

--- a/lib/ai-coe-readiness/cta.ts
+++ b/lib/ai-coe-readiness/cta.ts
@@ -1,0 +1,67 @@
+// Tier -> CTA routing for the AI CoE Readiness Assessment report screen.
+//
+// Per the spec (starlight/factory/ai-coe.product-experience.v1.md §3, §5): this is a single
+// sales-cycle funnel, not a barbell split like the Operator Scorecard. Every tier's primary CTA
+// is the same paid entry point — the executive briefing that scopes the Architect Sprint — at
+// /workshops/personal-ai-coe (a real, live intake surface with a booking form; never a fake
+// booking system). Only the framing and the secondary link vary by tier, for peer positioning.
+
+import type { TierId } from './engine'
+
+export interface TierCta {
+  eyebrow: string
+  headline: string
+  body: string
+  ctaLabel: string
+  ctaHref: string
+  secondaryLabel: string
+  secondaryHref: string
+}
+
+export const CTA_BY_TIER: Record<TierId, TierCta> = {
+  'ad-hoc': {
+    eyebrow: 'Where most programs start',
+    headline: 'Skip the year of committee meetings.',
+    body: 'An Ad Hoc program does not need more strategy decks — it needs one accountable owner and one production use case. An executive briefing scopes the fastest path to a governed pilot, in your environment.',
+    ctaLabel: 'Book the executive briefing',
+    ctaHref: '/workshops/personal-ai-coe',
+    secondaryLabel: 'Read the six-pillar operating model',
+    secondaryHref: '/ai-coe',
+  },
+  piloting: {
+    eyebrow: 'Next rung',
+    headline: 'The gap is graduation, not another pilot.',
+    body: 'Pilots that never reach production are common — and also the top reason CoEs lose funding. The Architect Sprint takes one real use case from pilot to governed production, fast.',
+    ctaLabel: 'Book the executive briefing',
+    ctaHref: '/workshops/personal-ai-coe',
+    secondaryLabel: 'Read the six-pillar operating model',
+    secondaryHref: '/ai-coe',
+  },
+  scaling: {
+    eyebrow: 'Your next lane',
+    headline: 'Production is real. Governance has not caught up.',
+    body: 'You already have proof this works. The highest-leverage move now is closing the named gap before it becomes an incident — a build-with-you Sprint scoped to your actual architecture, not a generic framework.',
+    ctaLabel: 'Apply for an Architect Sprint',
+    ctaHref: '/workshops/personal-ai-coe',
+    secondaryLabel: 'Review production architecture patterns',
+    secondaryHref: '/ai-architecture',
+  },
+  industrializing: {
+    eyebrow: 'Ahead of most enterprise programs',
+    headline: 'Compound what already runs.',
+    body: 'Most enterprise AI programs never reach where you are. The remaining gap is usually the one dimension no one has touched — closing it with a build partner is faster than another internal initiative.',
+    ctaLabel: 'Apply for an Architect Sprint',
+    ctaHref: '/workshops/personal-ai-coe',
+    secondaryLabel: 'Review production architecture patterns',
+    secondaryHref: '/ai-architecture',
+  },
+  'autonomous-ready': {
+    eyebrow: 'You are ahead of the market',
+    headline: 'Most CoEs never get here. Get the proof published.',
+    body: 'The Sprint at this stage is not about catching up — it is about closing the last named gap with a partner who has actually operated agents in production, and turning the result into a reference case.',
+    ctaLabel: 'Apply for an Architect Sprint',
+    ctaHref: '/workshops/personal-ai-coe',
+    secondaryLabel: 'Review production architecture patterns',
+    secondaryHref: '/ai-architecture',
+  },
+}

--- a/lib/ai-coe-readiness/engine.ts
+++ b/lib/ai-coe-readiness/engine.ts
@@ -1,0 +1,414 @@
+// AI CoE Readiness Assessment — scoring engine.
+//
+// Pure, dependency-free, unit-testable. Spec: starlight/factory/ai-coe.product-experience.v1.md
+// (§3-6). The enterprise twin of the Operator Scorecard — the qualification gate into the
+// Architect Sprint / CoE Retainer lane. 6 dimensions, 12 questions, 5 maturity levels
+// (Ad Hoc -> Piloting -> Scaling -> Industrializing -> Autonomous-Ready).
+//
+// No framework imports here on purpose — this file is imported both by the Next.js client
+// component and directly by node:test in scripts/test-ai-coe-readiness-engine.mjs.
+//
+// Scoring arithmetic (dimension tallying, tier resolution, ceiling selection) is shared with
+// the Operator Scorecard via ../scorecard/shared — this is the second concrete product to use
+// it, which is what justified extracting it in the first place.
+
+import { tallyScores, resolveTier, lowestScoringDimension } from '../scorecard/shared.ts'
+
+export type DimensionId =
+  | 'execSponsorship'
+  | 'dataArchitecture'
+  | 'useCaseMaturity'
+  | 'talentOpModel'
+  | 'governanceRisk'
+  | 'roiDiscipline'
+
+export interface Dimension {
+  id: DimensionId
+  label: string
+  /** One-line definition shown on the radar / report legend. */
+  description: string
+}
+
+export const DIMENSIONS: Dimension[] = [
+  {
+    id: 'execSponsorship',
+    label: 'Exec Sponsorship',
+    description: 'Does a named executive own outcomes and budget, or is AI everyone’s side project?',
+  },
+  {
+    id: 'dataArchitecture',
+    label: 'Data & Architecture',
+    description: 'Is there a governed data/model layer use cases build on, or is access ad hoc per team?',
+  },
+  {
+    id: 'useCaseMaturity',
+    label: 'Use-Case Maturity',
+    description: 'Are use cases running in production with measured outcomes, or still pilots that never graduate?',
+  },
+  {
+    id: 'talentOpModel',
+    label: 'Talent & Op Model',
+    description: 'Is there a staffed operating model with a real bench, or does it depend on one enthusiast?',
+  },
+  {
+    id: 'governanceRisk',
+    label: 'Governance & Risk',
+    description: 'Are there real review gates and an incident process, or is this one prompt from a headline?',
+  },
+  {
+    id: 'roiDiscipline',
+    label: 'ROI Discipline',
+    description: 'Is value measured and attributed per use case, or is "AI ROI" a slide with nothing behind it?',
+  },
+]
+
+export interface QuestionOption {
+  id: string
+  label: string
+  /** 0-3 readiness points for this answer. */
+  points: 0 | 1 | 2 | 3
+}
+
+export interface Question {
+  id: string
+  dimension: DimensionId
+  prompt: string
+  options: QuestionOption[]
+}
+
+const scale = (opts: [string, 0 | 1 | 2 | 3][]): QuestionOption[] =>
+  opts.map(([label, points], i) => ({ id: String.fromCharCode(97 + i), label, points }))
+
+export const QUESTIONS: Question[] = [
+  {
+    id: 'execSponsorship-1',
+    dimension: 'execSponsorship',
+    prompt: 'Who owns AI outcomes at the executive level?',
+    options: scale([
+      ['No one specific — it is distributed across teams.', 0],
+      ['A working group or committee tracks it part-time.', 1],
+      ['A named VP or Director owns the mandate and reports on it.', 2],
+      ['A named executive owns budget and outcomes, and reports to the CEO or board.', 3],
+    ]),
+  },
+  {
+    id: 'execSponsorship-2',
+    dimension: 'execSponsorship',
+    prompt: 'What happens when an AI initiative needs budget or a policy exception fast?',
+    options: scale([
+      ['It waits for the next planning cycle.', 0],
+      ['It gets raised informally and sometimes moves.', 1],
+      ['There is a defined escalation path that usually works.', 2],
+      ['The sponsoring executive can approve it directly, the same week.', 3],
+    ]),
+  },
+  {
+    id: 'dataArchitecture-1',
+    dimension: 'dataArchitecture',
+    prompt: 'How would you describe the data and model access layer your use cases actually run on?',
+    options: scale([
+      ['Ad hoc — each team pulls data its own way, no shared layer.', 0],
+      ['Some shared data sources, but access and quality vary by team.', 1],
+      ['A defined architecture — gateway, permissions, catalog — most teams use.', 2],
+      ['A governed platform — access, lineage, and model routing are centrally managed.', 3],
+    ]),
+  },
+  {
+    id: 'dataArchitecture-2',
+    dimension: 'dataArchitecture',
+    prompt: 'If a new use case needed a new data source tomorrow, how long until it is usable and governed?',
+    options: scale([
+      ['Weeks to months — every integration is bespoke.', 0],
+      ['A couple of weeks, mostly manual wiring.', 1],
+      ['Days — there is a repeatable onboarding path.', 2],
+      ['Hours — the platform is built for this.', 3],
+    ]),
+  },
+  {
+    id: 'useCaseMaturity-1',
+    dimension: 'useCaseMaturity',
+    prompt: 'How many AI use cases are actually running in production today, not in a pilot or sandbox?',
+    options: scale([
+      ['None — everything is still a demo or a pilot.', 0],
+      ['One, and it took much longer than planned to get there.', 1],
+      ['A handful, with a repeatable path from pilot to production.', 2],
+      ['Several, with a portfolio view and a pipeline of what is next.', 3],
+    ]),
+  },
+  {
+    id: 'useCaseMaturity-2',
+    dimension: 'useCaseMaturity',
+    prompt: 'What typically happens to a pilot before it would reach production here?',
+    options: scale([
+      ['We do not really know — pilots quietly stop getting mentioned.', 0],
+      ['Unclear ownership of who takes it from pilot to production.', 1],
+      ['It usually makes it, sometimes slower than we would like.', 2],
+      ['Pilots rarely die — the graduation path is a known process.', 3],
+    ]),
+  },
+  {
+    id: 'talentOpModel-1',
+    dimension: 'talentOpModel',
+    prompt: 'Who runs your AI use cases day to day?',
+    options: scale([
+      ['A handful of enthusiasts doing it alongside their real job.', 0],
+      ['A small informal team, with no defined roles.', 1],
+      ['A defined team with clear roles — product, engineering, risk.', 2],
+      ['A staffed operating model with a bench deep enough to survive someone leaving.', 3],
+    ]),
+  },
+  {
+    id: 'talentOpModel-2',
+    dimension: 'talentOpModel',
+    prompt: 'What happens to institutional AI knowledge when your best person leaves?',
+    options: scale([
+      ['It leaves with them.', 0],
+      ['Some of it lives in a shared doc; most does not.', 1],
+      ['Documented playbooks cover most of what they did.', 2],
+      ['The role is designed to be handed off — nothing is a single point of failure.', 3],
+    ]),
+  },
+  {
+    id: 'governanceRisk-1',
+    dimension: 'governanceRisk',
+    prompt: 'What review happens before an agent gets access to a new system or dataset?',
+    options: scale([
+      ['None — whoever is building it just wires it up.', 0],
+      ['An informal check with a colleague or manager.', 1],
+      ['A defined review with security or risk sign-off.', 2],
+      ['A standing review board with an audit trail and revocation process.', 3],
+    ]),
+  },
+  {
+    id: 'governanceRisk-2',
+    dimension: 'governanceRisk',
+    prompt: 'If an agent took a wrong, costly, or embarrassing action in production today, what would happen?',
+    options: scale([
+      ['We would probably find out from a customer or the press first.', 0],
+      ['We would catch it eventually through normal monitoring.', 1],
+      ['We would catch it fast and have a rollback or incident process.', 2],
+      ['We would catch it in real time, with an owner and a rehearsed response.', 3],
+    ]),
+  },
+  {
+    id: 'roiDiscipline-1',
+    dimension: 'roiDiscipline',
+    prompt: 'How is AI value measured?',
+    options: scale([
+      ['It is not, really — we assume it is helping.', 0],
+      ['Anecdotes and a few success stories get shared around.', 1],
+      ['Specific use cases have real before/after metrics.', 2],
+      ['Every production use case has attributed ROI reviewed on a cadence.', 3],
+    ]),
+  },
+  {
+    id: 'roiDiscipline-2',
+    dimension: 'roiDiscipline',
+    prompt: 'When budget gets tight, how does AI spend hold up?',
+    options: scale([
+      ['It is usually one of the first things cut — no one can defend it with numbers.', 0],
+      ['It survives on reputation more than evidence.', 1],
+      ['The use cases with clear ROI get protected.', 2],
+      ['AI spend is treated like any other line item, with defendable ROI.', 3],
+    ]),
+  },
+]
+
+export type TierId = 'ad-hoc' | 'piloting' | 'scaling' | 'industrializing' | 'autonomous-ready'
+
+export interface Tier {
+  id: TierId
+  label: string
+  /** Inclusive lower bound, 0-100 scale of total score. */
+  minScore: number
+  headline: string
+  description: string
+  /**
+   * One sharp line of peer positioning — direct, credibility-first, zero
+   * playfulness. Shown as the tier lands in the reveal sequence, separate
+   * from `description`'s fuller diagnostic paragraph.
+   */
+  tierLine: string
+}
+
+// Boundaries: 0-19 / 20-39 / 40-59 / 60-79 / 80-100. Clean quintiles matching the spec's
+// five-stage maturity curve so the labeled level reads like a benchmark, not a percentile.
+export const TIERS: Tier[] = [
+  {
+    id: 'ad-hoc',
+    label: 'Ad Hoc',
+    minScore: 0,
+    headline: 'There is no operating system yet.',
+    description:
+      'AI activity here is real but uncoordinated — no named owner, no governed data path, no production use case. This is where most enterprise AI programs actually start. The fix is a scoped first build, not another strategy deck.',
+    tierLine: 'This is the stage most CoE charters get written at — and stall at.',
+  },
+  {
+    id: 'piloting',
+    label: 'Piloting',
+    minScore: 20,
+    headline: 'Pilots exist. Production does not.',
+    description:
+      'The organization can start AI projects. It has not yet proven it can finish one — pilots stall before they reach governed production. The gap is graduation, not another proof of concept.',
+    tierLine: 'The pilot-to-production gap is the single most common place enterprise AI programs die.',
+  },
+  {
+    id: 'scaling',
+    label: 'Scaling',
+    minScore: 40,
+    headline: 'Production is real. Governance has not caught up.',
+    description:
+      'Use cases are live and delivering value, but the review gates, incident response, and ROI instrumentation have not scaled with them. This is precisely the stage where an ungoverned agent becomes a board-level incident.',
+    tierLine: 'Proof of value is no longer the question here — proof of control is.',
+  },
+  {
+    id: 'industrializing',
+    label: 'Industrializing',
+    minScore: 60,
+    headline: 'The operating model is real.',
+    description:
+      'A staffed team, a governed platform, and a portfolio of production use cases are in place. The remaining gap is usually the one dimension no one has touched — closing it compounds everything else already running.',
+    tierLine: 'Ahead of most enterprise AI programs we assess. The remaining gap is narrow and named.',
+  },
+  {
+    id: 'autonomous-ready',
+    label: 'Autonomous-Ready',
+    minScore: 80,
+    headline: 'Most CoEs never get here.',
+    description:
+      'Exec ownership, governed architecture, production use cases, a real bench, standing review gates, and attributed ROI are all in place. The frontier from here is compounding what already runs and publishing the proof.',
+    tierLine: 'Fewer enterprise AI programs reach this stage than leadership decks tend to admit.',
+  },
+]
+
+export interface CeilingCopy {
+  dimension: DimensionId
+  name: string
+  description: string
+  /**
+   * The named, board-relevant risk this ceiling currently carries — enterprise
+   * buyers respond to risk framing more reliably than to upside framing. One
+   * sentence, specific, never hypothetical hand-waving.
+   */
+  riskExposure: string
+  actions: [string, string, string]
+}
+
+export const CEILINGS: Record<DimensionId, CeilingCopy> = {
+  execSponsorship: {
+    dimension: 'execSponsorship',
+    name: 'Exec Sponsorship',
+    description:
+      'Nothing durable gets built without a named owner who controls budget and answers for outcomes. Right now AI here is everyone’s initiative and no one’s job.',
+    riskExposure:
+      'Named risk: initiative churn. Without one accountable executive, AI programs restart every reorg — the capability never compounds long enough to earn the board’s confidence.',
+    actions: [
+      'Name one executive as the single accountable owner of AI outcomes this quarter — not a committee.',
+      'Give that owner a real budget line and a report-out cadence to the board, not just a channel.',
+      'Write the one-sentence mandate: what they own, what they can approve without escalation.',
+    ],
+  },
+  dataArchitecture: {
+    dimension: 'dataArchitecture',
+    name: 'Data & Architecture',
+    description:
+      'Every use case is currently rebuilding its own path to data and models. That is not a governance gap — it is the reason nothing scales past the team that built it.',
+    riskExposure:
+      'Named risk: shadow data pipelines. Ungoverned, team-by-team data access is how sensitive data ends up in an uncontrolled model call — the incident that turns into a regulatory conversation.',
+    actions: [
+      'Inventory every data source currently feeding an AI use case, and who approved that access.',
+      'Stand up one shared gateway or catalog for the next new use case instead of another bespoke integration.',
+      'Assign an architecture owner accountable for model and data access decisions across teams.',
+    ],
+  },
+  useCaseMaturity: {
+    dimension: 'useCaseMaturity',
+    name: 'Use-Case Maturity',
+    description:
+      'Pilots keep launching and quietly stalling before production. The organization has proven it can start AI projects — not that it can finish them.',
+    riskExposure:
+      'Named risk: credibility decay. Every pilot that dies quietly without a stated reason spends down the board’s patience for the next one.',
+    actions: [
+      'Pick the single pilot closest to production and name what is actually blocking graduation.',
+      'Define pilot-to-production graduation criteria before starting the next pilot.',
+      'Kill or ship every pilot older than one quarter — no permanent pilots.',
+    ],
+  },
+  talentOpModel: {
+    dimension: 'talentOpModel',
+    name: 'Talent & Op Model',
+    description:
+      'The work currently depends on a small number of individuals doing this alongside their day job. That is not a team — it is a single point of failure with a headcount of one or two.',
+    riskExposure:
+      'Named risk: key-person exposure. If your most capable AI operator left tomorrow, most of what they built would stop improving — and no one could tell you why it broke.',
+    actions: [
+      'Document the playbook your best AI operator runs — the one currently only in their head.',
+      'Define at least one explicit role, even part-time, with AI delivery as a real job description.',
+      'Cross-train a second person on the highest-value use case before adding a new one.',
+    ],
+  },
+  governanceRisk: {
+    dimension: 'governanceRisk',
+    name: 'Governance & Risk',
+    description:
+      'There is no standing review before an agent gets access to something new, and no rehearsed response if it does something wrong in production.',
+    riskExposure:
+      'Named risk: unowned incident. The first time an agent takes a costly or embarrassing action, the board’s question is who approved its access — and right now that question has no clean answer.',
+    actions: [
+      'Stand up a lightweight review gate — even a single sign-off — before any agent gets new system or data access.',
+      'Write the one-page incident response: who is paged, who can revoke access, who talks to the board.',
+      'Run one tabletop exercise: simulate an agent’s costly mistake and time your actual response.',
+    ],
+  },
+  roiDiscipline: {
+    dimension: 'roiDiscipline',
+    name: 'ROI Discipline',
+    description:
+      'AI value is currently a story, not a number. That is the exact reason AI budget is first on the cut list the moment finance tightens.',
+    riskExposure:
+      'Named risk: unattributed spend. Without per-use-case ROI, every dollar of AI spend is defended by anecdote — the weakest possible position when budgets get reviewed.',
+    actions: [
+      'Pick your single highest-visibility use case and instrument a real before/after metric this month.',
+      'Put AI spend on the same reporting cadence and rigor as any other line item.',
+      'Kill the use case with the weakest evidence of value before defending a new one.',
+    ],
+  },
+}
+
+export interface DimensionScore {
+  dimension: DimensionId
+  label: string
+  raw: number
+  max: number
+  pct: number
+}
+
+export interface ReadinessResult {
+  totalRaw: number
+  totalMax: number
+  /** 0-100, rounded. */
+  totalScore: number
+  tier: Tier
+  dimensionScores: DimensionScore[]
+  ceiling: CeilingCopy
+}
+
+export function getTierForScore(score: number): Tier {
+  return resolveTier(TIERS, score)
+}
+
+/**
+ * Scores a completed (or partial) assessment.
+ * `answers` maps questionId -> optionId. Unanswered questions score 0.
+ */
+export function scoreReadiness(answers: Record<string, string>): ReadinessResult {
+  const { dimensionScores, totalRaw, totalMax, totalScore } = tallyScores(DIMENSIONS, QUESTIONS, answers)
+  const tier = getTierForScore(totalScore)
+
+  // The ONE named ceiling + risk-exposure callout = lowest-scoring dimension.
+  // Ties break toward the dimension listed first in DIMENSIONS (exec
+  // sponsorship first — nothing else durably fixes without it).
+  const ceiling = CEILINGS[lowestScoringDimension(dimensionScores)]
+
+  return { totalRaw, totalMax, totalScore, tier, dimensionScores, ceiling }
+}

--- a/lib/scorecard/engine.ts
+++ b/lib/scorecard/engine.ts
@@ -7,6 +7,12 @@
 //
 // No framework imports here on purpose — this file is imported both by the Next.js client
 // component and directly by node:test in scripts/test-scorecard-engine.mjs.
+//
+// Scoring arithmetic (dimension tallying, tier resolution, ceiling selection) lives in
+// ./shared — extracted once the AI CoE Readiness Assessment became a second product needing
+// the identical math. This file keeps its exact public exports so nothing downstream changes.
+
+import { tallyScores, resolveTier, lowestScoringDimension } from './shared.ts'
 
 export type DimensionId =
   | 'delegation'
@@ -375,14 +381,8 @@ export interface ScorecardResult {
   ceiling: CeilingCopy
 }
 
-const MAX_POINTS_PER_QUESTION = 3
-
 export function getTierForScore(score: number): Tier {
-  let match = TIERS[0]
-  for (const tier of TIERS) {
-    if (score >= tier.minScore) match = tier
-  }
-  return match
+  return resolveTier(TIERS, score)
 }
 
 /**
@@ -390,46 +390,13 @@ export function getTierForScore(score: number): Tier {
  * `answers` maps questionId -> optionId. Unanswered questions score 0.
  */
 export function scoreScorecard(answers: Record<string, string>): ScorecardResult {
-  const byDimension = new Map<DimensionId, { raw: number; max: number }>()
-  for (const dim of DIMENSIONS) byDimension.set(dim.id, { raw: 0, max: 0 })
-
-  let totalRaw = 0
-  let totalMax = 0
-
-  for (const question of QUESTIONS) {
-    const bucket = byDimension.get(question.dimension)!
-    bucket.max += MAX_POINTS_PER_QUESTION
-    totalMax += MAX_POINTS_PER_QUESTION
-
-    const chosenId = answers[question.id]
-    const option = question.options.find((o) => o.id === chosenId)
-    const points = option?.points ?? 0
-    bucket.raw += points
-    totalRaw += points
-  }
-
-  const dimensionScores: DimensionScore[] = DIMENSIONS.map((dim) => {
-    const bucket = byDimension.get(dim.id)!
-    return {
-      dimension: dim.id,
-      label: dim.label,
-      raw: bucket.raw,
-      max: bucket.max,
-      pct: bucket.max === 0 ? 0 : Math.round((bucket.raw / bucket.max) * 100),
-    }
-  })
-
-  const totalScore = totalMax === 0 ? 0 : Math.round((totalRaw / totalMax) * 100)
+  const { dimensionScores, totalRaw, totalMax, totalScore } = tallyScores(DIMENSIONS, QUESTIONS, answers)
   const tier = getTierForScore(totalScore)
 
   // The ONE named ceiling = lowest-scoring dimension. Ties break toward the
   // dimension listed first in DIMENSIONS (delegation first — it is the
   // highest-leverage fix per the spec's moment-of-proof framing).
-  let lowest = dimensionScores[0]
-  for (const d of dimensionScores) {
-    if (d.pct < lowest.pct) lowest = d
-  }
-  const ceiling = CEILINGS[lowest.dimension]
+  const ceiling = CEILINGS[lowestScoringDimension(dimensionScores)]
 
   return { totalRaw, totalMax, totalScore, tier, dimensionScores, ceiling }
 }

--- a/lib/scorecard/shared.ts
+++ b/lib/scorecard/shared.ts
@@ -1,0 +1,111 @@
+// Generic, pure, dependency-free scoring primitives shared by every
+// scorecard/assessment product (Operator Scorecard, AI CoE Readiness
+// Assessment, and any future one). Extracted from lib/scorecard/engine.ts
+// once a second concrete product needed the same scoring arithmetic —
+// dimension tallying, percent-of-max, tier resolution, and "lowest-scoring
+// dimension" ceiling selection. Each product still owns its own content
+// (dimensions, questions, tier copy, ceiling copy) and its own richer types;
+// this file only holds the math that is identical across all of them.
+//
+// No framework imports — importable from Next.js client components and
+// directly from node:test via --experimental-strip-types.
+
+export interface ScoredOption {
+  id: string
+  points: number
+}
+
+export interface ScorableQuestion<D extends string> {
+  id: string
+  dimension: D
+  options: ScoredOption[]
+}
+
+export interface DimensionScore<D extends string> {
+  dimension: D
+  label: string
+  raw: number
+  max: number
+  pct: number
+}
+
+export interface ScoreTally<D extends string> {
+  dimensionScores: DimensionScore<D>[]
+  totalRaw: number
+  totalMax: number
+  /** 0-100, rounded. */
+  totalScore: number
+}
+
+/**
+ * Tallies raw/max/pct per dimension and the overall 0-100 score from a
+ * completed (or partial) answer set. `answers` maps questionId -> optionId.
+ * Unanswered or unrecognized options score 0 — never throws.
+ */
+export function tallyScores<D extends string>(
+  dimensions: { id: D; label: string }[],
+  questions: ScorableQuestion<D>[],
+  answers: Record<string, string>,
+): ScoreTally<D> {
+  const byDimension = new Map<D, { raw: number; max: number }>()
+  for (const dim of dimensions) byDimension.set(dim.id, { raw: 0, max: 0 })
+
+  let totalRaw = 0
+  let totalMax = 0
+
+  for (const question of questions) {
+    const bucket = byDimension.get(question.dimension)
+    if (!bucket) continue
+    const maxPoints = question.options.reduce((max, o) => Math.max(max, o.points), 0)
+    bucket.max += maxPoints
+    totalMax += maxPoints
+
+    const chosenId = answers[question.id]
+    const option = question.options.find((o) => o.id === chosenId)
+    const points = option?.points ?? 0
+    bucket.raw += points
+    totalRaw += points
+  }
+
+  const dimensionScores: DimensionScore<D>[] = dimensions.map((dim) => {
+    const bucket = byDimension.get(dim.id)!
+    return {
+      dimension: dim.id,
+      label: dim.label,
+      raw: bucket.raw,
+      max: bucket.max,
+      pct: bucket.max === 0 ? 0 : Math.round((bucket.raw / bucket.max) * 100),
+    }
+  })
+
+  const totalScore = totalMax === 0 ? 0 : Math.round((totalRaw / totalMax) * 100)
+
+  return { dimensionScores, totalRaw, totalMax, totalScore }
+}
+
+/**
+ * Resolves the highest tier whose `minScore` the score satisfies. Tiers need
+ * not be pre-sorted. Assumes at least one tier has `minScore === 0` (or
+ * lower) so every score resolves to something.
+ */
+export function resolveTier<T extends { minScore: number }>(tiers: T[], score: number): T {
+  let match = tiers[0]
+  for (const tier of tiers) {
+    if (score >= tier.minScore) match = tier
+  }
+  return match
+}
+
+/**
+ * Picks the lowest-scoring dimension — the single named ceiling. Ties break
+ * toward whichever dimension appears first in `dimensionScores` (i.e. first
+ * in the product's declared dimension order), so each product controls its
+ * own tie-break priority simply by how it orders its DIMENSIONS array.
+ */
+export function lowestScoringDimension<D extends string>(dimensionScores: DimensionScore<D>[]): D {
+  let lowest = dimensionScores[0]
+  for (const d of dimensionScores) {
+    if (d.pct < lowest.pct) lowest = d
+  }
+  return lowest.dimension
+}

--- a/scripts/test-ai-coe-readiness-engine.mjs
+++ b/scripts/test-ai-coe-readiness-engine.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// Regression test for the AI CoE Readiness Assessment scoring engine
+// (lib/ai-coe-readiness/engine.ts). Verifies every maturity level is reachable, every question
+// maps to one of the six dimensions, and the tier boundaries score correctly. Mirrors
+// scripts/test-scorecard-engine.mjs's pattern for the Operator Scorecard.
+//
+// No test runner is configured in this repo (package.json has no "test" script). This engine
+// has zero '@/*'-aliased imports, so it runs directly with node:test:
+//   node --experimental-strip-types scripts/test-ai-coe-readiness-engine.mjs
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+
+const {
+  DIMENSIONS,
+  QUESTIONS,
+  TIERS,
+  scoreReadiness,
+  getTierForScore,
+} = await import(pathToFileURL(resolve(ROOT, 'lib/ai-coe-readiness/engine.ts')).href)
+
+test('every question maps to a declared dimension', () => {
+  const dimensionIds = new Set(DIMENSIONS.map((d) => d.id))
+  for (const q of QUESTIONS) {
+    assert.ok(dimensionIds.has(q.dimension), `question "${q.id}" references unknown dimension "${q.dimension}"`)
+  }
+})
+
+test('all six dimensions are covered by at least one question', () => {
+  const covered = new Set(QUESTIONS.map((q) => q.dimension))
+  for (const dim of DIMENSIONS) {
+    assert.ok(covered.has(dim.id), `dimension "${dim.id}" has no question mapped to it`)
+  }
+})
+
+test('spec calls for 6 dimensions and ~12 questions', () => {
+  assert.equal(DIMENSIONS.length, 6)
+  assert.equal(QUESTIONS.length, 12)
+})
+
+test('every dimension has exactly two questions', () => {
+  const counts = new Map()
+  for (const q of QUESTIONS) counts.set(q.dimension, (counts.get(q.dimension) ?? 0) + 1)
+  for (const dim of DIMENSIONS) {
+    assert.equal(counts.get(dim.id), 2, `dimension "${dim.id}" should have exactly 2 questions`)
+  }
+})
+
+test('every question has exactly 4 options scored 0-3 with no gaps', () => {
+  for (const q of QUESTIONS) {
+    assert.equal(q.options.length, 4, `question "${q.id}" should have 4 options`)
+    const points = q.options.map((o) => o.points).sort((a, b) => a - b)
+    assert.deepEqual(points, [0, 1, 2, 3], `question "${q.id}" options should score exactly 0,1,2,3`)
+  }
+})
+
+test('every option id is unique within its question', () => {
+  for (const q of QUESTIONS) {
+    const ids = q.options.map((o) => o.id)
+    assert.equal(new Set(ids).size, ids.length, `question "${q.id}" has duplicate option ids`)
+  }
+})
+
+test('an empty answer set scores 0 and resolves to the lowest maturity level', () => {
+  const result = scoreReadiness({})
+  assert.equal(result.totalScore, 0)
+  assert.equal(result.tier.id, 'ad-hoc')
+})
+
+test('answering every question with the top option scores 100 and resolves to Autonomous-Ready', () => {
+  const answers = {}
+  for (const q of QUESTIONS) {
+    const top = q.options.find((o) => o.points === 3)
+    answers[q.id] = top.id
+  }
+  const result = scoreReadiness(answers)
+  assert.equal(result.totalScore, 100)
+  assert.equal(result.tier.id, 'autonomous-ready')
+})
+
+test('all five maturity levels are reachable', () => {
+  const seen = new Set()
+  for (let score = 0; score <= 100; score++) {
+    seen.add(getTierForScore(score).id)
+  }
+  const expected = new Set(TIERS.map((t) => t.id))
+  assert.deepEqual(seen, expected, 'every declared tier must be reachable by some integer score 0-100')
+})
+
+test('tier boundaries are correct, contiguous quintiles', () => {
+  const sorted = [...TIERS].sort((a, b) => a.minScore - b.minScore)
+  assert.equal(sorted[0].minScore, 0, 'lowest tier must start at 0')
+  assert.equal(sorted[sorted.length - 1].minScore < 100, true, 'top tier must start below 100')
+
+  assert.equal(getTierForScore(0).id, 'ad-hoc')
+  assert.equal(getTierForScore(19).id, 'ad-hoc')
+  assert.equal(getTierForScore(20).id, 'piloting')
+  assert.equal(getTierForScore(39).id, 'piloting')
+  assert.equal(getTierForScore(40).id, 'scaling')
+  assert.equal(getTierForScore(59).id, 'scaling')
+  assert.equal(getTierForScore(60).id, 'industrializing')
+  assert.equal(getTierForScore(79).id, 'industrializing')
+  assert.equal(getTierForScore(80).id, 'autonomous-ready')
+  assert.equal(getTierForScore(100).id, 'autonomous-ready')
+})
+
+test('dimension scores sum to the total raw score', () => {
+  const answers = {}
+  for (const [i, q] of QUESTIONS.entries()) {
+    // Mix of answers so this is not just the all-zero or all-max case.
+    const pick = q.options[i % q.options.length]
+    answers[q.id] = pick.id
+  }
+  const result = scoreReadiness(answers)
+  const summed = result.dimensionScores.reduce((acc, d) => acc + d.raw, 0)
+  assert.equal(summed, result.totalRaw)
+  const summedMax = result.dimensionScores.reduce((acc, d) => acc + d.max, 0)
+  assert.equal(summedMax, result.totalMax)
+})
+
+test('the named ceiling (with risk exposure) is always the lowest-scoring dimension', () => {
+  // Force "governanceRisk" to be the clear lowest, everything else near-max.
+  const answers = {}
+  for (const q of QUESTIONS) {
+    if (q.dimension === 'governanceRisk') {
+      answers[q.id] = q.options.find((o) => o.points === 0).id
+    } else {
+      answers[q.id] = q.options.find((o) => o.points === 3).id
+    }
+  }
+  const result = scoreReadiness(answers)
+  assert.equal(result.ceiling.dimension, 'governanceRisk')
+  assert.ok(result.ceiling.riskExposure && result.ceiling.riskExposure.length > 0, 'ceiling must carry a named risk-exposure callout')
+
+  const governanceScore = result.dimensionScores.find((d) => d.dimension === 'governanceRisk')
+  for (const d of result.dimensionScores) {
+    assert.ok(d.pct >= governanceScore.pct, `${d.dimension} (${d.pct}%) should not score below the ceiling dimension`)
+  }
+})
+
+test('every dimension has a ceiling with a non-empty risk-exposure callout and 3 actions', async () => {
+  const { CEILINGS } = await import(pathToFileURL(resolve(ROOT, 'lib/ai-coe-readiness/engine.ts')).href)
+  for (const dim of DIMENSIONS) {
+    const ceiling = CEILINGS[dim.id]
+    assert.ok(ceiling, `dimension "${dim.id}" has no ceiling copy`)
+    assert.ok(ceiling.riskExposure.length > 0, `dimension "${dim.id}" ceiling has an empty riskExposure`)
+    assert.equal(ceiling.actions.length, 3, `dimension "${dim.id}" ceiling should have exactly 3 actions`)
+  }
+})
+
+test('an unanswered question contributes 0 points, not a crash', () => {
+  const [first] = QUESTIONS
+  const result = scoreReadiness({ [first.id]: 'not-a-real-option-id' })
+  assert.equal(result.totalRaw, 0)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Ships the **AI CoE Readiness Assessment** — the enterprise twin of the Operator Scorecard (#254) and the qualification gate into Frank's high-ticket lane (Architect Sprint / executive briefing). Spec: `starlight/factory/ai-coe.product-experience.v1.md`.

- **Route:** `/ai-coe-readiness`
- **12 questions across 6 dimensions:** Exec Sponsorship, Data & Architecture, Use-Case Maturity, Talent & Op Model, Governance & Risk, ROI Discipline
- **5 maturity levels:** Ad Hoc → Piloting → Scaling → Industrializing → Autonomous-Ready (clean quintile boundaries: 0/20/40/60/80)
- **Report:** peer-positioning tier copy + six-dimension radar + one named "fix this first" ceiling + a **named risk-exposure callout** (enterprise buyers respond to risk framing, not just upside) + tier-routed CTA into the executive briefing at `/workshops/personal-ai-coe` (a real, live intake surface with a booking form — never a fake booking system)
- **Email gate:** reuses `app/api/subscribe` with the existing `ai-architect` list type

## Engine reuse / extension

- Extracted `lib/scorecard/shared.ts` — the dimension-tallying, tier-resolution, and ceiling-selection *arithmetic*, generalized out of the Operator Scorecard's `lib/scorecard/engine.ts` now that a second product needs the identical math. Per the repo's own "don't add abstractions until there's a second concrete use site" rule — this is that second use site.
- `lib/scorecard/engine.ts` now delegates to `shared.ts` internally. **Public exports are byte-identical** — all 12 pre-existing tests in `scripts/test-scorecard-engine.mjs` pass unmodified.
- New `lib/ai-coe-readiness/engine.ts` + `lib/ai-coe-readiness/cta.ts` hold the AI-CoE-specific content (dimensions, 12 questions, 5 tiers, ceiling copy with the added `riskExposure` field enterprise ceiling copy needs).
- `components/scorecard/DimensionRadar.tsx`: widened its prop type off the Operator Scorecard's specific `DimensionId` union to a structural `DimensionScoreLike` shape — the component only ever reads `dimension` as an opaque key, so both products' scores satisfy it without a cast.
- `tsconfig.json`: added `allowImportingTsExtensions: true` (safe with existing `noEmit: true`) so `engine.ts` can import `./shared.ts` with an explicit extension — required for the standalone `node --experimental-strip-types` test runner to resolve the nested relative import; TS/Next's bundler resolution accepts explicit extensions natively.
- GSAP choreography copied from `OperatorScorecardClient.tsx` verbatim (including its synchronous-state-with-decorative-GSAP fix — state changes fire immediately, GSAP only decorates). No hint microcopy (enterprise register — zero playfulness); cyan accent instead of emerald to visually distinguish the enterprise lane.

## Test + gate results

- `node --experimental-strip-types scripts/test-scorecard-engine.mjs` — **12/12 pass** (unmodified, confirms refactor is behavior-preserving)
- `node --experimental-strip-types scripts/test-ai-coe-readiness-engine.mjs` — **14/14 pass** (new suite: dimension/question coverage, all 5 tiers reachable, quintile boundaries, ceiling + risk-exposure presence on every dimension)
- `tsc --noEmit` — clean, zero errors
- `eslint` on all new/changed files — clean, zero errors
- `next build` (full production build) — **succeeded**, exit 0, all 1549 static pages generated including `/ai-coe-readiness`. (Spec noted this sometimes times out on an unrelated blog page — it did not this run.)

## Manual verification (dev server, desktop + mobile)

Walked the full flow end-to-end: intro → all 12 questions (radiogroup semantics, Back/Next gating) → reveal (6/6 dimensions scored, correct tier resolution + tierLine) → email gate → report (named ceiling correctly tie-broken to Exec Sponsorship, risk-exposure block rendered, 3 actions, six-dimension radar, tier-routed CTA linking to real `/workshops/personal-ai-coe` and `/ai-architecture`). Re-verified at mobile viewport (375×812) — same content, responsive classes hold.

One artifact from the automated preview tooling: the reveal stage's GSAP score-counter tween didn't visibly animate because the preview tab reports `document.hidden = true` (browser rAF throttling for background tabs) — this is a test-harness property, not a bug; the report stage renders the score as static JSX (not GSAP-driven) and displayed correctly (100/100). Reduced-motion wasn't emulated live (the available tool doesn't expose a media-feature toggle) but the guard clauses (`if (prefersReducedMotion) return`) are copied verbatim from the already-shipped Operator Scorecard pattern.

## Merge order

**Stacked on #254 — merge #254 first, then this PR**, since this branches off `agent/claude/operator-scorecard` to reuse its engine/component/GSAP patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)