### PR TITLE
obs(vercel-cost): weekly snapshot 2026-W29 — RED

### DIFF
--- a/data/observability/vercel-cost/2026-W29.json
+++ b/data/observability/vercel-cost/2026-W29.json
@@ -39,7 +39,7 @@
   "verdict": "RED",
   "alerts": [
     "duration_p50=570s > 360s RED threshold (was 510s W28, +11.8%). Build times still elevated and trending up; Turbopack + Next.js with large content library now averaging ~563s per READY build. P95=663s is the highest sampled this observability cycle — single slow outlier (dpl_Fs6jRMWvEHzS7wuDdd3Mwuj5yNUY, Jul 12 production) drove the tail.",
-    "count_error=1 (was 7 W28, -85.7% improvement). Single failure on preview branch agent/claude/web-excellence (dpl_7GdmpQ5pjHmWd3pinktVkrSES5ue, Jul 1) — not a production regression. Below RED threshold of ≥2.",
+    "count_error=1 (was 7 W28, -85.7% improvement). Single failure on preview branch agent/claude/web-excellence (dpl_7GdmpQ5pjHmWd3pinktVkrSES5ue, Jul 9 ~23:12 UTC) — not a production regression. Below RED threshold of ≥2.",
     "total_build_minutes=817 vs W28=961 (-15.0%). Lower total driven by fewer deploys this week (100 vs 128). Absolute level (817 min) well below 1500-min RED ceiling. count_skipped rose from 8 to 12 (+50%) but absolute swing is small (+4 deploys skipped)."
   ]
 }

--- a/data/observability/vercel-cost/2026-W29.json
+++ b/data/observability/vercel-cost/2026-W29.json
@@ -1,0 +1,45 @@
+{
+  "week": "2026-W29",
+  "generatedAt": "2026-07-13T07:10:00Z",
+  "projectId": "prj_NHVIKZtglNidOE1FJiq6eYx5QjIL",
+  "windowDays": 7,
+  "windowStart": "2026-07-06T07:08:50Z",
+  "windowEnd": "2026-07-13T07:08:50Z",
+  "metrics": {
+    "count_total": 100,
+    "count_production": 20,
+    "count_preview": 80,
+    "count_skipped": 12,
+    "count_error": 1,
+    "count_ready": 87,
+    "duration_p50_seconds": 570,
+    "duration_p95_seconds": 663,
+    "duration_max_seconds": 663,
+    "total_build_minutes": 817,
+    "duration_method": "readyAt_minus_buildingAt",
+    "ready_deploys_sampled": 10,
+    "ready_deploys_total": 87,
+    "duration_note": "10/87 READY deploys sampled via get_deployment (spanning Jul 6 – Jul 13); total_build_minutes extrapolated as avg(563.1s) × 87 = 817 min"
+  },
+  "deltas_vs_prior_week": {
+    "prior_week": "2026-W28",
+    "count_total": -28,
+    "count_total_pct": "-21.9%",
+    "count_production": -6,
+    "count_preview": -7,
+    "count_error": -6,
+    "count_error_pct": "-85.7%",
+    "count_skipped": 4,
+    "count_skipped_pct": "+50.0%",
+    "duration_p50_seconds": 60,
+    "duration_p50_pct": "+11.8%",
+    "total_build_minutes": -144,
+    "total_build_minutes_pct": "-15.0%"
+  },
+  "verdict": "RED",
+  "alerts": [
+    "duration_p50=570s > 360s RED threshold (was 510s W28, +11.8%). Build times still elevated and trending up; Turbopack + Next.js with large content library now averaging ~563s per READY build. P95=663s is the highest sampled this observability cycle — single slow outlier (dpl_Fs6jRMWvEHzS7wuDdd3Mwuj5yNUY, Jul 12 production) drove the tail.",
+    "count_error=1 (was 7 W28, -85.7% improvement). Single failure on preview branch agent/claude/web-excellence (dpl_7GdmpQ5pjHmWd3pinktVkrSES5ue, Jul 1) — not a production regression. Below RED threshold of ≥2.",
+    "total_build_minutes=817 vs W28=961 (-15.0%). Lower total driven by fewer deploys this week (100 vs 128). Absolute level (817 min) well below 1500-min RED ceiling. count_skipped rose from 8 to 12 (+50%) but absolute swing is small (+4 deploys skipped)."
+  ]
+}


### PR DESCRIPTION
## Vercel Cost Watch — W29 (Jul 6–13 2026)

Automated weekly observability snapshot. Read-only data file; no production code changed.

### Metrics summary

| Metric | W29 | W28 | Δ | Flag |
|---|---|---|---|---|
| Total deploys | 100 | 128 | −28 (−21.9%) | ✅ |
| Production | 20 | 26 | −6 | ✅ |
| Preview | 80 | 87 | −7 | ✅ |
| Skipped | 12 | 8 | +4 (+50%) | — |
| Errors | **1** | 7 | −6 (−85.7%) | ✅ |
| Build p50 | **570s** | 510s | +60s (+11.8%) | 🔴 |
| Build p95 | **663s** | 531s | +132s | 🔴 |
| Build max | 663s | 537s | +126s | — |
| Total build min | **817** | 961 | −144 (−15.0%) | ✅ |

### Verdict: 🔴 RED

**Driver:** `duration_p50=570s > 360s` RED threshold (same driver as W28). Build times remain elevated and have ticked up +11.8% week-over-week.

### Alerts

1. **Build time — RED**: p50=570s (+12% vs W28 510s). Turbopack + Next.js with large content library averaging ~563s/build. P95=663s is the highest sampled this cycle — single slow outlier `dpl_Fs6jRMWvEHzS7wuDdd3Mwuj5yNUY` (Jul 12 production) drove the tail.

2. **Errors — improving**: count_error=1 (was 7 W28, −85.7%). Single failure on preview branch `agent/claude/web-excellence` — not a production regression. Below RED threshold of ≥2.

3. **Build minutes — improving**: 817 min vs W28=961 (−15.0%). Fewer deploys this week (100 vs 128) offset the higher per-build time. Well below 1500-min RED ceiling.

### Duration sample (10/87 READY deploys)

Sampled via `get_deployment` across the full week window (Jul 6–Jul 13):

| Deployment | Date | Type | Duration |
|---|---|---|---|
| dpl_EaHiti7ZsZywtMtrxRStvWqKN4LG | Jul 06 | production | 509s |
| dpl_3KqE9PhczCSU5UTQr73LwT4ikJcn | Jul 08 | production | 592s |
| dpl_3eUGxMQAPsP1B9YS9dR6piRepVEH | Jul 09 | production | 482s |
| dpl_DEKYE7Y9mbSMvrRcJfy7t2QtDdkc | Jul 10 | production | 527s |
| dpl_GVNPaxCVxyD3PiQ8QK95f1Tzd9uj | Jul 11 | production | 581s |
| dpl_Fxqtxs4K69jVcGzsFE7q4iVAnaR7 | Jul 11 | production | 566s |
| dpl_A9Hc5y7kyHZTt2FAazBfn7LVkdLv | Jul 11 | preview | 573s |
| dpl_HnWS6PgSN7oxhCiRgrJMy4f67UMi | Jul 12 | production | 551s |
| dpl_Fs6jRMWvEHzS7wuDdd3Mwuj5yNUY | Jul 12 | production | 663s |
| dpl_DLqv43VVk7wYvGWAYLTGKF9Jcqmv | Jul 13 | production | 587s |

---

*Generated by FrankX Vercel Cost Watch routine — Phase 3.4*

---
_Generated by [Claude Code](https://claude.ai/code/session_019XnJLrsDpsM988STMkQ51U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability**
  * Added weekly build and deployment metrics for 2026-W29.
  * Included comparisons with the previous week, threshold alerts, and an overall RED status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->