### PR TITLE
Add Tallinn Experience Foundry and Purpose to Practice pilot

### DIFF
--- a/app/api/tallinn-interest/route.ts
+++ b/app/api/tallinn-interest/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { clientKey, rateLimited } from '@/lib/rate-limit'
+import { TallinnInterestSchema } from '@/lib/tallinn-interest/schema'
+import { captureTallinnInterest } from '@/lib/tallinn-interest/service'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const MAX_BODY_BYTES = 12_000
+const REVIEW_EMAIL = /@example\.com$/i
+
+function reviewMode() {
+  return !(
+    process.env.VERCEL_ENV === 'production' &&
+    process.env.TALLINN_CAPTURE_MODE === 'live'
+  )
+}
+export async function POST(request: NextRequest) {
+  try {
+    const contentLength = Number(request.headers.get('content-length') || '0')
+    if (contentLength > MAX_BODY_BYTES) {
+      return NextResponse.json(
+        { ok: false, error: 'Request is too large.' },
+        { status: 413 },
+      )
+    }
+
+    if (rateLimited('intake', clientKey(request))) {
+      return NextResponse.json(
+        { ok: false, error: 'Too many requests. Please try again shortly.' },
+        { status: 429, headers: { 'Retry-After': '60' } },
+      )
+    }
+
+    const body = await request.json().catch(() => null)
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid request.' },
+        { status: 400 },
+      )
+    }
+
+    const parsed = TallinnInterestSchema.safeParse(body)
+    if (!parsed.success) {
+      const firstIssue = parsed.error.issues[0]
+      return NextResponse.json(
+        {
+          ok: false,
+          error: firstIssue?.message ?? 'Validation failed.',
+          issues: parsed.error.issues.map((issue) => ({
+            path: issue.path.join('.'),
+            message: issue.message,
+          })),
+        },
+        { status: 400 },
+      )
+    }
+
+    if (parsed.data.website) {
+      return NextResponse.json({ ok: true, message: 'Thanks.' })
+    }
+
+    if (reviewMode()) {
+      if (!REVIEW_EMAIL.test(parsed.data.email)) {
+        return NextResponse.json(
+          {
+            ok: false,
+            reviewMode: true,
+            error:
+              'This private preview stores no personal data. Use test@example.com to exercise the flow.',
+          },
+          { status: 409 },
+        )
+      }
+
+      console.log(
+        '[tallinn-interest-preview]',
+        JSON.stringify({
+          experienceSlug: parsed.data.experienceSlug,
+          variantId: parsed.data.variantId,
+          slotCount: parsed.data.slotIds.length,
+          simulated: true,
+        }),
+      )
+      return NextResponse.json({
+        ok: true,
+        reviewMode: true,
+        receiptSent: false,
+        duplicate: false,
+        message: 'Preview simulation passed. No data was stored and no email was sent.',
+      })
+    }
+
+    const notionToken = process.env.NOTION_TOKEN || process.env.NOTION_API_KEY
+    const notionDatabaseId = process.env.NOTION_INQUIRIES_DB_ID
+    if (!notionToken || !notionDatabaseId) {
+      console.error('[tallinn-interest] capture disabled: Notion configuration missing')
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'Interest capture is temporarily unavailable. Please email frank@frankx.ai.',
+        },
+        { status: 503 },
+      )
+    }
+
+    const result = await captureTallinnInterest(parsed.data, {
+      notionToken,
+      notionDatabaseId,
+      resendApiKey: process.env.RESEND_API_KEY,
+      operatorEmail: process.env.OPERATOR_EMAIL || 'frank@frankx.ai',
+    })
+
+    console.log(
+      '[tallinn-interest]',
+      JSON.stringify({
+        experienceSlug: parsed.data.experienceSlug,
+        variantId: parsed.data.variantId,
+        stored: result.stored,
+        duplicate: result.duplicate,
+        receiptSent: result.receiptSent,
+        operatorNotified: result.operatorNotified,
+        error: result.error,
+      }),
+    )
+
+    if (!result.stored) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'Your request was not stored. Please try again or email frank@frankx.ai.',
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json({
+      ok: true,
+      reviewMode: false,
+      receiptSent: result.receiptSent,
+      duplicate: result.duplicate,
+      message: result.duplicate
+        ? 'This request was already recorded.'
+        : 'Your interest is recorded. This is not a ticket or venue confirmation yet.',
+    })
+  } catch (error) {
+    console.error('[tallinn-interest] unexpected error', error)
+    return NextResponse.json(
+      { ok: false, error: 'An unexpected error occurred. Please try again.' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/experiences/tallinn-2026/[slug]/not-found.tsx
+++ b/app/experiences/tallinn-2026/[slug]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function TallinnOfferNotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#08090b] px-5 text-center text-white">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Format not found</p>
+        <h1 className="mt-4 font-display text-4xl font-semibold">This working room is not in the current portfolio.</h1>
+        <Link
+          href="/experiences/tallinn-2026"
+          className="mt-8 inline-flex min-h-12 items-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950"
+        >
+          Compare the ten formats
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/app/experiences/tallinn-2026/[slug]/page.tsx
+++ b/app/experiences/tallinn-2026/[slug]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { TallinnOfferPage } from '@/components/tallinn-experience/TallinnOfferPage'
+import { getTallinnExperience, tallinnExperiences } from '@/data/tallinn-experiences'
+import { createMetadata } from '@/lib/seo'
+
+interface TallinnOfferRouteProps {
+  params: Promise<{ slug: string }>
+}
+export function generateStaticParams() {
+  return tallinnExperiences.map((experience) => ({ slug: experience.slug }))
+}
+
+export async function generateMetadata({ params }: TallinnOfferRouteProps): Promise<Metadata> {
+  const { slug } = await params
+  const experience = getTallinnExperience(slug)
+
+  if (!experience) {
+    return createMetadata({
+      title: 'Tallinn working session',
+      description: 'Private concept preview.',
+      path: `/experiences/tallinn-2026/${slug}`,
+      noindex: true,
+    })
+  }
+
+  return createMetadata({
+    title: `${experience.title} — Tallinn working session`,
+    description: experience.promise,
+    path: `/experiences/tallinn-2026/${experience.slug}`,
+    noindex: true,
+  })
+}
+
+export default async function TallinnOfferRoute({ params }: TallinnOfferRouteProps) {
+  const { slug } = await params
+  const experience = getTallinnExperience(slug)
+  if (!experience) notFound()
+
+  const captureEnabled =
+    process.env.VERCEL_ENV === 'production' &&
+    process.env.TALLINN_CAPTURE_MODE === 'live'
+
+  return <TallinnOfferPage experience={experience} captureEnabled={captureEnabled} />
+}

--- a/app/experiences/tallinn-2026/page.tsx
+++ b/app/experiences/tallinn-2026/page.tsx
@@ -1,0 +1,18 @@
+import { TallinnFoundryPage } from '@/components/tallinn-experience/TallinnFoundryPage'
+import { createMetadata } from '@/lib/seo'
+
+export const metadata = createMetadata({
+  title: 'Tallinn Experience Foundry — Small rooms, working artifacts',
+  description:
+    'A private concept preview for independent, 90-minute working sessions in Tallinn: purpose, creator practice, and human + agent teams.',
+  path: '/experiences/tallinn-2026',
+  noindex: true,
+})
+
+export default function TallinnExperienceFoundryPage() {
+  const captureEnabled =
+    process.env.VERCEL_ENV === 'production' &&
+    process.env.TALLINN_CAPTURE_MODE === 'live'
+
+  return <TallinnFoundryPage captureEnabled={captureEnabled} />
+}

--- a/app/experiences/tallinn-2026/purpose-to-practice/map/page.tsx
+++ b/app/experiences/tallinn-2026/purpose-to-practice/map/page.tsx
@@ -1,0 +1,221 @@
+import Link from 'next/link'
+
+import { PrintWorksheetButton } from '@/components/tallinn-experience/PrintWorksheetButton'
+import { createMetadata } from '@/lib/seo'
+
+export const metadata = createMetadata({
+  title: 'Human + AI Practice Map — Purpose to Practice',
+  description: 'The print-ready working artifact for the independent Purpose to Practice session in Tallinn.',
+  path: '/experiences/tallinn-2026/purpose-to-practice/map',
+  noindex: true,
+})
+
+const signals = [
+  {
+    number: '01',
+    title: 'Everyday meaning',
+    prompt: 'What people, activities, moments, or responsibilities bring value and aliveness now?',
+  },
+  {
+    number: '02',
+    title: 'Demonstrated strengths',
+    prompt: 'What do people already trust you to notice, make, decide, or improve?',
+  },
+  {
+    number: '03',
+    title: 'Useful contribution',
+    prompt: 'Whose real situation could become meaningfully better through your contribution?',
+  },
+  {
+    number: '04',
+    title: 'This season',
+    prompt: 'What must the next practice respect: energy, money, care, time, or attention?',
+  },
+] as const
+
+const roles = [
+  { n: 'A1', role: 'Research steward', output: 'Evidence, sources, open questions' },
+  { n: 'A2', role: 'Making partner', output: 'Draft, plan, prototype, or synthesis' },
+  { n: 'A3', role: 'Verifier', output: 'Checks, gaps, risks, and stop signal' },
+] as const
+
+function WritingLines({ count = 3 }: { count?: number }) {
+  return (
+    <div aria-hidden="true" className="mt-5 space-y-5">
+      {Array.from({ length: count }, (_, index) => (
+        <div key={index} className="h-px bg-slate-300" />
+      ))}
+    </div>
+  )
+}
+export default function HumanAiPracticeMapPage() {
+  return (
+    <main id="tallinn-worksheet" className="min-h-screen bg-[#08090b] px-4 pb-16 pt-28 text-white sm:px-8 print:bg-white print:p-0 print:text-slate-950">
+      <style>{`
+        @media print {
+          @page { size: A4; margin: 10mm; }
+          body { background: white !important; }
+          body > *:not(#main) { display: none !important; }
+          #main { min-height: 0 !important; overflow: visible !important; }
+          #tallinn-worksheet { min-height: 0 !important; }
+          .worksheet-sheet { box-shadow: none !important; break-after: page; }
+          .worksheet-sheet:last-of-type { break-after: auto; }
+        }
+      `}</style>
+
+      <div className="mx-auto mb-6 flex max-w-[210mm] flex-col gap-4 sm:flex-row sm:items-center sm:justify-between print:hidden">
+        <div>
+          <Link href="/experiences/tallinn-2026/purpose-to-practice" className="text-sm text-slate-400 underline decoration-white/20 underline-offset-4 hover:text-white">
+            ← Purpose to Practice
+          </Link>
+          <p className="mt-2 text-xs text-slate-500">Review or print two A4 working pages. No participant data is stored.</p>
+        </div>
+        <PrintWorksheetButton />
+      </div>
+
+      <section className="worksheet-sheet mx-auto min-h-[277mm] max-w-[210mm] bg-[#fffdf8] p-7 text-slate-950 shadow-[0_24px_90px_rgba(0,0,0,0.45)] sm:p-10 print:min-h-[277mm] print:p-6">
+        <header className="flex items-start justify-between gap-6 border-b border-slate-300 pb-6">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-700">Purpose to Practice · working map 01/02</p>
+            <h1 className="mt-3 font-display text-4xl font-semibold tracking-[-0.04em]">Human signal</h1>
+            <p className="mt-3 max-w-xl text-sm leading-6 text-slate-600">Start from lived evidence. The four areas are a modern reflection scaffold, not a test and not the full meaning of ikigai.</p>
+          </div>
+          <div className="min-w-36 text-xs leading-6 text-slate-500">
+            <p>Name __________________</p>
+            <p>Date ___________________</p>
+          </div>
+        </header>
+
+        <div className="mt-7 grid gap-4 sm:grid-cols-2 print:grid-cols-2">
+          {signals.map((signal) => (
+            <article key={signal.number} className="min-h-52 border border-slate-300 p-5">
+              <p className="font-mono text-[10px] font-semibold text-amber-700">{signal.number}</p>
+              <h2 className="mt-4 text-lg font-bold">{signal.title}</h2>
+              <p className="mt-2 text-xs leading-5 text-slate-600">{signal.prompt}</p>
+              <WritingLines count={3} />
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-5 border-2 border-slate-900 p-5">
+          <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-amber-700">One honest trade-off</p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">To make this practice real, what will you decline, reduce, postpone, or stop?</p>
+          <WritingLines count={2} />
+        </div>
+
+        <div className="mt-5 bg-slate-950 p-6 text-white print:bg-slate-950 print:text-white">
+          <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-amber-300">Purpose-to-practice sentence</p>
+          <p className="mt-3 text-sm leading-6 text-slate-200">In this season, I will use <strong>[strength]</strong> to help <strong>[who]</strong> move toward <strong>[useful change]</strong>, while protecting <strong>[boundary]</strong>.</p>
+          <div aria-hidden="true" className="mt-7 space-y-6">
+            <div className="h-px bg-white/50" />
+            <div className="h-px bg-white/50" />
+          </div>
+        </div>
+
+        <footer className="mt-6 flex items-center justify-between border-t border-slate-300 pt-4 text-[9px] leading-4 text-slate-500">
+          <p>Independent Tallinn working session · no Mindvalley affiliation or endorsement</p>
+          <p>FrankX · participant-owned artifact</p>
+        </footer>
+      </section>
+
+      <section className="worksheet-sheet mx-auto mt-8 min-h-[277mm] max-w-[210mm] bg-white p-7 text-slate-950 shadow-[0_24px_90px_rgba(0,0,0,0.45)] sm:p-10 print:mt-0 print:min-h-[277mm] print:p-6">
+        <header className="border-b border-slate-300 pb-6">
+          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-cyan-700">Purpose to Practice · working map 02/02</p>
+          <h1 className="mt-3 font-display text-4xl font-semibold tracking-[-0.04em]">Practice → system → experiment</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">AI can help prepare, make, and verify. Meaning, consent, consequential judgment, and the final commitment stay human.</p>
+        </header>
+
+        <div className="mt-7 grid gap-5 sm:grid-cols-[0.9fr_1.1fr] print:grid-cols-[0.9fr_1.1fr]">
+          <section className="border border-slate-300 p-5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-cyan-700">Weekly practice</p>
+            <dl className="mt-5 space-y-5 text-xs">
+              <div>
+                <dt className="font-bold">Trigger</dt>
+                <dd className="mt-1 text-slate-500">When and where does the practice begin?</dd>
+                <WritingLines count={1} />
+              </div>
+              <div>
+                <dt className="font-bold">Human move</dt>
+                <dd className="mt-1 text-slate-500">What do I notice, choose, or decide?</dd>
+                <WritingLines count={2} />
+              </div>
+              <div>
+                <dt className="font-bold">Evidence</dt>
+                <dd className="mt-1 text-slate-500">What useful change will I inspect?</dd>
+                <WritingLines count={2} />
+              </div>
+              <div>
+                <dt className="font-bold">Review</dt>
+                <dd className="mt-1 text-slate-500">When do I continue, change, or stop?</dd>
+                <WritingLines count={1} />
+              </div>
+            </dl>
+          </section>
+
+          <section className="border border-slate-300 p-5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-cyan-700">Three light agent roles</p>
+            <div className="mt-5 divide-y divide-slate-300 border-y border-slate-300">
+              {roles.map((role) => (
+                <div key={role.n} className="grid grid-cols-[2.2rem_1fr] gap-3 py-3 text-xs">
+                  <p className="font-mono font-bold text-cyan-700">{role.n}</p>
+                  <div>
+                    <p className="font-bold">{role.role}</p>
+                    <p className="mt-1 text-slate-500">{role.output}</p>
+                    <p className="mt-3 border-b border-slate-300 pb-1 text-slate-400">My version:</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-5">
+              <p className="text-xs font-bold">Shared sources they may use</p>
+              <WritingLines count={2} />
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-5 grid gap-5 sm:grid-cols-2 print:grid-cols-2">
+          <section className="border-2 border-slate-900 p-5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-amber-700">Human-only decisions</p>
+            <p className="mt-2 text-xs leading-5 text-slate-500">What may no agent publish, promise, spend, send, or decide without you?</p>
+            <WritingLines count={3} />
+          </section>
+          <section className="border-2 border-slate-900 p-5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-amber-700">Stop conditions</p>
+            <p className="mt-2 text-xs leading-5 text-slate-500">Which uncertainty, privacy, quality, or impact signal returns the work to a human?</p>
+            <WritingLines count={3} />
+          </section>
+        </div>
+
+        <section className="mt-5 bg-slate-950 p-6 text-white print:bg-slate-950 print:text-white">
+          <div className="flex items-center justify-between gap-5">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-emerald-300">30-day experiment</p>
+            <p className="text-[10px] text-slate-400">Small · reversible · dated · inspectable</p>
+          </div>
+          <div className="mt-5 grid gap-5 text-xs sm:grid-cols-2 print:grid-cols-2">
+            <div>
+              <p className="text-slate-400">From / until</p>
+              <div className="mt-4 h-px bg-white/50" />
+            </div>
+            <div>
+              <p className="text-slate-400">Smallest useful proof</p>
+              <div className="mt-4 h-px bg-white/50" />
+            </div>
+            <div>
+              <p className="text-slate-400">One person I may ask for feedback</p>
+              <div className="mt-4 h-px bg-white/50" />
+            </div>
+            <div>
+              <p className="text-slate-400">Weekly review appointment</p>
+              <div className="mt-4 h-px bg-white/50" />
+            </div>
+          </div>
+        </section>
+
+        <footer className="mt-6 flex items-center justify-between border-t border-slate-300 pt-4 text-[9px] leading-4 text-slate-500">
+          <p>This is an educational reflection and operating artifact—not therapy, medical, legal, or employment advice.</p>
+          <p>Human + AI Practice Map · v0.1</p>
+        </footer>
+      </section>
+    </main>
+  )
+}

--- a/components/tallinn-experience/ExperienceRouter.tsx
+++ b/components/tallinn-experience/ExperienceRouter.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { ArrowRight, Route } from 'lucide-react'
+
+import type {
+  TallinnOutcome,
+  TallinnPersona,
+} from '@/data/tallinn-experiences'
+import {
+  TALLINN_OUTCOMES,
+  TALLINN_PERSONAS,
+} from '@/data/tallinn-experiences'
+
+export interface RouterExperience {
+  slug: string
+  title: string
+  promise: string
+  artifact: string
+  personas: readonly TallinnPersona[]
+  outcomes: readonly TallinnOutcome[]
+  reviewRank: number | null
+  frankRole: string
+  anaInvitation: string
+}
+interface ExperienceRouterProps {
+  experiences: readonly RouterExperience[]
+}
+
+const pathStages = [
+  { label: 'Human signal', note: 'What matters and what stays human' },
+  { label: 'Practice', note: 'A decision or artifact you can use' },
+  { label: 'System', note: 'A repeatable workflow with boundaries' },
+  { label: 'Team', note: 'Roles, knowledge, escalation, review' },
+] as const
+
+const activeStage: Record<TallinnOutcome, number> = {
+  direction: 0,
+  artifact: 1,
+  workflow: 2,
+  'team-system': 3,
+}
+
+function recommendationScore(
+  experience: RouterExperience,
+  persona: TallinnPersona,
+  outcome: TallinnOutcome,
+) {
+  const personaScore = experience.personas.includes(persona) ? 8 : 0
+  const outcomeScore = experience.outcomes.includes(outcome) ? 8 : 0
+  const reviewScore = experience.reviewRank ? 6 - experience.reviewRank : 0
+  return personaScore + outcomeScore + reviewScore
+}
+
+export function ExperienceRouter({ experiences }: ExperienceRouterProps) {
+  const [persona, setPersona] = useState<TallinnPersona>('creator')
+  const [outcome, setOutcome] = useState<TallinnOutcome>('direction')
+
+  const recommendations = useMemo(
+    () =>
+      [...experiences]
+        .sort(
+          (a, b) =>
+            recommendationScore(b, persona, outcome) -
+            recommendationScore(a, persona, outcome),
+        )
+        .slice(0, 2),
+    [experiences, outcome, persona],
+  )
+
+  const [primary, alternative] = recommendations
+  const stage = activeStage[outcome]
+
+  return (
+    <section id="find-your-format" className="border-y border-white/[0.07] bg-white/[0.015]">
+      <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold tracking-[0.2em] text-cyan-300">
+            Outcome router
+          </p>
+          <h2 className="mt-4 font-display text-3xl font-semibold tracking-[-0.03em] text-white sm:text-5xl">
+            Find the room that matches the work.
+          </h2>
+          <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+            Two choices. One recommendation. Every format ends in an inspectable artifact.
+          </p>
+        </div>
+
+        <div className="mt-12 grid gap-10 lg:grid-cols-[0.88fr_1.12fr] lg:items-start">
+          <div className="space-y-9">
+            <fieldset>
+              <legend className="text-sm font-semibold text-white">I am here as a…</legend>
+              <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-2">
+                {(Object.keys(TALLINN_PERSONAS) as TallinnPersona[]).map((id) => (
+                  <button
+                    key={id}
+                    type="button"
+                    aria-pressed={persona === id}
+                    onClick={() => setPersona(id)}
+                    className={`min-h-12 rounded-2xl border px-4 py-3 text-left text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] ${
+                      persona === id
+                        ? 'border-cyan-300/55 bg-cyan-300/10 text-white'
+                        : 'border-white/10 bg-white/[0.025] text-slate-300 hover:border-white/25 hover:text-white'
+                    }`}
+                  >
+                    {TALLINN_PERSONAS[id].label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <fieldset>
+              <legend className="text-sm font-semibold text-white">I want to leave with…</legend>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {(Object.keys(TALLINN_OUTCOMES) as TallinnOutcome[]).map((id) => (
+                  <button
+                    key={id}
+                    type="button"
+                    aria-pressed={outcome === id}
+                    onClick={() => setOutcome(id)}
+                    className={`min-h-14 rounded-2xl border px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b] ${
+                      outcome === id
+                        ? 'border-emerald-300/55 bg-emerald-300/10 text-white'
+                        : 'border-white/10 bg-white/[0.025] text-slate-300 hover:border-white/25 hover:text-white'
+                    }`}
+                  >
+                    <span className="block text-sm font-semibold">{TALLINN_OUTCOMES[id].label}</span>
+                    <span className="mt-1 block text-xs leading-5 text-slate-400">
+                      {TALLINN_OUTCOMES[id].note}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+
+          <div
+            aria-live="polite"
+            className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[#0d1117] p-6 shadow-[0_28px_90px_rgba(0,0,0,0.35)] sm:p-8"
+          >
+            <div className="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-cyan-300/70 to-transparent" />
+            <div className="flex items-center gap-2 text-xs font-semibold tracking-[0.16em] text-cyan-300">
+              <Route className="h-4 w-4" aria-hidden="true" />
+              Recommended working room
+            </div>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-4">
+              {pathStages.map((item, index) => (
+                <div
+                  key={item.label}
+                  className={`relative border-l-2 py-2 pl-4 sm:border-l-0 sm:border-t-2 sm:pl-0 sm:pt-4 ${
+                    index <= stage ? 'border-cyan-300/70' : 'border-white/10'
+                  }`}
+                >
+                  <p className={index <= stage ? 'text-sm font-semibold text-white' : 'text-sm text-slate-500'}>
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">{item.note}</p>
+                </div>
+              ))}
+            </div>
+
+            {primary ? (
+              <div className="mt-8 border-t border-white/10 pt-7">
+                <p className="text-sm text-slate-400">
+                  {TALLINN_PERSONAS[persona].note}
+                </p>
+                <h3 className="mt-4 font-display text-3xl font-semibold tracking-[-0.02em] text-white">
+                  {primary.title}
+                </h3>
+                <p className="mt-3 text-base leading-7 text-slate-300">{primary.promise}</p>
+                <dl className="mt-6 grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <dt className="text-xs font-semibold tracking-[0.14em] text-slate-500">You make</dt>
+                    <dd className="mt-1 text-sm text-white">{primary.artifact}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs font-semibold tracking-[0.14em] text-slate-500">Host shape</dt>
+                    <dd className="mt-1 text-sm leading-6 text-slate-300">
+                      Frank leads. Ana’s lane is invitation-only and hers to choose.
+                    </dd>
+                  </div>
+                </dl>
+                <Link
+                  href={`/experiences/tallinn-2026/${primary.slug}`}
+                  className="mt-7 inline-flex min-h-12 items-center gap-2 rounded-full bg-cyan-300 px-6 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1117]"
+                >
+                  Review this format
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+                {alternative ? (
+                  <p className="mt-5 text-sm text-slate-400">
+                    Alternative:{' '}
+                    <Link
+                      href={`/experiences/tallinn-2026/${alternative.slug}`}
+                      className="font-medium text-white underline decoration-white/25 underline-offset-4 hover:decoration-white"
+                    >
+                      {alternative.title}
+                    </Link>
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/tallinn-experience/PrintWorksheetButton.tsx
+++ b/components/tallinn-experience/PrintWorksheetButton.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { Printer } from 'lucide-react'
+
+export function PrintWorksheetButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => window.print()}
+      className="inline-flex min-h-11 items-center gap-2 rounded-full bg-white px-5 py-2.5 text-sm font-semibold text-slate-950 hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090b] print:hidden"
+    >
+      <Printer className="h-4 w-4" aria-hidden="true" />
+      Print the map
+    </button>
+  )
+}

--- a/components/tallinn-experience/TallinnFoundryPage.tsx
+++ b/components/tallinn-experience/TallinnFoundryPage.tsx
@@ -1,0 +1,451 @@
+import Link from 'next/link'
+import {
+  ArrowRight,
+  CalendarClock,
+  Check,
+  CircleDot,
+  ExternalLink,
+  MapPin,
+  ShieldCheck,
+  Sparkles,
+  Users,
+} from 'lucide-react'
+
+import {
+  TALLINN_EVENT,
+  TALLINN_TIME_WINDOWS,
+  TALLINN_VALIDATION_GATE,
+  tallinnExperiences,
+  tallinnReviewExperiences,
+} from '@/data/tallinn-experiences'
+
+import { ExperienceRouter } from './ExperienceRouter'
+import { TallinnInterestForm } from './TallinnInterestForm'
+
+interface TallinnFoundryPageProps {
+  captureEnabled: boolean
+}
+
+const systemStages = [
+  { index: '01', label: 'Human', note: 'meaning + judgment' },
+  { index: '02', label: 'Practice', note: 'one useful artifact' },
+  { index: '03', label: 'System', note: 'repeatable boundaries' },
+  { index: '04', label: 'Team', note: 'roles + review' },
+] as const
+
+const sourceRail = [
+  {
+    label: 'Ikigai & Personal Branding',
+    href: '/workshops/ikigai-branding',
+    note: 'Purpose and positioning scaffold',
+  },
+  {
+    label: 'Research',
+    href: '/research',
+    note: 'Source-aware synthesis',
+  },
+  {
+    label: 'Library',
+    href: '/library',
+    note: 'Books, models, and field notes',
+  },
+  {
+    label: 'Agentic Builder Lab',
+    href: '/agentic-builder-lab',
+    note: 'Working agent architecture',
+  },
+] as const
+
+const collaborationModes = [
+  {
+    mode: 'Producer',
+    title: 'Ana stays offstage',
+    body: 'Venue, flow, participant care, and logistics. Frank facilitates. This is the default until Ana asks for a public lane.',
+  },
+  {
+    mode: 'Contributor',
+    title: 'One bounded people lens',
+    body: 'Ana approves a short prompt, role-clarity review, or closing reflection. Her exact wording, credit, and reuse rights are agreed first.',
+  },
+  {
+    mode: 'Co-creator',
+    title: 'A genuinely joint format',
+    body: 'A people + agent team workshop with shared design, delivery, commercial terms, and a written line between individual and joint IP.',
+  },
+] as const
+
+const demandSteps = [
+  {
+    n: '01',
+    title: 'Collect intent',
+    body: 'People choose an outcome, format, and compatible time. This is interest—not a ticket.',
+  },
+  {
+    n: '02',
+    title: 'Reconfirm one room',
+    body: `Choose the strongest format and ask likely attendees to reconfirm one time. Target ${TALLINN_VALIDATION_GATE.minimumConfirmed} confirmed + ${TALLINN_VALIDATION_GATE.standbyTarget} standby.`,
+  },
+  {
+    n: '03',
+    title: 'Price the venue',
+    body: `Request a resident room-only quote first. Frank reviews any spend; the working room-only ceiling is €${TALLINN_VALIDATION_GATE.roomOnlyCapEur}.`,
+  },
+  {
+    n: '04',
+    title: 'Confirm or release',
+    body: `At ${TALLINN_VALIDATION_GATE.decisionWindow}, confirm the room and logistics—or release the idea cleanly.`,
+  },
+] as const
+
+const aftercare = [
+  { when: 'Immediately', what: 'Interest receipt; no ticket or venue promise.' },
+  { when: 'After the gate', what: 'One reconfirmation request for the chosen format and time.' },
+  { when: 'T−24 hours', what: 'Room, access, what to bring, and confidentiality boundary.' },
+  { when: 'Same day', what: 'The participant’s artifact, template, and sources.' },
+  { when: '+48 hours', what: 'One implementation prompt, only if requested.' },
+  { when: 'Day 7', what: 'A practice check, only with separate aftercare consent.' },
+] as const
+
+function SystemMap() {
+  return (
+    <div className="grid gap-px overflow-hidden rounded-[1.75rem] border border-white/10 bg-white/10 sm:grid-cols-4">
+      {systemStages.map((stage, index) => (
+        <div key={stage.label} className="relative bg-[#0d1117] p-5 sm:min-h-40 sm:p-6">
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-xs text-cyan-300">{stage.index}</span>
+            {index < systemStages.length - 1 ? (
+              <ArrowRight className="h-4 w-4 text-slate-700 max-sm:rotate-90" aria-hidden="true" />
+            ) : (
+              <CircleDot className="h-4 w-4 text-emerald-300" aria-hidden="true" />
+            )}
+          </div>
+          <p className="mt-9 text-base font-semibold text-white">{stage.label}</p>
+          <p className="mt-1 text-xs leading-5 text-slate-500">{stage.note}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function TallinnFoundryPage({ captureEnabled }: TallinnFoundryPageProps) {
+  const reviewOffers = [...tallinnReviewExperiences].sort(
+    (a, b) => (a.reviewRank ?? 99) - (b.reviewRank ?? 99),
+  )
+  const secondWave = tallinnExperiences.filter((experience) => experience.reviewRank === null)
+  const formExperiences = tallinnExperiences.map(({ slug, title }) => ({ slug, title }))
+
+  return (
+    <main className="overflow-hidden bg-[#08090b] text-white">
+      <section className="relative border-b border-white/[0.07]">
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-[38rem] bg-[radial-gradient(circle_at_72%_10%,rgba(67,191,227,0.12),transparent_42%),radial-gradient(circle_at_22%_5%,rgba(245,158,11,0.08),transparent_34%)]" />
+        <div className="relative mx-auto max-w-7xl px-5 pb-20 pt-28 sm:px-8 sm:pt-36 lg:px-10 lg:pb-28 lg:pt-44">
+          <div className="grid gap-14 lg:grid-cols-[1.04fr_0.96fr] lg:items-end">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">
+                Tallinn · {TALLINN_EVENT.window} · independent field lab
+              </p>
+              <h1 className="mt-7 max-w-4xl font-display text-5xl font-semibold leading-[0.94] tracking-[-0.055em] text-white sm:text-7xl lg:text-[5.65rem]">
+                Leave Tallinn with one thing running.
+              </h1>
+              <p className="mt-7 max-w-2xl text-lg leading-8 text-slate-300 sm:text-xl">
+                Small, artifact-led working rooms for purpose, creator practice, and human + agent teams. Ninety minutes. Eight to twelve people. No stage required.
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="#find-your-format"
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090b]"
+                >
+                  Find your format
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+                <Link
+                  href="#request"
+                  className="inline-flex min-h-12 items-center justify-center rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-white transition-colors hover:border-white/35 hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                >
+                  Test demand first
+                </Link>
+              </div>
+            </div>
+
+            <div>
+              <p className="mb-4 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                The artifact system
+              </p>
+              <SystemMap />
+              <div className="mt-5 flex items-start gap-3 text-sm leading-6 text-slate-400">
+                <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
+                <p>Venue not booked. Interest comes first. Frank leads; Ana chooses her visibility and contribution.</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-16 flex flex-col gap-3 border-t border-white/10 pt-6 text-xs leading-5 text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+            <p>{TALLINN_EVENT.independenceNotice}</p>
+            <a
+              href="https://www.mindvalley.com/u"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex shrink-0 items-center gap-1.5 text-slate-300 underline decoration-white/20 underline-offset-4 hover:text-white"
+            >
+              Official event information
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <ExperienceRouter experiences={tallinnExperiences} />
+
+      <section className="border-b border-white/[0.07]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-10 lg:grid-cols-[0.7fr_1.3fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">Five to review first</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                One family. Five distinct doors.
+              </h2>
+              <p className="mt-5 max-w-lg text-base leading-7 text-slate-400">
+                These are the strongest formats to discuss with Ana. The first is the recommended pilot; the fifth quietly tests whether a deeper retreat deserves to exist.
+              </p>
+            </div>
+
+            <div className="border-t border-white/10">
+              {reviewOffers.map((experience) => (
+                <article
+                  key={experience.slug}
+                  className="grid gap-5 border-b border-white/10 py-8 sm:grid-cols-[4rem_1fr_auto] sm:items-start"
+                >
+                  <p className="font-mono text-sm text-slate-600">0{experience.reviewRank}</p>
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="font-display text-2xl font-semibold text-white">{experience.title}</h3>
+                      {experience.reviewRank === 1 ? (
+                        <span className="rounded-full border border-amber-300/30 bg-amber-300/[0.07] px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-amber-200">
+                          Pilot
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">{experience.promise}</p>
+                    <p className="mt-3 text-xs leading-5 text-slate-500">
+                      Leave with: <span className="text-slate-300">{experience.artifact}</span>
+                    </p>
+                  </div>
+                  <Link
+                    href={`/experiences/tallinn-2026/${experience.slug}`}
+                    aria-label={`Review ${experience.title}`}
+                    className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-cyan-300 underline decoration-cyan-300/25 underline-offset-4 hover:decoration-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                  >
+                    Review
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-20 grid gap-8 border-t border-white/10 pt-10 lg:grid-cols-[0.7fr_1.3fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Second-wave tests</p>
+              <p className="mt-3 max-w-sm text-sm leading-6 text-slate-400">
+                Five sharper message and market variants. Build only after the first demand signals tell us where to lean.
+              </p>
+            </div>
+            <div className="grid gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/10 sm:grid-cols-2">
+              {secondWave.map((experience) => (
+                <Link
+                  key={experience.slug}
+                  href={`/experiences/tallinn-2026/${experience.slug}`}
+                  className="group bg-[#0b0d10] p-6 transition-colors hover:bg-white/[0.035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-cyan-300"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-600">{experience.eyebrow}</p>
+                  <h3 className="mt-3 text-base font-semibold text-white">{experience.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">{experience.artifact}</p>
+                  <ArrowRight className="mt-5 h-4 w-4 text-slate-600 transition-colors group-hover:text-cyan-300" aria-hidden="true" />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07] bg-white/[0.012]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">Built from work that already exists</p>
+            <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+              No theatre. Inspectable source material.
+            </h2>
+          </div>
+          <div className="mt-12 grid gap-px overflow-hidden rounded-[1.75rem] border border-white/10 bg-white/10 sm:grid-cols-2 lg:grid-cols-4">
+            {sourceRail.map((source) => (
+              <Link
+                key={source.href}
+                href={source.href}
+                className="group min-h-44 bg-[#0b0d10] p-6 transition-colors hover:bg-white/[0.035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-cyan-300"
+              >
+                <Sparkles className="h-5 w-5 text-slate-600 transition-colors group-hover:text-cyan-300" aria-hidden="true" />
+                <p className="mt-8 text-sm font-semibold text-white">{source.label}</p>
+                <p className="mt-2 text-xs leading-5 text-slate-500">{source.note}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-300">Frank + Ana</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                Collaboration without forced visibility.
+              </h2>
+              <p className="mt-5 max-w-lg text-base leading-7 text-slate-400">
+                Ana does not need the spotlight to have real authorship. The role expands only with her consent, clear scope, and fair commercial terms.
+              </p>
+            </div>
+            <div className="divide-y divide-white/10 border-y border-white/10">
+              {collaborationModes.map((item) => (
+                <div key={item.mode} className="grid gap-3 py-7 sm:grid-cols-[8rem_1fr]">
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-emerald-300">{item.mode}</p>
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">{item.body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="mt-10 rounded-2xl border border-amber-300/20 bg-amber-300/[0.045] p-5 text-sm leading-6 text-amber-50/90">
+            Public claims stay deliberately narrow: no therapy, IFS, neuroscience, psychology, certification, or health-outcome claims unless Ana supplies and approves the exact evidence and wording.
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07] bg-[#0b0d10]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr]">
+            <div>
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-amber-300">
+                <MapPin className="h-4 w-4" aria-hidden="true" />
+                Tallink candidate
+              </div>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                Validate the room before buying the room.
+              </h2>
+              <p className="mt-5 max-w-lg text-base leading-7 text-slate-400">
+                Tallink Spa & Conference Hotel is convenient because Frank is already staying there. It is still only a venue candidate; hotel residence does not establish free meeting-room access.
+              </p>
+              <a
+                href="https://hotels.tallink.com/events/tallink-spa-conference-hotel-conference-center"
+                target="_blank"
+                rel="noreferrer"
+                className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-white underline decoration-white/25 underline-offset-4 hover:decoration-white"
+              >
+                View Tallink’s published conference offer
+                <ExternalLink className="h-4 w-4" aria-hidden="true" />
+              </a>
+              <p className="mt-5 text-xs leading-5 text-slate-500">
+                Published weekday package baseline: 10-person minimum, €43 per person for half day. Ask separately for a two-hour room-only resident quote or courtesy hold; do not assume it exists.
+              </p>
+            </div>
+            <ol className="grid gap-px overflow-hidden rounded-[1.75rem] border border-white/10 bg-white/10 sm:grid-cols-2">
+              {demandSteps.map((step) => (
+                <li key={step.n} className="bg-[#0e1116] p-6 sm:p-7">
+                  <p className="font-mono text-xs text-slate-600">{step.n}</p>
+                  <h3 className="mt-7 text-lg font-semibold text-white">{step.title}</h3>
+                  <p className="mt-3 text-sm leading-6 text-slate-400">{step.body}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="mt-12 rounded-[1.75rem] border border-white/10 bg-[#08090b] p-6 sm:p-8">
+            <div className="flex items-center gap-2 text-sm font-semibold text-white">
+              <CalendarClock className="h-5 w-5 text-cyan-300" aria-hidden="true" />
+              Windows to test—not promises
+            </div>
+            <div className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+              {TALLINN_TIME_WINDOWS.map((slot) => (
+                <div key={slot.id} className="rounded-xl border border-white/10 bg-white/[0.02] p-4 text-sm leading-6 text-slate-300">
+                  {slot.label}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">Care after the room</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                The workshop is a beginning with boundaries.
+              </h2>
+              <p className="mt-5 max-w-lg text-base leading-7 text-slate-400">
+                Follow-through is session-specific, consent-based, and designed to help the artifact survive the trip home—not to smuggle people into a marketing list.
+              </p>
+            </div>
+            <div className="divide-y divide-white/10 border-y border-white/10">
+              {aftercare.map((item) => (
+                <div key={item.when} className="grid gap-2 py-5 sm:grid-cols-[8rem_1fr]">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">{item.when}</p>
+                  <p className="text-sm leading-6 text-slate-300">{item.what}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="request" className="relative bg-[#0a0d12]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(16,185,129,0.08),transparent_30%),radial-gradient(circle_at_80%_70%,rgba(67,191,227,0.08),transparent_34%)]" />
+        <div className="relative mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.72fr_1.28fr] lg:items-start">
+            <div className="lg:sticky lg:top-28">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-300">
+                <Users className="h-4 w-4" aria-hidden="true" />
+                Demand signal
+              </div>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                Request the room you would actually attend.
+              </h2>
+              <p className="mt-5 max-w-md text-base leading-7 text-slate-400">
+                Choose honestly. The venue decision is made only from reconfirmed, time-compatible demand.
+              </p>
+              <ul className="mt-8 space-y-3 text-sm text-slate-300">
+                {[
+                  'No payment or ticket at this stage',
+                  'No venue is currently booked',
+                  'No newsletter consent bundled in',
+                  'No sensitive health or employment details',
+                ].map((item) => (
+                  <li key={item} className="flex gap-3">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-[2rem] border border-white/10 bg-[#0d1117] p-5 shadow-[0_28px_100px_rgba(0,0,0,0.38)] sm:p-8 lg:p-10">
+              <TallinnInterestForm
+                experiences={formExperiences}
+                defaultExperienceSlug="purpose-to-practice"
+                captureEnabled={captureEnabled}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer className="border-t border-white/[0.07] bg-[#08090b]">
+        <div className="mx-auto max-w-7xl px-5 py-10 text-xs leading-5 text-slate-500 sm:px-8 lg:px-10">
+          <p>{TALLINN_EVENT.independenceNotice}</p>
+          <p className="mt-2">Concept preview · venue, schedule, host roles, capacity, and live capture remain unconfirmed.</p>
+        </div>
+      </footer>
+    </main>
+  )
+}

--- a/components/tallinn-experience/TallinnInterestForm.tsx
+++ b/components/tallinn-experience/TallinnInterestForm.tsx
@@ -1,0 +1,337 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { ArrowRight, CheckCircle2, Loader2, ShieldCheck } from 'lucide-react'
+
+import {
+  TALLINN_TIME_WINDOWS,
+  TALLINN_VALIDATION_GATE,
+} from '@/data/tallinn-experiences'
+import {
+  TALLINN_ATTENDANCE_INTENTS,
+  TALLINN_ROLE_LENSES,
+} from '@/lib/tallinn-interest/options'
+
+interface FormExperience {
+  slug: string
+  title: string
+}
+
+interface TallinnInterestFormProps {
+  experiences: readonly FormExperience[]
+  defaultExperienceSlug: string
+  lockExperience?: boolean
+  captureEnabled: boolean
+}
+
+const roleLabel: Record<(typeof TALLINN_ROLE_LENSES)[number], string> = {
+  creator: 'Creator',
+  'solo-founder': 'Solo founder',
+  'team-leader': 'Team leader',
+  'people-ops': 'People / HR',
+  other: 'Other',
+}
+
+const intentLabel: Record<(typeof TALLINN_ATTENDANCE_INTENTS)[number], string> = {
+  exploring: 'Exploring',
+  likely: 'Likely if the format fits',
+  'ready-if-time-works': 'Ready if one time works',
+}
+
+function safeVariant() {
+  const params = new URLSearchParams(window.location.search)
+  const candidate = params.get('variant') || params.get('ref') || 'default'
+  return /^[a-z0-9-]{1,60}$/.test(candidate) ? candidate : 'default'
+}
+
+export function TallinnInterestForm({
+  experiences,
+  defaultExperienceSlug,
+  lockExperience = false,
+  captureEnabled,
+}: TallinnInterestFormProps) {
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle')
+  const [message, setMessage] = useState<string | null>(null)
+  const [simulated, setSimulated] = useState(false)
+  const submissionId = useRef<string | null>(null)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setStatus('submitting')
+    setMessage(null)
+
+    const form = event.currentTarget
+    const data = new FormData(form)
+    submissionId.current ||= window.crypto.randomUUID()
+
+    const payload = {
+      fullName: String(data.get('fullName') || ''),
+      email: String(data.get('email') || ''),
+      experienceSlug: String(data.get('experienceSlug') || defaultExperienceSlug),
+      variantId: safeVariant(),
+      roleLens: String(data.get('roleLens') || ''),
+      attendanceIntent: String(data.get('attendanceIntent') || ''),
+      slotIds: data.getAll('slotIds').map(String),
+      companyOrProject: String(data.get('companyOrProject') || ''),
+      note: String(data.get('note') || ''),
+      aftercareConsent: data.get('aftercareConsent') === 'on',
+      consentToContact: data.get('consentToContact') === 'on',
+      submissionId: submissionId.current,
+      website: String(data.get('website') || ''),
+    }
+
+    try {
+      const response = await fetch('/api/tallinn-interest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const json = await response.json().catch(() => ({}))
+      if (response.ok && json.ok) {
+        setStatus('done')
+        setSimulated(Boolean(json.reviewMode))
+        setMessage(json.message || 'Your interest is recorded.')
+        form.reset()
+        submissionId.current = null
+      } else {
+        setStatus('error')
+        setMessage(json.error || 'Something went wrong. Please try again.')
+      }
+    } catch {
+      setStatus('error')
+      setMessage('Network error. Please try again or email frank@frankx.ai.')
+    }
+  }
+
+  if (status === 'done') {
+    return (
+      <div role="status" aria-live="polite" className="py-4 text-center">
+        <CheckCircle2 className="mx-auto h-9 w-9 text-emerald-300" aria-hidden="true" />
+        <h3 className="mt-4 font-display text-2xl font-semibold text-white">
+          {simulated ? 'Review flow passed.' : 'You are in the interest cohort.'}
+        </h3>
+        <p className="mx-auto mt-3 max-w-lg text-sm leading-6 text-slate-300">{message}</p>
+        <p className="mx-auto mt-3 max-w-lg text-xs leading-5 text-slate-500">
+          {simulated
+            ? 'No personal data was stored and no email was sent.'
+            : `A room is considered only after ${TALLINN_VALIDATION_GATE.minimumConfirmed} people reconfirm one compatible time.`}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setStatus('idle')
+            setMessage(null)
+          }}
+          className="mt-6 min-h-11 text-sm font-semibold text-cyan-300 underline decoration-cyan-300/30 underline-offset-4 hover:decoration-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+        >
+          Test another request
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {!captureEnabled ? (
+        <div className="flex gap-3 rounded-2xl border border-amber-300/20 bg-amber-300/[0.06] p-4 text-sm leading-6 text-amber-50">
+          <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" aria-hidden="true" />
+          <p>
+            Private review mode. No external service is called. Use{' '}
+            <code className="font-mono text-amber-200">test@example.com</code> to exercise the complete interface.
+          </p>
+        </div>
+      ) : null}
+
+      {lockExperience ? (
+        <input type="hidden" name="experienceSlug" value={defaultExperienceSlug} />
+      ) : (
+        <div>
+          <label htmlFor="experienceSlug" className="block text-sm font-semibold text-white">
+            Session to test
+          </label>
+          <select
+            id="experienceSlug"
+            name="experienceSlug"
+            defaultValue={defaultExperienceSlug}
+            className="mt-2 min-h-12 w-full rounded-xl border border-white/10 bg-[#0a0d12] px-4 text-sm text-white focus:border-cyan-300/60 focus:outline-none focus:ring-1 focus:ring-cyan-300/60"
+          >
+            {experiences.map((experience) => (
+              <option key={experience.slug} value={experience.slug}>
+                {experience.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="fullName" className="block text-sm font-semibold text-white">Name</label>
+          <input
+            id="fullName"
+            name="fullName"
+            required
+            maxLength={200}
+            autoComplete="name"
+            className="mt-2 min-h-12 w-full rounded-xl border border-white/10 bg-white/[0.025] px-4 text-sm text-white placeholder:text-slate-600 focus:border-cyan-300/60 focus:outline-none focus:ring-1 focus:ring-cyan-300/60"
+            placeholder="Your name"
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm font-semibold text-white">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            maxLength={200}
+            autoComplete="email"
+            className="mt-2 min-h-12 w-full rounded-xl border border-white/10 bg-white/[0.025] px-4 text-sm text-white placeholder:text-slate-600 focus:border-cyan-300/60 focus:outline-none focus:ring-1 focus:ring-cyan-300/60"
+            placeholder={captureEnabled ? 'you@company.com' : 'test@example.com'}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="roleLens" className="block text-sm font-semibold text-white">Current lens</label>
+          <select
+            id="roleLens"
+            name="roleLens"
+            required
+            defaultValue=""
+            className="mt-2 min-h-12 w-full rounded-xl border border-white/10 bg-[#0a0d12] px-4 text-sm text-white focus:border-cyan-300/60 focus:outline-none focus:ring-1 focus:ring-cyan-300/60"
+          >
+            <option value="" disabled>Choose one</option>
+            {TALLINN_ROLE_LENSES.map((role) => (
+              <option key={role} value={role}>{roleLabel[role]}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="companyOrProject" className="block text-sm font-semibold text-white">
+            Company or project <span className="font-normal text-slate-500">(optional)</span>
+          </label>
+          <input
+            id="companyOrProject"
+            name="companyOrProject"
+            maxLength={200}
+            autoComplete="organization"
+            className="mt-2 min-h-12 w-full rounded-xl border border-white/10 bg-white/[0.025] px-4 text-sm text-white placeholder:text-slate-600 focus:border-cyan-300/60 focus:outline-none focus:ring-1 focus:ring-cyan-300/60"
+            placeholder="What you are building"
+          />
+        </div>
+      </div>
+
+      <fieldset>
+        <legend className="text-sm font-semibold text-white">How real is the interest?</legend>
+        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+          {TALLINN_ATTENDANCE_INTENTS.map((intent) => (
+            <label key={intent} className="flex min-h-12 cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-slate-300 has-[:checked]:border-emerald-300/55 has-[:checked]:bg-emerald-300/[0.08] has-[:checked]:text-white">
+              <input
+                type="radio"
+                name="attendanceIntent"
+                value={intent}
+                required
+                className="h-4 w-4 border-white/30 bg-transparent text-emerald-400 focus:ring-emerald-300/60"
+              />
+              {intentLabel[intent]}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend className="text-sm font-semibold text-white">Which times could work?</legend>
+        <p className="mt-1 text-xs leading-5 text-slate-500">Choose one to three. The official agenda still takes priority.</p>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          {TALLINN_TIME_WINDOWS.map((slot) => (
+            <label key={slot.id} className="flex min-h-12 cursor-pointer items-start gap-3 rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm leading-6 text-slate-300 has-[:checked]:border-cyan-300/55 has-[:checked]:bg-cyan-300/[0.08] has-[:checked]:text-white">
+              <input
+                type="checkbox"
+                name="slotIds"
+                value={slot.id}
+                className="mt-1 h-4 w-4 rounded border-white/30 bg-transparent text-cyan-400 focus:ring-cyan-300/60"
+              />
+              {slot.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <div>
+        <label htmlFor="note" className="block text-sm font-semibold text-white">
+          What do you want to leave with? <span className="font-normal text-slate-500">(optional)</span>
+        </label>
+        <textarea
+          id="note"
+          name="note"
+          maxLength={800}
+          rows={4}
+          aria-describedby="note-guidance"
+          className="mt-2 w-full resize-y rounded-xl border border-white/10 bg-white/[0.025] px-4 py-3 text-sm text-white placeholder:text-slate-600 focus:border-cyan-300/60 focus:outline-none focus:ring-1 focus:ring-cyan-300/60"
+          placeholder="One useful outcome is enough. Please do not include health or therapy details."
+        />
+        <p id="note-guidance" className="mt-2 text-xs leading-5 text-slate-500">
+          Keep this practical. No sensitive health, therapy, or employment-case information.
+        </p>
+      </div>
+
+      <div aria-hidden="true" className="absolute left-[-9999px] h-0 w-0 overflow-hidden">
+        <label htmlFor="website">Website</label>
+        <input id="website" name="website" tabIndex={-1} autoComplete="off" />
+      </div>
+
+      <div className="space-y-3 border-t border-white/10 pt-5">
+        <label className="flex cursor-pointer items-start gap-3 text-sm leading-6 text-slate-300">
+          <input
+            name="consentToContact"
+            type="checkbox"
+            required
+            className="mt-1 h-4 w-4 rounded border-white/30 bg-transparent text-cyan-400 focus:ring-cyan-300/60"
+          />
+          <span>
+            I agree that FrankX may store my details to evaluate and coordinate this Tallinn session and contact me about this request. No newsletter or unrelated marketing.
+          </span>
+        </label>
+        <label className="flex cursor-pointer items-start gap-3 text-sm leading-6 text-slate-400">
+          <input
+            name="aftercareConsent"
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-white/30 bg-transparent text-emerald-400 focus:ring-emerald-300/60"
+          />
+          <span>If the session runs, send me its artifact and session-related Day-7 check.</span>
+        </label>
+      </div>
+
+      {status === 'error' && message ? (
+        <p role="alert" className="rounded-xl border border-rose-300/25 bg-rose-300/[0.06] px-4 py-3 text-sm leading-6 text-rose-100">
+          {message}
+        </p>
+      ) : null}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-cyan-300 px-6 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-cyan-200 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1117]"
+        >
+          {status === 'submitting' ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+              Checking…
+            </>
+          ) : (
+            <>
+              {captureEnabled ? 'Request a seat' : 'Simulate request'}
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </>
+          )}
+        </button>
+        <p className="text-xs leading-5 text-slate-500">
+          Not a ticket. Not a room booking. No payment.
+        </p>
+      </div>
+    </form>
+  )
+}

--- a/components/tallinn-experience/TallinnOfferPage.tsx
+++ b/components/tallinn-experience/TallinnOfferPage.tsx
@@ -1,0 +1,279 @@
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Clock3,
+  MapPin,
+  ShieldCheck,
+  Users,
+} from 'lucide-react'
+
+import {
+  TALLINN_EVENT,
+  TALLINN_TIME_WINDOWS,
+  TALLINN_VALIDATION_GATE,
+  tallinnExperiences,
+  type TallinnAccent,
+  type TallinnExperience,
+} from '@/data/tallinn-experiences'
+
+import { TallinnInterestForm } from './TallinnInterestForm'
+
+interface TallinnOfferPageProps {
+  experience: TallinnExperience
+  captureEnabled: boolean
+}
+
+const accentStyles: Record<
+  TallinnAccent,
+  { eyebrow: string; border: string; glow: string; number: string }
+> = {
+  amber: {
+    eyebrow: 'text-amber-300',
+    border: 'border-amber-300/25',
+    glow: 'from-amber-300/10',
+    number: 'text-amber-300',
+  },
+  cyan: {
+    eyebrow: 'text-cyan-300',
+    border: 'border-cyan-300/25',
+    glow: 'from-cyan-300/10',
+    number: 'text-cyan-300',
+  },
+  emerald: {
+    eyebrow: 'text-emerald-300',
+    border: 'border-emerald-300/25',
+    glow: 'from-emerald-300/10',
+    number: 'text-emerald-300',
+  },
+}
+
+export function TallinnOfferPage({ experience, captureEnabled }: TallinnOfferPageProps) {
+  const accent = accentStyles[experience.accent]
+  const formExperiences = tallinnExperiences.map(({ slug, title }) => ({ slug, title }))
+
+  return (
+    <main className="overflow-hidden bg-[#08090b] text-white">
+      <section className="relative border-b border-white/[0.07]">
+        <div className={`pointer-events-none absolute inset-x-0 top-0 h-[34rem] bg-gradient-to-b ${accent.glow} to-transparent`} />
+        <div className="relative mx-auto max-w-7xl px-5 pb-20 pt-28 sm:px-8 sm:pt-36 lg:px-10 lg:pb-28 lg:pt-44">
+          <Link
+            href="/experiences/tallinn-2026"
+            className="inline-flex min-h-11 items-center gap-2 text-sm text-slate-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Tallinn Experience Foundry
+          </Link>
+
+          <div className="mt-12 grid gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:items-end">
+            <div>
+              <p className={`text-xs font-semibold uppercase tracking-[0.2em] ${accent.eyebrow}`}>
+                {experience.eyebrow} · {experience.duration} · {experience.capacity}
+              </p>
+              <h1 className="mt-6 max-w-4xl font-display text-5xl font-semibold leading-[0.95] tracking-[-0.055em] text-white sm:text-7xl">
+                {experience.title}
+              </h1>
+              <p className="mt-7 max-w-3xl text-xl leading-8 text-slate-200 sm:text-2xl">
+                {experience.promise}
+              </p>
+              <p className="mt-6 max-w-2xl text-base leading-7 text-slate-400">{experience.description}</p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="#request-this-room"
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08090b]"
+                >
+                  Test this format
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+                <Link
+                  href="#run-of-show"
+                  className="inline-flex min-h-12 items-center justify-center rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-white hover:border-white/35 hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                >
+                  Inspect the 90 minutes
+                </Link>
+              </div>
+            </div>
+
+            <div className={`rounded-[2rem] border ${accent.border} bg-[#0d1117] p-7 shadow-[0_28px_90px_rgba(0,0,0,0.35)] sm:p-8`}>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">The leave-with</p>
+              <p className="mt-5 font-display text-3xl font-semibold text-white">{experience.artifact}</p>
+              <p className="mt-5 text-sm leading-6 text-slate-300">{experience.leaveWith}</p>
+              {experience.slug === 'purpose-to-practice' ? (
+                <Link
+                  href="/experiences/tallinn-2026/purpose-to-practice/map"
+                  className="mt-6 inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-white underline decoration-white/25 underline-offset-4 hover:decoration-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                >
+                  Inspect the working map
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              ) : null}
+              <div className="mt-7 border-t border-white/10 pt-5">
+                <p className="text-xs leading-5 text-slate-500">Arrive with</p>
+                <p className="mt-2 text-sm leading-6 text-slate-300">{experience.arriveWith}</p>
+              </div>
+            </div>
+          </div>
+
+          <p className="mt-16 border-t border-white/10 pt-6 text-xs leading-5 text-slate-500">
+            {TALLINN_EVENT.independenceNotice}
+          </p>
+        </div>
+      </section>
+
+      <section id="run-of-show" className="border-b border-white/[0.07]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.7fr_1.3fr]">
+            <div>
+              <p className={`text-xs font-semibold uppercase tracking-[0.2em] ${accent.eyebrow}`}>Run of show</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                Every minute earns the artifact.
+              </h2>
+              <p className="mt-5 max-w-md text-base leading-7 text-slate-400">
+                A working room, not a compressed keynote. Demonstration stays short so participants can make, inspect, and commit.
+              </p>
+            </div>
+            <ol className="border-t border-white/10">
+              {experience.sessionArc.map((beat, index) => (
+                <li key={`${beat.minutes}-${beat.title}`} className="grid gap-5 border-b border-white/10 py-7 sm:grid-cols-[4rem_7rem_1fr]">
+                  <p className={`font-mono text-xs ${accent.number}`}>0{index + 1}</p>
+                  <p className="text-sm font-semibold text-white">{beat.minutes} min</p>
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{beat.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">{beat.detail}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07] bg-white/[0.012]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-2">
+            <div className="rounded-[1.75rem] border border-white/10 bg-[#0d1117] p-7 sm:p-9">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">You leave with</p>
+              <ul className="mt-7 space-y-4">
+                {experience.deliverables.map((deliverable) => (
+                  <li key={deliverable} className="flex gap-3 text-sm leading-6 text-slate-200">
+                    <Check className="mt-1 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+                    {deliverable}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-[1.75rem] border border-white/10 bg-[#0d1117] p-7 sm:p-9">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Host architecture</p>
+              <dl className="mt-7 space-y-6">
+                <div>
+                  <dt className="text-sm font-semibold text-white">Frank</dt>
+                  <dd className="mt-2 text-sm leading-6 text-slate-400">{experience.frankRole}</dd>
+                </div>
+                <div className="border-t border-white/10 pt-6">
+                  <dt className="text-sm font-semibold text-white">Ana · invitation, not assumption</dt>
+                  <dd className="mt-2 text-sm leading-6 text-slate-400">{experience.anaInvitation}</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.72fr_1.28fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">Inspectable proof</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">Built from real surfaces.</h2>
+              <p className="mt-5 max-w-md text-base leading-7 text-slate-400">
+                The pilot repackages working research, templates, and architecture. It does not pretend a new methodology has already been validated.
+              </p>
+            </div>
+            <div className="grid gap-px overflow-hidden rounded-[1.75rem] border border-white/10 bg-white/10 sm:grid-cols-3">
+              {experience.proofLinks.map((proof) => (
+                <Link
+                  key={proof.href}
+                  href={proof.href}
+                  className="group min-h-52 bg-[#0b0d10] p-6 transition-colors hover:bg-white/[0.035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-cyan-300"
+                >
+                  <ShieldCheck className="h-5 w-5 text-slate-600 transition-colors group-hover:text-cyan-300" aria-hidden="true" />
+                  <h3 className="mt-8 text-sm font-semibold text-white">{proof.label}</h3>
+                  <p className="mt-3 text-xs leading-5 text-slate-500">{proof.note}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.07] bg-[#0b0d10]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.72fr_1.28fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">Operational truth</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">A proposal until demand clears the gate.</h2>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-2xl border border-white/10 bg-[#0e1116] p-6">
+                <MapPin className="h-5 w-5 text-amber-300" aria-hidden="true" />
+                <h3 className="mt-7 text-lg font-semibold text-white">Venue candidate</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-400">{TALLINN_EVENT.venueCandidate}. No room is booked and no free room is assumed.</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-[#0e1116] p-6">
+                <Users className="h-5 w-5 text-cyan-300" aria-hidden="true" />
+                <h3 className="mt-7 text-lg font-semibold text-white">Demand threshold</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-400">{TALLINN_VALIDATION_GATE.minimumConfirmed} reconfirmed + {TALLINN_VALIDATION_GATE.standbyTarget} standby at one time before venue review.</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-[#0e1116] p-6">
+                <Clock3 className="h-5 w-5 text-emerald-300" aria-hidden="true" />
+                <h3 className="mt-7 text-lg font-semibold text-white">Windows to test</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-400">{TALLINN_TIME_WINDOWS.slice(0, 3).map((slot) => slot.label).join(' · ')}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-[#0e1116] p-6">
+                <ShieldCheck className="h-5 w-5 text-slate-300" aria-hidden="true" />
+                <h3 className="mt-7 text-lg font-semibold text-white">Decision owner</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-400">Frank approves venue, spend, final host roles, schedule, and any move from preview to live capture.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="request-this-room" className="relative bg-[#0a0d12]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-28">
+          <div className="grid gap-12 lg:grid-cols-[0.72fr_1.28fr] lg:items-start">
+            <div className="lg:sticky lg:top-28">
+              <p className={`text-xs font-semibold uppercase tracking-[0.2em] ${accent.eyebrow}`}>Interest, not booking</p>
+              <h2 className="mt-4 font-display text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">Would you enter this room?</h2>
+              <p className="mt-5 max-w-md text-base leading-7 text-slate-400">Your answer helps choose one format and one compatible time. It creates no payment, ticket, or venue commitment.</p>
+              <div className="mt-8 rounded-2xl border border-white/10 bg-white/[0.02] p-5 text-sm leading-6 text-slate-400">
+                <p className="font-semibold text-white">After the room</p>
+                <ul className="mt-3 space-y-2">
+                  {experience.aftercare.map((item) => <li key={item}>· {item}</li>)}
+                </ul>
+              </div>
+            </div>
+            <div className="rounded-[2rem] border border-white/10 bg-[#0d1117] p-5 shadow-[0_28px_100px_rgba(0,0,0,0.38)] sm:p-8 lg:p-10">
+              <TallinnInterestForm
+                experiences={formExperiences}
+                defaultExperienceSlug={experience.slug}
+                lockExperience
+                captureEnabled={captureEnabled}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer className="border-t border-white/[0.07] bg-[#08090b]">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-10 text-xs leading-5 text-slate-500 sm:px-8 lg:flex-row lg:items-center lg:justify-between lg:px-10">
+          <p>{TALLINN_EVENT.independenceNotice}</p>
+          <Link href="/experiences/tallinn-2026" className="shrink-0 text-slate-300 underline decoration-white/20 underline-offset-4 hover:text-white">
+            Compare all ten formats
+          </Link>
+        </div>
+      </footer>
+    </main>
+  )
+}

--- a/data/tallinn-experiences.ts
+++ b/data/tallinn-experiences.ts
@@ -1,0 +1,714 @@
+export type TallinnPersona =
+  | 'creator'
+  | 'founder'
+  | 'team'
+  | 'people'
+  | 'integration'
+
+export type TallinnOutcome =
+  | 'direction'
+  | 'artifact'
+  | 'workflow'
+  | 'team-system'
+
+export type TallinnAccent = 'amber' | 'cyan' | 'emerald'
+
+export interface TallinnProofLink {
+  label: string
+  href: string
+  note: string
+}
+
+export interface TallinnSessionBeat {
+  minutes: string
+  title: string
+  detail: string
+}
+
+export interface TallinnExperience {
+  slug: string
+  title: string
+  shortTitle: string
+  eyebrow: string
+  promise: string
+  description: string
+  audience: string
+  personas: readonly TallinnPersona[]
+  outcomes: readonly TallinnOutcome[]
+  duration: string
+  capacity: string
+  accent: TallinnAccent
+  reviewRank: number | null
+  arriveWith: string
+  leaveWith: string
+  artifact: string
+  sessionArc: readonly TallinnSessionBeat[]
+  deliverables: readonly string[]
+  frankRole: string
+  anaInvitation: string
+  proofLinks: readonly TallinnProofLink[]
+  aftercare: readonly string[]
+  testHypothesis: string
+  followOn: string
+}
+
+export const TALLINN_EVENT = {
+  city: 'Tallinn, Estonia',
+  window: '20 July–2 August 2026',
+  venueCandidate: 'Tallink Spa & Conference Hotel',
+  venueStatus: 'Candidate only · no room is booked',
+  independenceNotice:
+    'An independent working session for people gathering in Tallinn during Mindvalley U. This experience is not affiliated with, sponsored by, or endorsed by Mindvalley.',
+} as const
+
+export const TALLINN_VALIDATION_GATE = {
+  minimumConfirmed: 8,
+  standbyTarget: 2,
+  roomCapacityTarget: 12,
+  decisionWindow: '48 hours before the selected session',
+  roomOnlyCapEur: 250,
+  rule:
+    'A room is considered only after eight people reconfirm one compatible time. Venue choice and spend always require Frank’s approval.',
+} as const
+
+export const TALLINN_TIME_WINDOWS = [
+  {
+    id: 'tue-evening',
+    label: 'Tuesday 21 July · 18:30–20:00',
+  },
+  {
+    id: 'wed-morning',
+    label: 'Wednesday 22 July · 08:00–09:30',
+  },
+  {
+    id: 'thu-evening',
+    label: 'Thursday 23 July · 17:30–19:00',
+  },
+  {
+    id: 'other',
+    label: 'Another window after the official agenda is clear',
+  },
+] as const
+
+export const TALLINN_PERSONAS: Record<
+  TallinnPersona,
+  { label: string; note: string }
+> = {
+  creator: {
+    label: 'Creator',
+    note: 'Turn a real point of view into visible work without adding more content noise.',
+  },
+  founder: {
+    label: 'Solo founder',
+    note: 'Create a small governed agent team around the work only you should own.',
+  },
+  team: {
+    label: 'Team lead',
+    note: 'Clarify decisions, knowledge, escalation, and human accountability.',
+  },
+  people: {
+    label: 'People / HR leader',
+    note: 'Redesign roles and operating agreements before adding more automation.',
+  },
+  integration: {
+    label: 'Integration-minded',
+    note: 'Convert a week of insight into one calm practice and one next move.',
+  },
+}
+
+export const TALLINN_OUTCOMES: Record<
+  TallinnOutcome,
+  { label: string; note: string }
+> = {
+  direction: {
+    label: 'Clear direction',
+    note: 'A decision, trade-off, and 30-day experiment.',
+  },
+  artifact: {
+    label: 'A finished artifact',
+    note: 'Something useful you can inspect, export, and improve.',
+  },
+  workflow: {
+    label: 'A weekly workflow',
+    note: 'A repeatable human + AI practice with clear boundaries.',
+  },
+  'team-system': {
+    label: 'A team system',
+    note: 'Roles, escalation, shared knowledge, and a review cadence.',
+  },
+}
+
+export const tallinnExperiences = [
+  {
+    slug: 'purpose-to-practice',
+    title: 'Purpose to Practice',
+    shortTitle: 'Purpose to Practice',
+    eyebrow: 'Recommended first pilot',
+    promise: 'Build a calm Human + AI Practice Map you can use the next morning.',
+    description:
+      'Start with evidence about what gives meaning, what you can contribute, and what your current season can sustain. Then turn it into one 30-day experiment, three light agent roles, and one weekly practice—with the human-only decisions named explicitly.',
+    audience: 'Creators, founders, and people in transition who have insight but no operating shape for it yet.',
+    personas: ['creator', 'founder', 'integration'],
+    outcomes: ['direction', 'workflow'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'amber',
+    reviewRank: 1,
+    arriveWith: 'One real question about the work or chapter you are entering.',
+    leaveWith: 'A one-page Human + AI Practice Map and a dated 30-day experiment.',
+    artifact: 'Human + AI Practice Map',
+    sessionArc: [
+      {
+        minutes: '0–18',
+        title: 'Meaning, without mythology',
+        detail:
+          'Frame ikigai as a broader Japanese idea of everyday meaning; use the familiar four-circle diagram only as a modern reflection scaffold.',
+      },
+      {
+        minutes: '18–45',
+        title: 'Evidence into direction',
+        detail:
+          'Map energising work, demonstrated strengths, useful service, sustainable livelihood, and one honest trade-off.',
+      },
+      {
+        minutes: '45–72',
+        title: 'Direction into a practice',
+        detail:
+          'Write one purpose-to-practice statement, three agent roles, human-only decisions, and one repeatable weekly workflow.',
+      },
+      {
+        minutes: '72–90',
+        title: 'Commit and export',
+        detail:
+          'Peer-review the map, choose a 30-day experiment, and leave with the artifact—not a longer inspiration list.',
+      },
+    ],
+    deliverables: [
+      'Purpose-to-practice statement',
+      'Three light agent roles',
+      'Human-only decision boundary',
+      'One weekly workflow',
+      'Dated 30-day experiment',
+    ],
+    frankRole:
+      'Lead facilitator: meaning-to-system synthesis, operating-map demo, and artifact review.',
+    anaInvitation:
+      'Executive producer by default. If Ana chooses, she may add a brief opening reflection or people lens; no spotlight is assumed and no clinical claim is attached.',
+    proofLinks: [
+      {
+        label: 'Ikigai & Branding workshop',
+        href: '/workshops/ikigai-branding',
+        note: 'The working reflection and synthesis surface already live.',
+      },
+      {
+        label: 'Blue Zones, Ikigai & the AI Era',
+        href: '/research/blue-zones-ikigai-ai-era',
+        note: 'Source-aware context behind the purpose material.',
+      },
+      {
+        label: 'Personal AI CoE',
+        href: '/workshops/personal-ai-coe',
+        note: 'The operating-system pattern adapted into a nontechnical one-pager.',
+      },
+    ],
+    aftercare: [
+      'Same-day artifact export and source stack',
+      'One implementation prompt after 48 hours, only if requested',
+      'Day-7 practice check, only with aftercare consent',
+    ],
+    testHypothesis:
+      'A human-first promise will attract the broadest high-intent group while showing Frank’s distinctive bridge into governed agentic work.',
+    followOn:
+      'Personal AI CoE, founder implementation sprint, or a later Starlight integration retreat—only after the participant asks for the next layer.',
+  },
+  {
+    slug: 'agentic-creator-studio',
+    title: 'Agentic Creator Studio',
+    shortTitle: 'Creator Studio',
+    eyebrow: 'Creator route',
+    promise: 'Turn one sourced idea into one shippable artifact and the recipe to make the next one.',
+    description:
+      'A focused build room for creators who want evidence, voice, and a repeatable AI-assisted workflow—not another list of content tools.',
+    audience: 'Creators, coaches, writers, and educators with one real idea they are ready to shape.',
+    personas: ['creator', 'founder'],
+    outcomes: ['artifact', 'workflow'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'cyan',
+    reviewRank: 2,
+    arriveWith: 'One idea, claim, lesson, or source you genuinely care about.',
+    leaveWith: 'One shippable draft, its source trail, voice guardrails, and a reusable creation recipe.',
+    artifact: 'Source-to-artifact creator recipe',
+    sessionArc: [
+      {
+        minutes: '0–18',
+        title: 'Choose the signal',
+        detail: 'Reduce one idea to a useful claim, intended reader, and source boundary.',
+      },
+      {
+        minutes: '18–42',
+        title: 'Build the brief',
+        detail: 'Define voice, proof, exclusions, format, and the job the artifact must do.',
+      },
+      {
+        minutes: '42–72',
+        title: 'Create in three passes',
+        detail: 'Draft, inspect, and sharpen with AI assisting the work rather than inventing the point of view.',
+      },
+      {
+        minutes: '72–90',
+        title: 'Package the recipe',
+        detail: 'Export the artifact and the exact repeatable sequence for next week’s work.',
+      },
+    ],
+    deliverables: [
+      'One shippable draft',
+      'Source trail',
+      'Voice and claim guardrails',
+      'Reusable creator workflow',
+    ],
+    frankRole:
+      'Lead facilitator and live builder: research, prompt architecture, editorial review, and workflow packaging.',
+    anaInvitation:
+      'Experience producer or participant-observer. An audience-empathy question can be added only if she wants a contributor lane.',
+    proofLinks: [
+      {
+        label: 'FrankX Research',
+        href: '/research',
+        note: 'The source and research discipline behind the studio.',
+      },
+      {
+        label: 'Prompt Library',
+        href: '/prompt-library',
+        note: 'Reusable building blocks already available.',
+      },
+      {
+        label: 'GenCreator principles',
+        href: '/gencreator/principles',
+        note: 'The creator operating philosophy behind the workflow.',
+      },
+    ],
+    aftercare: [
+      'Artifact and recipe export',
+      'Optional 48-hour draft review exchange',
+      'Day-7 “did the second artifact get easier?” check',
+    ],
+    testHypothesis:
+      'A concrete artifact promise will outperform generic creator-AI education for people who already use the tools but lack a reliable editorial system.',
+    followOn: 'GenCreator cohort, creator operating-system install, or a private research-to-release sprint.',
+  },
+  {
+    slug: 'build-your-agentic-team',
+    title: 'Build Your Agentic Team',
+    shortTitle: 'Agentic Team',
+    eyebrow: 'Solo-founder route',
+    promise: 'Design four agent roles around your real business—and keep the consequential decisions human.',
+    description:
+      'Frank opens the exact pattern behind his agentic business operating system, then helps each founder turn one overloaded workflow into roles, instructions, escalation, and a weekly review.',
+    audience: 'Solo founders and operators who have several AI tools but no team architecture.',
+    personas: ['founder', 'team'],
+    outcomes: ['workflow', 'team-system'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'cyan',
+    reviewRank: 3,
+    arriveWith: 'One recurring workflow that currently depends on you remembering everything.',
+    leaveWith: 'A four-role agent team canvas, first AGENTS/SKILL/SOP skeleton, and one human approval gate.',
+    artifact: 'Agentic Team Canvas',
+    sessionArc: [
+      {
+        minutes: '0–18',
+        title: 'Show the real system',
+        detail: 'Inspect how roles, instructions, evidence, and approvals compose in Frank’s working agent estate.',
+      },
+      {
+        minutes: '18–42',
+        title: 'Decompose one workflow',
+        detail: 'Separate judgment, creation, mechanics, verification, and the handoff between them.',
+      },
+      {
+        minutes: '42–72',
+        title: 'Write the team contract',
+        detail: 'Define four roles, their tools, shared knowledge, stop conditions, and human gates.',
+      },
+      {
+        minutes: '72–90',
+        title: 'Start the first week',
+        detail: 'Choose one bounded task and schedule the review that will keep the system honest.',
+      },
+    ],
+    deliverables: [
+      'Four-role team canvas',
+      'AGENTS.md starter',
+      'SKILL.md / SOP skeleton',
+      'Human approval gate',
+      'Weekly review cadence',
+    ],
+    frankRole:
+      'Lead architect: live system walkthrough, role decomposition, governance, and first-task design.',
+    anaInvitation:
+      'Producer and role-clarity reviewer. If she chooses, Ana can challenge whether responsibilities remain legible to the humans around the system.',
+    proofLinks: [
+      {
+        label: 'AI Architecture',
+        href: '/ai-architecture',
+        note: 'Inspectable architecture patterns behind the session.',
+      },
+      {
+        label: 'Agentic Builder Lab',
+        href: '/agentic-builder-lab',
+        note: 'The applied builder route.',
+      },
+      {
+        label: 'ACOS',
+        href: '/acos',
+        note: 'Frank’s personal AI operating-system work.',
+      },
+    ],
+    aftercare: [
+      'Starter files and annotated canvas',
+      'Optional 48-hour first-task review',
+      'Day-7 team health check',
+    ],
+    testHypothesis:
+      'Frank’s actual operating model is more differentiated than a generic AI-agent tutorial and creates a natural path into implementation work.',
+    followOn: 'Personal AI CoE install, founder command sprint, or a private agent-team architecture engagement.',
+  },
+  {
+    slug: 'human-agent-team-charter',
+    title: 'Human + Agent Team Charter',
+    shortTitle: 'Team Charter',
+    eyebrow: 'People + systems route',
+    promise: 'Decide what agents may do, what humans must own, and how the team knows the difference.',
+    description:
+      'A joint-ready B2B format that turns an abstract AI ambition into roles, escalation, knowledge ownership, and clear human accountability.',
+    audience: 'Founders, team leads, and people leaders introducing agents into real shared work.',
+    personas: ['team', 'people', 'founder'],
+    outcomes: ['team-system', 'direction'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'emerald',
+    reviewRank: 4,
+    arriveWith: 'One team workflow where ownership or AI use is currently ambiguous.',
+    leaveWith: 'A one-page charter covering roles, human-only decisions, data boundaries, escalation, and review.',
+    artifact: 'Human + Agent Team Charter',
+    sessionArc: [
+      {
+        minutes: '0–20',
+        title: 'Name the work and the risk',
+        detail: 'Choose one workflow and identify where speed, quality, privacy, or accountability can break.',
+      },
+      {
+        minutes: '20–45',
+        title: 'Map responsibilities',
+        detail: 'Assign human, agent, shared, and prohibited responsibilities without hiding the handoffs.',
+      },
+      {
+        minutes: '45–72',
+        title: 'Write the operating agreement',
+        detail: 'Set knowledge sources, evidence requirements, escalation, and human approval boundaries.',
+      },
+      {
+        minutes: '72–90',
+        title: 'Choose the trial',
+        detail: 'Define a reversible 30-day team experiment and the evidence needed to continue.',
+      },
+    ],
+    deliverables: [
+      'Responsibility map',
+      'Human-only decision list',
+      'Data and knowledge boundary',
+      'Escalation rule',
+      '30-day trial',
+    ],
+    frankRole:
+      'System architect: agent roles, governance, shared knowledge, evidence, and reversible rollout.',
+    anaInvitation:
+      'Potential true co-creator: people-operations questions, role clarity, and participant experience. Her title, module, and public credit remain hers to approve.',
+    proofLinks: [
+      {
+        label: 'AI Architecture',
+        href: '/ai-architecture',
+        note: 'Architecture and governance sources already visible.',
+      },
+      {
+        label: 'Personal AI CoE',
+        href: '/workshops/personal-ai-coe',
+        note: 'The six-pillar source pattern at personal scale.',
+      },
+      {
+        label: 'Research library',
+        href: '/library',
+        note: 'The shared-knowledge discipline behind the charter.',
+      },
+    ],
+    aftercare: [
+      'Editable charter template',
+      'Optional 48-hour team review prompt',
+      'Day-7 evidence check for the selected trial',
+    ],
+    testHypothesis:
+      'People leaders want a concrete human-accountability contract more than another AI adoption presentation.',
+    followOn: 'Private team charter workshop, AI operating-model sprint, or Ana-led people/role engagement.',
+  },
+  {
+    slug: 'founder-integration-salon',
+    title: 'Founder Integration Salon',
+    shortTitle: 'Integration Salon',
+    eyebrow: 'Retreat discovery route',
+    promise: 'Turn a week of insight into one decision, one practice, and two useful relationships.',
+    description:
+      'A quiet, curated salon for founders who do not need another framework. The room uses confidentiality, peer questions, and a compact integration card to convert signal into Monday decisions.',
+    audience: 'Founders and operators who value depth, discretion, and useful peer connection.',
+    personas: ['integration', 'founder'],
+    outcomes: ['direction', 'workflow'],
+    duration: '90 minutes',
+    capacity: '8–10 people',
+    accent: 'amber',
+    reviewRank: 5,
+    arriveWith: 'One decision you do not want to carry home unresolved.',
+    leaveWith: 'A founder integration card, one next move, and two consent-based peer connections.',
+    artifact: 'Founder Integration Card',
+    sessionArc: [
+      {
+        minutes: '0–15',
+        title: 'Arrival and confidentiality',
+        detail: 'Set the boundary: no pitching, no unsolicited coaching, and no stories repeated outside the room.',
+      },
+      {
+        minutes: '15–48',
+        title: 'Three founder clinics',
+        detail: 'Use precise peer questions to separate the decision, the fear, the evidence, and the reversible move.',
+      },
+      {
+        minutes: '48–72',
+        title: 'Integration card',
+        detail: 'Write the decision, what stops, what starts, one weekly practice, and one request for support.',
+      },
+      {
+        minutes: '72–90',
+        title: 'Connection with consent',
+        detail: 'Make only the introductions people explicitly choose and close without a sales pitch.',
+      },
+    ],
+    deliverables: [
+      'One clarified decision',
+      'Start / stop boundary',
+      'One weekly practice',
+      'Consent-based peer connections',
+    ],
+    frankRole: 'Host and systems integrator: decision structure, peer clinic, and operating commitment.',
+    anaInvitation:
+      'Executive producer and hospitality lead, entirely offstage if preferred. An optional reflective prompt can be co-designed only if she wants it.',
+    proofLinks: [
+      {
+        label: 'Conscious AI operating systems',
+        href: '/research/conscious-ai-operating-systems',
+        note: 'The reflection-to-system research lane.',
+      },
+      {
+        label: 'AI contemplative practice',
+        href: '/research/ai-contemplative-practice',
+        note: 'A source-aware bridge between attention and tools.',
+      },
+      {
+        label: 'FrankX Library',
+        href: '/library',
+        note: 'The books and field notes informing the salon.',
+      },
+    ],
+    aftercare: [
+      'Private integration-card copy',
+      'Chosen introductions only',
+      'Optional Day-7 decision check',
+    ],
+    testHypothesis:
+      'A low-tech, high-trust salon is the fastest safe way to learn whether a deeper Starlight Retreat format deserves to exist.',
+    followOn: 'A later founder circle or Starlight Retreat discovery conversation—never pitched inside the salon.',
+  },
+  {
+    slug: 'purpose-without-performance',
+    title: 'Purpose Without Performance',
+    shortTitle: 'Purpose, Quietly',
+    eyebrow: 'Message test',
+    promise: 'Find language for your next chapter without turning yourself into a content persona.',
+    description:
+      'A quieter alternative to “personal branding”: evidence, values, audience-of-one, and three small proof artifacts instead of constant visibility.',
+    audience: 'Creators and professionals who want expression without performative self-promotion.',
+    personas: ['creator', 'integration'],
+    outcomes: ['direction', 'artifact'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'amber',
+    reviewRank: null,
+    arriveWith: 'A transition, tension, or body of work you are trying to name.',
+    leaveWith: 'A positioning sentence, audience-of-one, and three proof artifacts sized for one month.',
+    artifact: 'Quiet Authority Map',
+    sessionArc: [
+      { minutes: '0–20', title: 'Evidence', detail: 'Name real moments, strengths, service, and constraints.' },
+      { minutes: '20–45', title: 'Position', detail: 'Write who the work is for, what changes, and what you refuse.' },
+      { minutes: '45–70', title: 'Express', detail: 'Design three small artifacts that prove the work without feeding a content treadmill.' },
+      { minutes: '70–90', title: 'Choose', detail: 'Select one artifact and a humane publishing cadence.' },
+    ],
+    deliverables: ['Positioning sentence', 'Audience-of-one', 'Three proof artifacts', 'One-month cadence'],
+    frankRole: 'Lead facilitator: purpose, positioning, evidence, and expression system.',
+    anaInvitation: 'Optional values and audience-empathy review, or producer-only mode.',
+    proofLinks: [
+      { label: 'Ikigai & Branding', href: '/workshops/ikigai-branding', note: 'The existing synthesis engine.' },
+      { label: 'Creator route', href: '/for/creators', note: 'The practical creator path.' },
+    ],
+    aftercare: ['Artifact template', 'Optional 48-hour language review', 'Day-7 expression check'],
+    testHypothesis: '“Purpose without performance” may resonate more strongly than “personal branding” with this audience.',
+    followOn: 'Quiet-authority content sprint or creator operating-system install.',
+  },
+  {
+    slug: 'voice-before-volume',
+    title: 'Voice Before Volume',
+    shortTitle: 'Voice Charter',
+    eyebrow: 'Responsible creator-AI route',
+    promise: 'Write the voice and claim rules your AI must follow before it creates at scale.',
+    description:
+      'Build a compact voice charter, prohibited-claims list, source rule, and review checklist using your own examples.',
+    audience: 'Founders and creators who can generate quickly but no longer trust the consistency of the output.',
+    personas: ['creator', 'founder', 'team'],
+    outcomes: ['artifact', 'team-system'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'cyan',
+    reviewRank: null,
+    arriveWith: 'Two examples that sound like you and one that clearly does not.',
+    leaveWith: 'A voice charter, claim boundary, source rule, and publish checklist.',
+    artifact: 'Voice + Claims Charter',
+    sessionArc: [
+      { minutes: '0–20', title: 'Hear the difference', detail: 'Compare real examples and extract the useful distinctions.' },
+      { minutes: '20–45', title: 'Write the voice', detail: 'Define rhythm, stance, proof, exclusions, and audience.' },
+      { minutes: '45–70', title: 'Govern the claims', detail: 'Set source, uncertainty, privacy, and review boundaries.' },
+      { minutes: '70–90', title: 'Test the charter', detail: 'Run one draft through the rules and tighten what fails.' },
+    ],
+    deliverables: ['Voice charter', 'Prohibited-claims list', 'Source rule', 'Publish checklist'],
+    frankRole: 'Editorial systems lead: voice extraction, claim governance, and live test.',
+    anaInvitation: 'Optional human-language and privacy lens; producer-only remains the default.',
+    proofLinks: [
+      { label: 'FrankX Research', href: '/research', note: 'Source discipline in public.' },
+      { label: 'Prompt Library', href: '/prompt-library', note: 'Prompts that can carry the charter.' },
+    ],
+    aftercare: ['Editable charter', 'One optional live-draft review', 'Day-7 consistency check'],
+    testHypothesis: 'Governance and voice may be a stronger creator pain than another generation tutorial.',
+    followOn: 'Voice OS audit, research-to-content sprint, or team editorial governance workshop.',
+  },
+  {
+    slug: 'personal-ai-coe-one-page',
+    title: 'Personal AI CoE on One Page',
+    shortTitle: 'Personal AI CoE',
+    eyebrow: 'Advanced operator route',
+    promise: 'Create the charter, tool policy, knowledge sources, and review cadence for your personal AI system.',
+    description:
+      'The six-pillar enterprise CoE pattern, reduced to one useful page and no terminal requirement.',
+    audience: 'Advanced creators and operators who need governance more than another tool.',
+    personas: ['founder', 'team'],
+    outcomes: ['workflow', 'team-system'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'cyan',
+    reviewRank: null,
+    arriveWith: 'Your current AI tools and one failure mode you do not want to repeat.',
+    leaveWith: 'A six-pillar personal charter, tool policy, source map, and weekly review.',
+    artifact: 'Personal AI CoE One-Pager',
+    sessionArc: [
+      { minutes: '0–20', title: 'See the pattern', detail: 'Inspect the six CoE pillars and why they exist.' },
+      { minutes: '20–45', title: 'Mirror the scale', detail: 'Translate strategy, governance, talent, technology, data, and ethics to one person.' },
+      { minutes: '45–72', title: 'Write the one-pager', detail: 'Make the policy and source choices concrete.' },
+      { minutes: '72–90', title: 'Install the cadence', detail: 'Schedule a weekly review and one bounded improvement.' },
+    ],
+    deliverables: ['Six-pillar charter', 'Tool policy', 'Source map', 'Weekly review'],
+    frankRole: 'Lead architect: enterprise pattern, personal mirror, and governance review.',
+    anaInvitation: 'Optional people and values question, or producer-only mode.',
+    proofLinks: [
+      { label: 'Personal AI CoE workshop', href: '/workshops/personal-ai-coe', note: 'The full existing 90-minute format.' },
+      { label: 'ACOS', href: '/acos', note: 'The public operating-system surface.' },
+    ],
+    aftercare: ['One-pager template', 'Optional 48-hour policy review', 'Day-7 cadence check'],
+    testHypothesis: 'Removing terminal setup makes Frank’s strongest architecture accessible to the MVU audience.',
+    followOn: 'Personal AI CoE install or founder operating-system sprint.',
+  },
+  {
+    slug: 'role-clarity-agent-era',
+    title: 'Role Clarity in the Agent Era',
+    shortTitle: 'Role Clarity',
+    eyebrow: 'Ana thought-leadership route',
+    promise: 'Redesign one role before automation quietly redesigns it for you.',
+    description:
+      'Map human judgment, agent assistance, shared work, prohibited delegation, and the 30-day trial that makes a role change observable.',
+    audience: 'People leaders, recruiters, founders, and team leads working through real role ambiguity.',
+    personas: ['people', 'team'],
+    outcomes: ['direction', 'team-system'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'emerald',
+    reviewRank: null,
+    arriveWith: 'One real role or responsibility that AI is already changing.',
+    leaveWith: 'A human/agent responsibility scorecard, non-delegable judgment list, and reversible 30-day trial.',
+    artifact: 'Role Clarity Scorecard',
+    sessionArc: [
+      { minutes: '0–20', title: 'Describe the real role', detail: 'Start from outcomes, decisions, relationships, and evidence—not the old task list.' },
+      { minutes: '20–48', title: 'Map responsibility', detail: 'Separate human, assisted, shared, and prohibited work.' },
+      { minutes: '48–72', title: 'Protect accountability', detail: 'Name ownership, escalation, privacy, and review.' },
+      { minutes: '72–90', title: 'Run a trial', detail: 'Choose a reversible change and the evidence that will decide its future.' },
+    ],
+    deliverables: ['Role outcome map', 'Responsibility scorecard', 'Human-only judgment list', '30-day trial'],
+    frankRole: 'Agent architecture and governance contributor.',
+    anaInvitation:
+      'Potential subject lead for the people/HR lens after she approves the scope, public wording, examples, and commercial ownership. No legal or psychological advice is implied.',
+    proofLinks: [
+      { label: 'AI Architecture', href: '/ai-architecture', note: 'The agent and governance layer.' },
+      { label: 'FrankX Library', href: '/library', note: 'The source and learning layer.' },
+    ],
+    aftercare: ['Editable scorecard', 'Optional trial review', 'Day-7 role evidence check'],
+    testHypothesis: 'A concrete role-design artifact can become Ana’s credible bridge into HR thought leadership and future agency work.',
+    followOn: 'Ana-owned HR/recruiting engagement, joint people + AI workshop, or team operating-model sprint.',
+  },
+  {
+    slug: 'calm-work-architecture',
+    title: 'Calm Work Architecture',
+    shortTitle: 'Calm Work',
+    eyebrow: 'Integration route',
+    promise: 'Move work off your mind without moving judgment out of human hands.',
+    description:
+      'Design an energy-aware week, explicit AI offload boundaries, two recovery buffers, and a review ritual—without medical or neurological claims.',
+    audience: 'Overloaded founders and creators who need a better operating week, not a productivity contest.',
+    personas: ['integration', 'founder', 'creator'],
+    outcomes: ['workflow', 'direction'],
+    duration: '90 minutes',
+    capacity: '8–12 people',
+    accent: 'amber',
+    reviewRank: null,
+    arriveWith: 'A normal week and one pattern that repeatedly drains attention.',
+    leaveWith: 'A weekly heat map, AI offload boundary, two buffers, and a 20-minute review ritual.',
+    artifact: 'Calm Work Week Map',
+    sessionArc: [
+      { minutes: '0–20', title: 'Map the week', detail: 'See where attention, coordination, and recovery currently break.' },
+      { minutes: '20–45', title: 'Set the boundary', detail: 'Choose what AI can assist, what stays human, and what stops entirely.' },
+      { minutes: '45–70', title: 'Rebuild the rhythm', detail: 'Place focus blocks, buffers, and one shared capture point.' },
+      { minutes: '70–90', title: 'Review the system', detail: 'Write the weekly 20-minute review that keeps the plan alive.' },
+    ],
+    deliverables: ['Weekly heat map', 'AI offload boundary', 'Two recovery buffers', 'Review ritual'],
+    frankRole: 'Operating-system designer: workload map, agent boundary, and cadence.',
+    anaInvitation:
+      'Optional grounding or people-operations questions after explicit approval. No therapy, IFS, neuroscience, or health outcome is claimed.',
+    proofLinks: [
+      { label: 'AI contemplative practice', href: '/research/ai-contemplative-practice', note: 'Source-aware attention and AI work.' },
+      { label: 'Conscious AI operating systems', href: '/research/conscious-ai-operating-systems', note: 'The operating-system bridge.' },
+    ],
+    aftercare: ['Week-map export', 'Optional 48-hour implementation prompt', 'Day-7 cadence check'],
+    testHypothesis: 'A calm operating promise can open the retreat and people-work pipeline without making clinical claims.',
+    followOn: 'Personal AI CoE, integration circle, or later retreat discovery.',
+  },
+] as const satisfies readonly TallinnExperience[]
+
+export const tallinnReviewExperiences = tallinnExperiences.filter(
+  (experience) => experience.reviewRank !== null,
+)
+
+export function getTallinnExperience(slug: string) {
+  return tallinnExperiences.find((experience) => experience.slug === slug)
+}

--- a/docs/premium-web-os/tallinn-experience-foundry-design-loop-evidence.json
+++ b/docs/premium-web-os/tallinn-experience-foundry-design-loop-evidence.json
@@ -1,0 +1,127 @@
+{
+  "version": "1.0",
+  "task": "Build a premium unlisted Tallinn workshop foundry and ten offer routes",
+  "surface": "/experiences/tallinn-2026 and ten artifact-led offer pages",
+  "audience": "Mindvalley U attendees in Tallinn, creators, founders, team leads, and people leaders",
+  "standards": [
+    "DESIGN_TASTE.md",
+    "WEB_EXPERIENCE_STANDARD.md",
+    "MOTION_TASTE_RUBRIC.md",
+    "MULTI_AGENT_DESIGN_COUNCIL.md",
+    "VISUAL_QA_GATE.md",
+    "design-agent-standards/PREMIUM_ASSET_STANDARD.md",
+    "design-agent-standards/AGENT_WARMUP_PROTOCOL.md",
+    "design-agent-standards/AGENTIC_DESIGN_LOOP.md",
+    "design-agent-standards/OUTCOMES.md",
+    "_intelligence/operating-system.md",
+    "_intelligence/taste.md",
+    "_intelligence/design.md",
+    "_intelligence/motion.md",
+    "_intelligence/quality-gates.md",
+    "_intelligence/brand-worlds.md"
+  ],
+  "references": [
+    "FrankX brand pack: obsidian base, disciplined cyan/amber/emerald signals, editorial typography",
+    "Premium council direction: one foundry hub, outcome router, editorial offer index, no marketplace wall",
+    "Exact-system visual: Human to Practice to System to Team",
+    "Real FrankX research, library, workshop, and agent architecture routes as proof"
+  ],
+  "direction": {
+    "keep": [
+      "literal artifact-led promise",
+      "one strong first-viewport system map",
+      "editorial offer index",
+      "visible operational truth and independence disclaimer",
+      "static composition with progressive enhancement"
+    ],
+    "avoid": [
+      "ten-card marketplace hero",
+      "generic retreat imagery",
+      "fake workshop proof",
+      "Mindvalley affiliation styling",
+      "decorative 3D, orbit, node, or neural-cosmos filler",
+      "unapproved Ana claims or forced visibility"
+    ],
+    "signature": "Leave Tallinn with one thing running, expressed through the Human to Practice to System to Team artifact map",
+    "system": "One data registry generates the hub, outcome recommendations, ten pages, artifact timelines, proof links, host lanes, and demand forms"
+  },
+  "asset_quality": {
+    "tier": "C",
+    "source_method": "vector-diagram",
+    "provenance": "owned",
+    "why_premium": "The primary visual is the exact workshop mechanism rendered as accessible HTML/CSS, not decorative media or an invented event photograph.",
+    "shortcut_risk": "low",
+    "context_tested": false
+  },
+  "artifacts": [
+    {
+      "path_or_url": "app/experiences/tallinn-2026/page.tsx",
+      "kind": "hub route",
+      "inspected": false
+    },
+    {
+      "path_or_url": "app/experiences/tallinn-2026/[slug]/page.tsx",
+      "kind": "ten generated offer routes",
+      "inspected": false
+    },
+    {
+      "path_or_url": "components/tallinn-experience/TallinnFoundryPage.tsx",
+      "kind": "premium editorial web surface",
+      "inspected": false
+    },
+    {
+      "path_or_url": "components/tallinn-experience/ExperienceRouter.tsx",
+      "kind": "interactive outcome router",
+      "inspected": false
+    }
+  ],
+  "checks": [
+    {
+      "name": "asset-tier",
+      "status": "pass",
+      "evidence": "Tier C exact system diagram is the correct medium; no unverified image is shipped."
+    },
+    {
+      "name": "claims-and-affiliation",
+      "status": "pass",
+      "evidence": "Independence, venue status, Ana role choice, and clinical claim boundaries are visible."
+    },
+    {
+      "name": "responsive-layout",
+      "status": "blocked",
+      "evidence": "Awaiting browser inspection at desktop and 390px mobile."
+    },
+    {
+      "name": "reduced-motion",
+      "status": "pass",
+      "evidence": "No essential animation, GSAP, WebGL, video, or scrolling runtime is introduced."
+    },
+    {
+      "name": "accessibility",
+      "status": "blocked",
+      "evidence": "Semantic and focus states are implemented; awaiting browser and automated verification."
+    },
+    {
+      "name": "export-inspection",
+      "status": "blocked",
+      "evidence": "Awaiting actual preview screenshots."
+    },
+    {
+      "name": "performance",
+      "status": "blocked",
+      "evidence": "No heavy runtime added; awaiting production build and preview verification."
+    }
+  ],
+  "score": {
+    "total": 25,
+    "max": 30,
+    "breakdown": {
+      "concept_and_specificity": 6,
+      "hierarchy_and_composition": 5,
+      "brand_and_asset_quality": 5,
+      "interaction_and_accessibility": 5,
+      "verification_and_release": 4
+    }
+  },
+  "decision": "iterate"
+}

--- a/docs/specs/tallinn-experience-foundry-scene-brief-2026-07-14.md
+++ b/docs/specs/tallinn-experience-foundry-scene-brief-2026-07-14.md
@@ -1,0 +1,106 @@
+# Tallinn Experience Foundry — page and scene brief
+
+Date: 2026-07-14
+
+Status: implementation brief for private review
+Owner: Codex FrankX Tallinn Experience Foundry lane
+
+## Problem and audience
+
+Frank has six days before Mindvalley U begins in Tallinn. He needs one credible way to test demand for a small independent workshop without implying an official Mindvalley relationship, booking a room before demand exists, or asking Ana to become a public facilitator before she chooses that role.
+
+The first audience is a warm, high-intent group of creators, solo founders, team leaders, and people leaders who will already be in Tallinn. They do not need another talk. They need a compact working room and a useful artifact they can carry into the rest of the event.
+
+## Product decision
+
+Build one Experience Foundry with:
+
+- one hub at `/experiences/tallinn-2026`;
+- ten data-driven offer pages at `/experiences/tallinn-2026/[slug]`;
+- five offers marked for Frank + Ana review on 2026-07-15;
+- one shared interest and qualification form;
+- one transparent validation rule: eight compatible confirmations before any room commitment;
+- no checkout, room booking, email campaign, public counter, or automated follow-up in this release.
+
+All pages remain `noindex` until Frank and Ana approve the offer, roles, claims, timing, and venue.
+
+## First viewport
+
+Eyebrow: `Tallinn · 20 July–2 August 2026 · independent field lab`
+
+Headline: `Leave Tallinn with one thing running.`
+
+Deck: a small-room working-session promise, not a conference or inspiration claim.
+
+Primary action: `Find your format`, anchored to the outcome router.
+Trust line: venue not booked; interest first; independent of Mindvalley.
+
+The right side is a Tier C exact product surface: a four-stage operating map labelled `human → practice → system → team`. It is not a fake dashboard. Selecting a visitor context changes the recommended session, the artifact made in the room, and the proof route they can inspect now.
+
+## Signature interaction
+
+The outcome router has five explicit contexts:
+
+1. creator;
+2. solo founder;
+3. team lead;
+4. people / HR leader;
+5. integration-minded participant.
+
+The control uses real button semantics, visible focus, and a static first recommendation in server-rendered HTML. Motion is limited to color and border transitions. With reduced motion, nothing animates and no information is lost.
+
+## Page rhythm
+
+1. Independent field-lab hero and real operating map.
+2. Experience Compass.
+3. Five review-first sessions as an editorial numbered sequence.
+4. The remaining five validation pages as a compact offer index, not a card wall.
+5. Frank / Ana role architecture: Frank leads; Ana can choose producer, host, contributor, or observer without a spotlight obligation.
+6. Demand-to-room gate: interest → compatible confirmations → human venue approval → confirmed session.
+7. Tallink-first venue logic and explicit unconfirmed status.
+8. Shared request form and privacy boundary.
+9. Independent-event disclaimer and source links.
+
+Each offer page repeats only what is needed to decide: promise, who it is for, 90-minute arc, artifact, proof already live, collaborator invitation, venue gate, and request form.
+
+## Visual system
+
+- Brand: FrankX, dark-first.
+- Spectrum: bridge world with amber as the human signal and cyan as the system signal; both may appear in the operating map, but a section has one dominant signal.
+- Canvas: `#0a0a0b`, hairline white borders, warm off-white copy, cyan primary action.
+- Typography: existing Poppins display, Inter body, JetBrains Mono for labels.
+- Shape: rounded-full primary action; large-radius material surfaces only where they group a workflow.
+- Density: editorial rows and one large system surface; no grid of ten equal cards.
+- Imagery: none required. Tier A proof is the existing Ikigai workshop, research, prompt library, ACOS, and AI architecture routes. Tier C is the exact interactive recommendation map.
+
+## Responsive behavior
+
+- Desktop: split hero; sticky or adjacent operating map; editorial two-column session rows.
+- Tablet: hero stacks; compass remains horizontal-scroll-free.
+- Mobile: headline, promise, primary action, and unconfirmed-venue truth fit before the operating map; all controls are at least 44px high; session rows become single-column.
+- No horizontal overflow at 320px.
+
+## Performance and accessibility budgets
+
+- No WebGL, video, autoplay, generated hero, external font, or new runtime dependency.
+- Server-render all offer and proof content.
+- Client JavaScript is limited to the compass and interest form.
+- Visible focus, native labels, live submission status, useful error text, and no color-only status.
+- Respect `prefers-reduced-motion`; text never animates.
+- LCP target below 2.5s on a normal preview route; CLS target below 0.1.
+
+## Claims and approval boundaries
+
+- Say `independent session in Tallinn`, never `official Mindvalley workshop` unless Mindvalley approves it through its application path.
+- Do not use Mindvalley logos or imply access to its venue, agenda, attendees, or facilities.
+- Do not publish psychology, IFS, therapist, neuroscientist, or health-outcome claims for Ana without verified credentials and her explicit approval.
+- Ikigai is described as a modern reflection scaffold inspired by a broader Japanese idea of everyday meaning, not an ancient four-circle formula.
+- Ana is presented as a co-design invitation, not a confirmed speaker.
+
+## Release gates
+
+- Static route and registry invariants pass for one hub, ten pages, and five review-first offers.
+- Typecheck, scoped lint, claims audit, static internal-link check, and production build pass.
+- Desktop and mobile screenshots are inspected; keyboard and reduced-motion routes are checked.
+- `design-loop-evidence.json` reaches at least 26/30.
+- An independent verifier reviews the implementation before the preview is presented as release-ready.

--- a/docs/specs/tallinn-experience-operations-2026-07-14.md
+++ b/docs/specs/tallinn-experience-operations-2026-07-14.md
@@ -1,0 +1,359 @@
+# Tallinn Experience Foundry — operating plan
+
+**Status:** review-safe implementation; no venue, spend, external message, or live capture approved
+
+**Decision owner:** Frank
+
+**Proposed operator:** Ana, only in the role she accepts
+
+**Recommended pilot:** Purpose to Practice
+**Target session windows:** 21–23 July 2026, after comparison with the official agenda
+
+## 1. Command decision
+
+Build and review now; validate demand before booking; run one excellent room; use the evidence to decide whether a repeatable workshop, B2B offer, or retreat line deserves investment.
+
+The fastest credible sequence is:
+
+```text
+30 concepts → 10 unlisted pages → 5 reviewed with Ana → 1 demand test
+→ 1 time reconfirmed → 1 venue decision → 1 artifact-led session
+→ Day-7 evidence → next offer only by participant request
+```
+
+Do not call it a Mindvalley workshop. A formal Mindvalley session requires their application and approval. The independent format must retain the affiliation disclaimer on every route and in every invitation.
+
+## 2. Six-day launch calendar
+
+| Date | Decision / action | Owner | Done when |
+|---|---|---|---|
+| **Tue 14 Jul** | Build private preview, ten pages, request simulation, portfolio, runbook | Frank/Codex | Preview is reviewable; no personal data can be stored |
+| **Wed 15 Jul** | 45-minute Ana review of five formats | Frank + Ana | One format, one Ana role, one audience, and claims line chosen |
+| **Wed 15 Jul** | Revise the winning page and facilitation artifact | Frank | One page and one printable artifact are session-ready |
+| **Thu 16 Jul** | Frank approves wording, privacy notice, recipient list, and whether to open live capture | Frank | Written go/no-go; external send remains human-performed |
+| **Thu–Fri 16–17 Jul** | Bounded demand test to trusted attendees | Frank | Qualified interest by format and time is visible; no community spam |
+| **Sat 18 Jul** | Reconfirm the strongest format and one time | Frank | 8 reconfirmed + 2 standby or explicit stop |
+| **Sat 18 Jul** | Request a Tallink two-hour room-only resident quote / courtesy hold | Frank or Ana after approval | Written cost, capacity, equipment, cancellation, access, VAT, and hold expiry |
+| **Sun 19 Jul** | Venue decision by 18:30 Tallinn time | Frank | Book with approval or release cleanly; final logistics sent only if booked |
+| **Tue–Thu 21–23 Jul** | Run one 90-minute pilot | Frank; Ana in accepted role | Artifact completion and safety close completed |
+| **+48h / Day 7** | Consent-based implementation and evidence check | Frank; Ana only if agreed | Use, friction, referrals, and requested next problem recorded |
+
+If the official agenda makes all three windows unsuitable, do not squeeze the workshop into a bad slot. Offer “another window” or defer to a later online/Tallinn format.
+
+## 3. Funnel and data architecture
+
+### Participant journey
+
+```text
+Unlisted hub
+  → outcome router (role + desired leave-with)
+  → primary + alternative session
+  → exact offer page
+  → interest request (not booking)
+  → manual demand review
+  → one-time reconfirmation
+  → venue/spend decision
+  → final logistics
+  → session artifact
+  → optional +48h and Day-7 aftercare
+```
+
+### Request fields
+
+Collect only what is needed to evaluate and coordinate the session:
+
+- name and email;
+- selected experience;
+- creator / solo-founder / team-leader / people-ops / other lens;
+- exploring / likely / ready-if-time-works intent;
+- one to three compatible windows;
+- optional company/project and practical desired outcome;
+- explicit consent to store/contact for this session;
+- separate optional consent for artifact and Day-7 aftercare;
+- experiment variant and random submission ID;
+- hidden honeypot for abuse filtering.
+
+The form explicitly asks participants not to submit health, therapy, employment-case, or other sensitive details.
+
+### Review-safe mode
+
+When either condition is true—`VERCEL_ENV !== production` or `TALLINN_CAPTURE_MODE !== live`—the endpoint:
+
+- accepts only an `@example.com` test address;
+- validates the full payload;
+- stores nothing;
+- calls no Notion, Resend, Slack, KV, or marketing service;
+- returns a clear simulated receipt.
+
+This lets Frank and Ana test the entire experience safely on a Vercel preview.
+
+### Proposed live storage
+
+If Frank later approves live capture:
+
+1. `POST /api/tallinn-interest` validates and rate-limits the request.
+2. The service checks a Notion record by an idempotent source key.
+3. Notion becomes the primary durable inquiry record.
+4. Only after storage succeeds, Resend may send a transactional participant receipt and operator notice.
+5. No newsletter audience is updated and no follow-up automation is scheduled.
+6. Logs contain format, variant, counts, and status—not name, email, company, or notes.
+
+Required variables: `TALLINN_CAPTURE_MODE=live`, `NOTION_TOKEN` (or the existing transitional `NOTION_API_KEY`), `NOTION_INQUIRIES_DB_ID`, and optionally `RESEND_API_KEY` plus `OPERATOR_EMAIL`.
+
+### Privacy activation blocker
+
+Live personal-data capture must remain closed until Frank approves a canonical privacy notice that names:
+
+- Notion as the inquiry store and Resend as the transactional email processor, where applicable;
+- the controller and contact route;
+- the purpose and lawful basis for session coordination;
+- retention/deletion period;
+- participant rights and withdrawal route;
+- whether Ana receives participant information.
+
+Ana receives no participant data by default. If she needs operational access, document the minimum fields, purpose, retention, security, controller/processor roles, and participant notice first.
+
+## 4. Demand experiment design
+
+### Test order
+
+Do not distribute ten URLs at once. That fragments an already small sample.
+
+1. **Ana qualitative review:** five pages, all in preview mode.
+2. **Demand wave A:** Purpose to Practice to the broad trusted circle.
+3. **Demand wave B:** only if the audience splits clearly, route creator traffic to Agentic Creator Studio and founder traffic to Build Your Agentic Team.
+4. **B2B discovery:** share Human + Agent Team Charter only in direct, relevant conversations—not as a broad event promotion.
+5. **Retreat discovery:** invite a few suitable founders to the Integration Salon page; do not sell a retreat.
+
+### Tracking convention
+
+Use a clean query value that the API stores as `variantId`:
+
+- `?variant=ana-review`
+- `?variant=trusted-founder`
+- `?variant=trusted-creator`
+- `?variant=people-leader`
+- `?variant=retreat-discovery`
+
+No third-party behavioral tracker is required for the pilot. Count intentional requests in the inquiry store and compare qualitative notes manually.
+
+### Decision metrics
+
+| Metric | Definition | Pilot signal |
+|---|---|---:|
+| Qualified ready interest | `ready-if-time-works` with at least one viable window | ≥ 8 for one format/time |
+| Standby depth | Additional reconfirmed people | ≥ 2 |
+| Reconfirmation rate | Reconfirmed / likely + ready requests | ≥ 65% |
+| Show rate | Arrivals / confirmed | ≥ 80% |
+| Artifact completion | Participants who leave with usable artifact | ≥ 80% |
+| Day-7 use | Consenting participants who used or revised artifact | ≥ 50% |
+| Earned next-step signal | Participant asks for creator, founder, team, HR, or retreat help | Record direction; no hard sell |
+
+Do not treat page views, likes, compliments, or “sounds interesting” as venue demand.
+
+## 5. Venue decision system
+
+### What is known
+
+Tallink Spa & Conference Hotel publicly lists its weekday Neptune package for 10–30 participants. The half-day package is up to four hours at €43 per participant and includes the room, equipment, catering, and spa access. At the ten-person minimum, that is a **€430 public package baseline** before verifying VAT or any custom conditions.
+
+The hotel does not publicly promise a free meeting room to residents. Frank’s stay makes the hotel operationally attractive, not free.
+
+Source: [Tallink Spa & Conference Hotel Conference Center](https://hotels.tallink.com/events/tallink-spa-conference-hotel-conference-center).
+
+### Recommended gate
+
+- Ask first for a two-hour room-only resident quote or courtesy hold.
+- If room-only is **≤ €250**, consider booking only after **8 reconfirmed + 2 standby** at one time.
+- If only the €430 package is available, require **10 reconfirmed** plus Frank’s explicit choice to underwrite or transparently cost-share.
+- Capacity target is 12; never overbook beyond venue/fire rules.
+- Do not use a bedroom or occupy hotel space as an event venue without permission.
+- Frank approves every reservation, deposit, cancellation term, and participant charge.
+
+### Draft venue inquiry — do not send without Frank
+
+**Subject:** Resident inquiry: small 90-minute working session, 21–23 July
+
+> Hello Tallink Spa & Conference team,
+>
+> I am staying at Tallink Spa & Conference Hotel and am validating a small independent working session for 8–12 adults. No room has been promised to participants yet.
+>
+> Could you please quote the smallest suitable private meeting room for a two-hour session, ideally including 30 minutes before and after for setup, for any of these windows:
+>
+> - Tuesday 21 July, 18:30–20:00
+> - Wednesday 22 July, 08:00–09:30
+> - Thursday 23 July, 17:30–19:00
+>
+> Please include room-only and package options, total price including VAT, capacity/layout, screen or display, flipchart, water, access/setup time, cancellation terms, deposit/payment deadline, and whether a short courtesy hold is possible while attendees reconfirm.
+>
+> Thank you,
+> Frank
+
+### Time selection
+
+Test all viable windows in the form but confirm only one. Current priority:
+
+1. Tue 21 Jul, 18:30–20:00 — best for a deliberate first-room feeling if the official agenda allows.
+2. Wed 22 Jul, 08:00–09:30 — best high-intent filter; harder for social-evening fatigue.
+3. Thu 23 Jul, 17:30–19:00 — fallback when the first two conflict.
+
+Verify the official agenda before making any promise.
+
+## 6. Participant experience
+
+### Arrival contract
+
+- The gathering is independent and small.
+- No pitching, unsolicited coaching, or attendee-list harvesting.
+- Personal stories stay in the room; people may share their own artifacts.
+- Participants choose what to disclose and may pass on any prompt.
+- The format is educational and reflective, not therapy, medical care, employment advice, or psychological treatment.
+- AI never receives participant stories or sensitive notes without specific consent.
+
+### Room setup
+
+- One table or open U-shape; no theatre rows.
+- Screen for a ten-minute working-system demonstration, not a 60-slide deck.
+- A3/A4 artifact sheets, pens, sticky notes, timer, water.
+- Printed independence/consent boundary at check-in.
+- No automatic recording. Photography only with explicit per-person agreement and a non-photo seating zone.
+- Ana can operate arrival and room flow without being placed on stage.
+
+### Session standard
+
+Every workshop must:
+
+1. show the finished artifact in the first eight minutes;
+2. spend at least half the room on participant making and review;
+3. name human-only judgment and prohibited delegation;
+4. use real FrankX sources, not fabricated proof;
+5. close with one dated experiment, not a sales pitch;
+6. make follow-up optional and consent-specific.
+
+## 7. Aftercare system
+
+| Timing | Message / artifact | Gate |
+|---|---|---|
+| Submission | Honest receipt and threshold explanation | Session coordination consent |
+| Demand clear | Reconfirm one format and one time | One manual message only |
+| T−24 | Room, access, arrival, what to bring, boundaries | Venue already booked |
+| Same day | Participant artifact, clean template, cited sources | Attendee only |
+| +48h | One implementation prompt | Requested / aftercare consent |
+| Day 7 | “What did you use, change, or abandon?” | Separate aftercare consent |
+| Day 8–10 | Human review of follow-on signals | No automated sales sequence |
+
+The pilot uses manual operator review. No cron, unattended follow-up, newsletter sync, or lead-scoring automation should be activated on short notice.
+
+## 8. Business and pipeline architecture
+
+### Pilot economics
+
+The first room should optimize learning and trust, not maximize ticket revenue. Choose one of these only after demand and venue price are known:
+
+| Model | When to use | Guardrail |
+|---|---|---|
+| Host-funded research room | Room-only ≤ €250 and Frank values the learning | Hard spend cap; no hidden upsell obligation |
+| Exact cost share | Venue requires the €430 package | State the venue contribution transparently; participant charge approved before collection |
+| Complimentary partner room | Hotel explicitly offers it in writing | No implied endorsement; understand conditions |
+| Defer / online follow-up | Gate or economics fail | A clean no-go is a successful test |
+
+No payment flow has been built. Do not collect money until refund/cancellation terms, tax/VAT treatment, payment processor, privacy, and venue liability are approved.
+
+### Future offer ladder — validation ranges, not published prices
+
+| Layer | Frank value | Ana value | Indicative validation range |
+|---|---|---|---:|
+| 90-minute public lab | Facilitation + artifact system | Production or bounded people lens | €49–149 / participant |
+| Private team charter workshop | Agent architecture + governance | Role clarity + people operations | €2,500–5,000 |
+| 2-week implementation sprint | Agent team, knowledgebase, SOP/SKILL setup | Adoption, role, recruiting/HR workstream | €5,000–15,000 |
+| 30-day human + agent team pilot | Architecture, evidence, gates | People operating model and adoption | €10,000–25,000 |
+| 2-day Starlight founder retreat | Systems integration + facilitation | Experience operations + approved human practice | €1,500–3,500 / participant before venue/travel |
+
+These ranges are market hypotheses to validate, not current offers or promises.
+
+### Lead ownership and referral ethics
+
+- A FrankX-originated request stays FrankX operational data unless the participant asks for Ana’s service or consents to an introduction.
+- An Ana-originated HR/recruiting lead stays Ana’s unless a joint AI architecture need is introduced with consent.
+- A genuinely joint workshop lead is tagged joint and reviewed together.
+- No one copies the participant list into another CRM, audience, or agency pipeline by default.
+- Referral fees, revenue share, client ownership, non-solicitation, and case-study rights are written before the first paid joint engagement.
+
+### Earned routes after the pilot
+
+- Creator asks “how do I repeat this?” → GenCreator / Agentic Creator OS discovery.
+- Solo founder asks “can you install the team?” → Agentic Team or Personal AI CoE sprint.
+- Team leader asks “how do we govern this?” → Human + Agent Team Charter workshop.
+- People leader asks “how do roles and hiring change?” → Ana-led HR/recruiting discovery, with consent.
+- Founder asks “can we go deeper in a curated group?” → Starlight Retreat discovery conversation.
+
+## 9. Agentic operating process
+
+```text
+Portfolio registry (10 offers)
+  → generated static routes
+  → human review / claims gate
+  → Vercel preview
+  → request API in no-storage simulation
+  → approved production activation only
+  → Notion inquiry record
+  → manual demand and threshold review
+  → venue decision
+  → session artifact + evidence
+  → Day-7 learning back into the registry
+```
+
+The product registry in `data/tallinn-experiences.ts` is the single source for titles, promises, artifacts, run-of-show, proof links, host lanes, and aftercare. This makes later variants cheap without creating ten divergent one-off pages.
+
+Agent roles for a repeatable system:
+
+| Role | Responsibility | Human gate |
+|---|---|---|
+| Research steward | Verify event, venue, sources, and claim language | Frank approves consequential claims |
+| Offer architect | Score concepts and update registry | Frank + Ana choose portfolio direction |
+| Experience producer | Run room checklist, attendee state, artifact pack | Ana accepts scope; Frank approves spend |
+| Funnel operator | Monitor requests, deduplicate, prepare threshold view | No new data sharing or sends without approval |
+| Artifact steward | Package templates and Day-7 learning | Participant consent and privacy boundary |
+| Independent verifier | Check code, design, accessibility, claims, and gates | Cannot activate production or book venue |
+
+## 10. Ana review agenda — 45 minutes
+
+Send a short note, then review pages live rather than asking her to read a strategy document alone.
+
+| Minutes | Decision |
+|---:|---|
+| 0–5 | “Do we want to test one small room next week, yes or no?” |
+| 5–15 | React to the five pages; select one primary and one future format |
+| 15–23 | Choose Ana mode: producer, bounded contributor, or co-creator |
+| 23–30 | Approve/reject public wording and name any credentials she wants verified later |
+| 30–37 | Pick audience, candidate window, capacity, and venue ceiling |
+| 37–42 | Agree pre-existing IP, joint module, lead/data ownership, and commercial starting point |
+| 42–45 | Assign next 24-hour actions and a stop rule |
+
+### Draft message to Ana — do not send automatically
+
+> Ana, I think we have the beginning of something genuinely useful, but I do not want to turn it into pressure or put you in a spotlight you did not ask for. I built five very different 90-minute room concepts for Tallinn. My recommendation is one small Purpose to Practice pilot: people leave with a Human + AI Practice Map, I facilitate, and you can choose producer-only, one bounded contribution, or true co-creator mode. Could we spend 45 minutes tomorrow choosing whether one deserves a demand test? Nothing is booked, no role is assumed, and we stop if the room or timing does not validate.
+
+## 11. Go / no-go checklist
+
+### Go only if
+
+- Ana’s role and public wording are explicitly accepted;
+- one format and one time reaches the reconfirmation threshold;
+- venue cost, VAT, cancellation, access, equipment, and hold deadline are written;
+- Frank explicitly approves spend and any participant charge;
+- the artifact and facilitator run-of-show are complete;
+- privacy notice and live capture are approved—or Frank coordinates manually without the web form;
+- official agenda compatibility is checked;
+- independence disclaimer is visible in every message and page.
+
+### No-go if
+
+- the pitch depends on calling the session official or implying Mindvalley endorsement;
+- demand is compliments rather than reconfirmed time-compatible attendees;
+- Ana feels pressured into expertise, visibility, claims, or data access;
+- venue terms are vague or require unapproved spend;
+- the session requires clinical, therapy, IFS, neurological, or health claims;
+- the artifact cannot be delivered well by the chosen date.
+
+A no-go is not failure. The ten-page portfolio, demand evidence, artifact, and collaboration decisions remain reusable for a later online session, private team workshop, or Starlight retreat prototype.

--- a/docs/specs/tallinn-purpose-to-practice-facilitator-pack-2026-07-14.md
+++ b/docs/specs/tallinn-purpose-to-practice-facilitator-pack-2026-07-14.md
@@ -1,0 +1,184 @@
+# Purpose to Practice — facilitator pack
+
+**Version:** 0.1 private pilot
+
+**Format:** 90 minutes, 8–12 adults
+
+**Lead:** Frank
+
+**Ana:** producer by default; any contribution is opt-in and agreed before participant communication
+**Artifact:** two-page Human + AI Practice Map
+
+## Promise
+
+Participants leave with one purpose-to-practice sentence, a bounded weekly human + AI workflow, three light agent roles, explicit human-only decisions, and a dated 30-day experiment.
+
+The format is educational and reflective. It is not therapy, IFS, psychological treatment, medical advice, employment advice, or a neurological intervention.
+
+## Room and materials
+
+- Private room for 8–12; one shared table or open U-shape.
+- Screen for a maximum ten-minute demonstration.
+- One printed two-page map per participant plus three spare copies.
+- Dark pen, two sticky-note colors, water, visible timer.
+- Printed affiliation and confidentiality boundary at arrival.
+- No recording. Photography only with explicit per-person consent and a non-photo area.
+- Offline copies of the map and Frank’s example; the workshop does not depend on Wi-Fi.
+
+## Host handoff
+
+### Frank owns
+
+- opening and independence language;
+- ikigai framing and purpose synthesis;
+- working system demonstration;
+- human/agent boundary and 30-day experiment;
+- timekeeping and close.
+
+### Ana may own, only if she chooses
+
+- welcome and room flow;
+- participant arrival, materials, water, and accessibility needs;
+- a two-minute grounding pause in her own approved language;
+- observation notes on clarity, energy, and friction;
+- end-of-room logistics.
+
+Do not introduce Ana with psychology, neuroscience, IFS, therapy, meditation certification, or health language unless she provides and approves the exact evidence and wording.
+
+## Before doors open
+
+- [ ] Venue and outside-guest access are confirmed in writing.
+- [ ] Frank has approved spend, cancellation, capacity, and layout.
+- [ ] One format and time reached the reconfirmation gate.
+- [ ] Ana’s role and public wording are accepted.
+- [ ] Official agenda compatibility was checked.
+- [ ] Participant list is used for logistics only.
+- [ ] Maps are printed and one completed Frank example is ready.
+- [ ] No sensitive participant stories are loaded into an AI tool.
+- [ ] T−24 message was sent only after the room was booked.
+
+## Run of show
+
+### 00:00–00:08 — arrival contract and artifact preview
+
+**Say:**
+
+> Welcome. This is a small independent working room, not an official Mindvalley session. You can pass on any prompt. Share only what you want to share; personal stories stay here, while your own finished map is yours to use. There is no pitch at the end. In ninety minutes, the goal is this exact two-page map and one experiment small enough to begin next week.
+
+Show a finished map. Ask everyone to write only their name and date.
+
+### 00:08–00:18 — ikigai honestly
+
+**Teach in three points:**
+
+1. Ikigai is a broad Japanese idea about what gives value and joy to life; it is not only work.
+2. The familiar love/skill/need/paid four-circle model is a modern reflection scaffold, not an ancient Japanese formula.
+3. The room uses four prompts because they are practical, then adds the missing constraint: what this season can honestly sustain.
+
+No claims about longevity, healing, happiness, or finding one perfect purpose.
+
+### 00:18–00:32 — human-signal evidence
+
+Give 2.5 minutes per quadrant. Ask for examples, not adjectives.
+
+- “When did this happen?”
+- “What did you actually do?”
+- “Who found it useful?”
+- “What can your current season sustain?”
+
+At minute 30, ask participants to circle one phrase in each quadrant.
+
+### 00:32–00:45 — direction and trade-off
+
+Participants write one thing they must reduce or decline. Then complete:
+
+> In this season, I will use [strength] to help [who] move toward [useful change], while protecting [boundary].
+
+Pair review:
+
+- Is there a real person or situation?
+- Can the contribution be observed?
+- Is the boundary believable?
+
+### 00:45–00:55 — Frank’s working-system demonstration
+
+Use one real, non-sensitive example. Show only:
+
+```text
+Human intention
+  → source set
+  → research steward
+  → making partner
+  → verifier
+  → human approval
+  → one inspectable artifact
+```
+
+Name the governing files or patterns—AGENTS.md, SKILL.md, SOP, shared knowledge, evidence, stop conditions—without asking participants to install anything.
+
+### 00:55–01:10 — weekly practice and agent roles
+
+Participants define:
+
+- trigger;
+- human move;
+- smallest useful artifact;
+- evidence;
+- weekly review;
+- research, making, and verification roles;
+- sources the roles may use.
+
+Remind the room: an “agent role” can begin as a repeatable ChatGPT/Claude/Codex conversation. It does not need autonomous software.
+
+### 01:10–01:22 — human-only decisions and stop conditions
+
+Prompt:
+
+- What may no agent publish, promise, spend, send, or decide without you?
+- Which uncertainty, privacy, quality, or impact signal returns the work to a human?
+
+Suggested minimum: public send, money, private data, consequential claims, and decisions affecting another person stay human-approved.
+
+### 01:22–01:28 — 30-day experiment and peer review
+
+The experiment needs a start date, end date, smallest proof, feedback person, and weekly review appointment.
+
+Peer question: “Is it small, reversible, dated, and inspectable?”
+
+### 01:28–01:30 — close
+
+**Say:**
+
+> Your map belongs to you. If you asked for aftercare, I will send the clean map and one implementation prompt; otherwise the only remaining message is session logistics or closure. Before leaving, date the first review. The point is not to automate your purpose. It is to give your intention a practice that can survive ordinary life.
+
+No program pitch. If someone asks for help, note the requested problem and ask permission before any introduction to Frank or Ana.
+
+## Facilitation recovery moves
+
+| If | Then |
+|---|---|
+| Participants stay abstract | Ask for one moment, one person, and one observed change |
+| The room debates the “true” ikigai model | Re-state broad meaning, cite the source, and return to lived evidence |
+| Someone shares sensitive health or employment detail | Thank them, stop note-taking, and redirect to the practical boundary they choose to share |
+| AI anxiety dominates | Name a human-only decision and shrink the experiment to one assisted step |
+| Technical questions consume time | Capture them on a parking sheet; no setup is required in this room |
+| Ana is pulled toward an unwanted expert role | Frank answers or parks the question; her contribution scope is not renegotiated in public |
+| Time is ten minutes behind | Skip paired discussion, keep human-only decisions and the 30-day experiment |
+| Wi-Fi or screen fails | Use the printed Frank example and draw the six-step system on a flipchart |
+
+## Evidence capture
+
+No map is collected by default. At close, ask for anonymous hand signals or a one-line optional card:
+
+1. Did you finish the map? yes / partly / no
+2. Is the next practice clear enough to begin? yes / not yet
+3. Which future door, if any, do you want to ask about? creator / founder / team / people-HR / retreat / none
+
+At Day 7, only consenting participants receive:
+
+- Did you use, revise, or abandon the practice?
+- What created friction?
+- What useful evidence appeared?
+- What help, if any, are you asking for now?
+
+Aggregate learning may improve the format. Quotes, case studies, photographs, participant artifacts, and identifying stories require separate explicit permission.

--- a/docs/specs/tallinn-workshop-portfolio-2026-07-14.md
+++ b/docs/specs/tallinn-workshop-portfolio-2026-07-14.md
@@ -1,0 +1,198 @@
+# Tallinn Experience Foundry — 30-format portfolio
+
+**Status:** private decision draft
+
+**Prepared:** 14 July 2026
+
+**Event window:** 20 July–2 August 2026
+
+**Recommended pilot:** Purpose to Practice
+**Public posture:** independent working session; no Mindvalley affiliation or endorsement
+
+## Executive recommendation
+
+Do not launch thirty unrelated workshops. Use one premium parent concept—**Tallinn Experience Foundry**—with a consistent promise: *leave with one thing running*. Publish ten unlisted offer pages for qualitative review, place five in front of Ana on 15 July, and validate only one session before reserving a venue.
+
+The first pilot should be **Purpose to Practice: Build Your Calm Human + AI Operating System**. It is the best bridge across Frank’s existing Ikigai, positioning, research, Personal AI CoE, and agent-team material. It also lets Ana participate meaningfully without forcing her into a presenter role or relying on unverified public claims.
+
+This is not “a Mindvalley workshop” unless Mindvalley formally approves it. The public-safe description is:
+
+> An independent working session for people gathering in Tallinn during Mindvalley U. This experience is not affiliated with, sponsored by, or endorsed by Mindvalley.
+
+## Scoring model
+
+Each format is scored out of 100:
+
+| Dimension | Weight | Question |
+|---|---:|---|
+| Audience pull | 20 | Will a Tallinn attendee understand the desire in one sentence? |
+| FrankX proof | 20 | Can Frank demonstrate working research, templates, or systems now? |
+| 90-minute artifact | 15 | Can every participant finish something useful in the room? |
+| Frank + Ana fit | 15 | Is there a respectful, credible collaboration lane? |
+| Differentiation | 15 | Is this more distinctive than generic purpose, AI, or creator training? |
+| Follow-on integrity | 10 | Is there an earned next step without pitching inside the workshop? |
+| Short-notice feasibility | 5 | Can it be delivered well by 21–23 July? |
+
+Scores are prioritization judgments, not demand evidence. The landing pages and reconfirmation gate create that evidence.
+
+## The 30-format portfolio
+
+| # | Format | Primary audience | Leave-with artifact | Score | Decision |
+|---:|---|---|---|---:|---|
+| 1 | **Purpose to Practice** | Creators, founders, transition | Human + AI Practice Map | **95** | Pilot + page |
+| 2 | Ikigai, Honestly | Purpose seekers | Everyday Meaning Map | 86 | Reserve concept |
+| 3 | **Purpose Without Performance** | Quiet creators, professionals | Quiet Authority Map | **89** | Page |
+| 4 | Next Chapter Operating Map | Career transition | 30-day chapter map | 88 | Reserve concept |
+| 5 | Meaning-to-Market Offer Lab | Coaches, experts | Evidence-led offer sheet | 82 | Reserve concept |
+| 6 | **Agentic Creator Studio** | Creators, educators | Source-to-artifact recipe | **91** | Ana top five + page |
+| 7 | Research to Resonance | Thought leaders | Research-to-story brief | 87 | Reserve concept |
+| 8 | One Idea, Five Formats | Multi-format creators | Repurposing map | 84 | Reserve concept |
+| 9 | Creator Knowledge Garden | Knowledge creators | Source and idea graph | 85 | Reserve concept |
+| 10 | **Voice Before Volume** | Creators, founder brands | Voice + Claims Charter | **90** | Page |
+| 11 | **Build Your Agentic Team** | Solo founders | Agentic Team Canvas | **94** | Ana top five + page |
+| 12 | **Personal AI CoE on One Page** | Advanced operators | Personal AI CoE One-Pager | **92** | Page |
+| 13 | Founder Command Center | Founders | Weekly command board | 86 | Reserve concept |
+| 14 | SOP-to-Skill Studio | Operators | SOP/SKILL starter | 89 | Reserve concept |
+| 15 | Founder/Agent Delegation Matrix | Founders, executives | Delegation matrix | 90 | Reserve concept |
+| 16 | **Human + Agent Team Charter** | Teams, people leaders | Human + Agent Team Charter | **93** | Ana top five + page |
+| 17 | **Role Clarity in the Agent Era** | HR, recruiting, leaders | Role Clarity Scorecard | **91** | Page |
+| 18 | Hiring for Human-Agent Teams | Recruiters, founders | Hiring signal canvas | 84 | Reserve concept |
+| 19 | Shared Knowledgebase Sprint | Teams | Knowledge ownership map | 87 | Reserve concept |
+| 20 | AI Team Architecture Boardroom | Leadership teams | Team architecture blueprint | 88 | Reserve concept |
+| 21 | **Calm Work Architecture** | Overloaded founders | Calm Work Week Map | **91** | Page |
+| 22 | Attention Before Automation | Knowledge workers | Attention/automation boundary | 87 | Reserve concept |
+| 23 | Many Voices, One Decision | Founders | Decision voices map | 80 | Reserve; non-clinical only |
+| 24 | Meditation to Execution Bridge | Practitioners | Reflection-to-action card | 81 | Reserve; claims review |
+| 25 | Sustainable AI Pace Lab | Teams, founders | Sustainable pace protocol | 86 | Reserve concept |
+| 26 | **Founder Integration Salon** | Founders, operators | Founder Integration Card | **92** | Ana top five + page |
+| 27 | Starlight Retreat Preview Lab | Retreat prospects | Retreat prototype brief | 88 | Reserve concept |
+| 28 | Future of Human + Agent Work Salon | Leaders | Strategic questions charter | 89 | Reserve concept |
+| 29 | Purpose, People & Agents Breakfast | Mixed leadership | Three-layer action card | 83 | Reserve concept |
+| 30 | Retreat Experience Design Studio | Facilitators, hosts | Experience architecture canvas | 85 | Reserve concept |
+
+## The ten landing-page tests
+
+The implemented portfolio is deliberately balanced across five market doors:
+
+| Door | Page | What it tests |
+|---|---|---|
+| Human meaning | Purpose to Practice | Broad human-first bridge into agentic work |
+| Human meaning | Purpose Without Performance | Whether “personal branding” should be reframed as quiet authority |
+| Creator practice | Agentic Creator Studio | Demand for a shippable artifact, not AI education |
+| Creator practice | Voice Before Volume | Demand for editorial governance and authenticity |
+| Founder systems | Build Your Agentic Team | Frank’s strongest differentiated proof |
+| Founder systems | Personal AI CoE on One Page | Advanced architecture without terminal setup |
+| People + teams | Human + Agent Team Charter | Joint B2B people/AI opportunity |
+| People + teams | Role Clarity in the Agent Era | Ana’s potential HR thought-leadership bridge |
+| Integration | Calm Work Architecture | Calm operating-system and future retreat demand |
+| Integration | Founder Integration Salon | High-trust retreat discovery without a retreat pitch |
+
+## The five to review with Ana on 15 July
+
+1. **Purpose to Practice** — recommended first pilot and broadest audience.
+2. **Agentic Creator Studio** — strongest creator/GenCreator path.
+3. **Build Your Agentic Team** — strongest proof-led solo-founder path.
+4. **Human + Agent Team Charter** — strongest true co-creation and B2B path.
+5. **Founder Integration Salon** — safest discovery test for Starlight Retreats.
+
+The decision is not “which five should we launch?” It is “which one are we proud to validate first, and which role does Ana genuinely want?”
+
+## Recommended 90-minute pilot
+
+### Purpose to Practice: Build Your Calm Human + AI Operating System
+
+**Audience:** creators, founders, and people in transition with insight but no operating shape for it yet.
+
+**Capacity:** 8–12.
+
+**Arrival prompt:** bring one real question about the work or chapter you are entering.
+**Finished artifact:** one-page Human + AI Practice Map and a dated 30-day experiment.
+
+| Time | Beat | Participant work |
+|---|---|---|
+| 00–08 | Arrival | Consent, independence, no-pitch boundary, artifact preview |
+| 08–18 | Ikigai honestly | Everyday meaning; the four-circle visual is a modern reflection scaffold, not the entire Japanese concept |
+| 18–32 | Evidence | Energising moments, demonstrated strengths, useful service, current constraints |
+| 32–45 | Direction | One audience, contribution, trade-off, and purpose-to-practice sentence |
+| 45–55 | Working demo | Frank shows how a human intention becomes agent roles, knowledge, and gates |
+| 55–70 | System map | Three light agent roles, human-only decisions, sources, and stop conditions |
+| 70–82 | Weekly practice | Trigger, sequence, review, and one sustainable boundary |
+| 82–88 | Peer review | Is the practice clear, humane, inspectable, and small enough? |
+| 88–90 | Commit | Date the 30-day experiment and choose any consent-based follow-through |
+
+### Why this format first
+
+- It uses material Frank can already show: Ikigai & Branding, research, templates, Personal AI CoE, and his real agentic operating model.
+- It is human-first and nontechnical but still differentiates Frank from generic purpose facilitation.
+- It creates a useful artifact in ninety minutes; no new platform is required.
+- Ana can be producer, bounded contributor, or co-creator without a last-minute spotlight obligation.
+- It earns multiple future paths—creator, founder, team, or retreat—based on what participants ask for afterward.
+
+## Ikigai language boundary
+
+The Government of Japan describes ikigai broadly as that which brings value and joy to life, including people, work, hobbies, and everyday activity. Its article also attributes the popular four-circle diagram to American entrepreneur Marc Winn. Therefore:
+
+- Say **“a modern reflection scaffold”**, not “the authentic Japanese Ikigai model.”
+- Do not imply finding one perfect career intersection, a medical benefit, or a guaranteed life purpose.
+- Use work and livelihood as two possible dimensions inside a wider life—not the definition of ikigai.
+
+Source: [Government of Japan — Ikigai: The Japanese Secret to a Joyful Life](https://www.japan.go.jp/kizuna/2022/03/ikigai_japanese_secret_to_a_joyful_life.html).
+
+## Frank + Ana collaboration architecture
+
+### Mode A — producer
+
+- Ana owns hospitality, room flow, participant care, logistics, and operational feedback.
+- Frank leads and carries public claims.
+- Commercial starting point: fixed producer fee and reimbursed pre-approved costs.
+- Best for the first short-notice test and Ana’s stated preference not to seek the spotlight.
+
+### Mode B — producer + bounded contributor
+
+- Mode A plus one agreed prompt, people lens, closing reflection, or artifact review.
+- Ana approves the exact module, bio, public credit, recording policy, and reuse rights.
+- Commercial starting point: base producer fee plus **15–25% of net session revenue** when her module is delivered.
+
+### Mode C — true co-creator
+
+- Shared design and delivery of Human + Agent Team Charter or Role Clarity in the Agent Era.
+- Each retains pre-existing IP. Joint modules, examples, recordings, participant reuse, and future licensing are documented before sale.
+- Commercial starting point: approximately **50/50 of net revenue after approved direct costs**, adjusted only when delivery, acquisition, or IP contribution is materially unequal.
+
+These are negotiation anchors, not terms already agreed with Ana.
+
+## Public claims and participant-safety gate
+
+Until Ana provides and approves evidence, do not publicly describe her as a psychologist, neuroscientist, therapist, IFS practitioner, certified meditation teacher, or health professional. Do not promise neurological, therapeutic, trauma, recruiting, employment-law, or health outcomes.
+
+Safe contribution language includes:
+
+- people and role-clarity questions;
+- participant experience and operations;
+- reflective or grounding prompt, if she approves it;
+- HR/recruiting perspective in her own approved words;
+- co-design of non-clinical team practices.
+
+“Many Voices, One Decision” may borrow the neutral idea that people can hold competing perspectives. It must not be marketed as IFS, therapy, or treatment.
+
+## Business thesis
+
+The pilot is valuable even if it produces no immediate revenue. Its purpose is to validate four things with evidence:
+
+1. Which promise earns a real room request?
+2. Which artifact participants actually finish and use?
+3. Which follow-on problem participants ask Frank or Ana to solve?
+4. Which collaboration mode feels energising and commercially fair to both hosts?
+
+The near-term business is not thirty ticket products. It is a demand-sensing front door into three stronger lines:
+
+- **Frank:** agentic founder/creator operating-system installs and AI team architecture.
+- **Ana:** people operations, role design, recruiting, and HR agency opportunities in her approved scope.
+- **Joint:** Human + Agent Team Charter workshops, 30-day team pilots, and later premium Starlight integration retreats.
+
+## Research anchors
+
+- [Mindvalley U official event page](https://www.mindvalley.com/u) — dates, location, and official program positioning.
+- [Mindvalley Community Guidelines](https://help.mindvalley.com/hc/en-us/articles/40076576220827-Community-Guidelines) — avoid spam, excessive promotion, unsolicited coaching, and privacy breaches.
+- [Tallink Spa & Conference Hotel conference center](https://hotels.tallink.com/events/tallink-spa-conference-hotel-conference-center) — current public package baseline; a room-only quote remains unverified.
+- [Government of Japan on ikigai](https://www.japan.go.jp/kizuna/2022/03/ikigai_japanese_secret_to_a_joyful_life.html) — broad concept and four-circle provenance.

--- a/lib/email-templates-tallinn.ts
+++ b/lib/email-templates-tallinn.ts
@@ -6,6 +6,8 @@ import {
 } from '@/data/tallinn-experiences'
 import type { TallinnInterestPayload } from '@/lib/tallinn-interest/schema'
 
+type TallinnSlotLabel = (typeof TALLINN_TIME_WINDOWS)[number]['label']
+
 export interface TallinnEmailContent {
   subject: string
   text: string
@@ -23,7 +25,7 @@ function escapeHtml(value: string) {
 function slotLabels(payload: TallinnInterestPayload) {
   return payload.slotIds
     .map((id) => TALLINN_TIME_WINDOWS.find((slot) => slot.id === id)?.label)
-    .filter((label): label is string => Boolean(label))
+    .filter((label): label is TallinnSlotLabel => label !== undefined)
 }
 
 export function buildTallinnInterestReceipt(

--- a/lib/email-templates-tallinn.ts
+++ b/lib/email-templates-tallinn.ts
@@ -1,0 +1,108 @@
+import {
+  TALLINN_EVENT,
+  TALLINN_TIME_WINDOWS,
+  TALLINN_VALIDATION_GATE,
+  getTallinnExperience,
+} from '@/data/tallinn-experiences'
+import type { TallinnInterestPayload } from '@/lib/tallinn-interest/schema'
+
+export interface TallinnEmailContent {
+  subject: string
+  text: string
+  html: string
+}
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function slotLabels(payload: TallinnInterestPayload) {
+  return payload.slotIds
+    .map((id) => TALLINN_TIME_WINDOWS.find((slot) => slot.id === id)?.label)
+    .filter((label): label is string => Boolean(label))
+}
+
+export function buildTallinnInterestReceipt(
+  payload: TallinnInterestPayload,
+): TallinnEmailContent {
+  const experience = getTallinnExperience(payload.experienceSlug)
+  const firstName = payload.fullName.split(/\s+/)[0] || payload.fullName
+  const slots = slotLabels(payload)
+  const title = experience?.title ?? 'Tallinn working session'
+  const subject = `Interest received — ${title}`
+  const nextStep = `A room is considered only after ${TALLINN_VALIDATION_GATE.minimumConfirmed} people reconfirm one compatible time. This message is not a ticket or venue confirmation.`
+
+  const text = [
+    `Hi ${firstName},`,
+    '',
+    `Your interest in “${title}” is recorded.`,
+    '',
+    'Possible times:',
+    ...slots.map((slot) => `- ${slot}`),
+    '',
+    nextStep,
+    '',
+    TALLINN_EVENT.independenceNotice,
+    '',
+    payload.aftercareConsent
+      ? 'If the session runs, you also asked for the session artifact and related follow-up.'
+      : 'You did not opt into aftercare. Only coordination about this request will be sent.',
+    '',
+    '— Frank',
+    'frank@frankx.ai · frankx.ai',
+  ].join('\n')
+
+  const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;color:#172033;line-height:1.65">
+  <p>Hi ${escapeHtml(firstName)},</p>
+  <p>Your interest in <strong>${escapeHtml(title)}</strong> is recorded.</p>
+  <div style="margin:20px 0;padding:16px 18px;border-radius:14px;background:#f1f5f9;color:#334155">
+    <strong>Possible times</strong>
+    <ul>${slots.map((slot) => `<li>${escapeHtml(slot)}</li>`).join('')}</ul>
+  </div>
+  <p>${escapeHtml(nextStep)}</p>
+  <p style="font-size:13px;color:#64748b">${escapeHtml(TALLINN_EVENT.independenceNotice)}</p>
+  <p style="font-size:13px;color:#64748b">${
+    payload.aftercareConsent
+      ? 'If the session runs, you also asked for the session artifact and related follow-up.'
+      : 'You did not opt into aftercare. Only coordination about this request will be sent.'
+  }</p>
+  <p style="margin-top:26px;color:#64748b">— Frank<br/>frank@frankx.ai · frankx.ai</p>
+</div>`.trim()
+
+  return { subject, text, html }
+}
+
+export function buildTallinnOperatorNotification(
+  payload: TallinnInterestPayload,
+): TallinnEmailContent {
+  const experience = getTallinnExperience(payload.experienceSlug)
+  const slots = slotLabels(payload)
+  const title = experience?.title ?? payload.experienceSlug
+  const subject = `Tallinn interest · ${title} · ${payload.fullName}`
+  const lines = [
+    'New Tallinn Experience Foundry interest.',
+    '',
+    `Name: ${payload.fullName}`,
+    `Email: ${payload.email}`,
+    `Offer: ${title} (${payload.experienceSlug})`,
+    `Variant: ${payload.variantId}`,
+    `Role lens: ${payload.roleLens}`,
+    `Attendance intent: ${payload.attendanceIntent}`,
+    `Possible times: ${slots.join(' | ')}`,
+    `Company / project: ${payload.companyOrProject || '(not provided)'}`,
+    `Aftercare: ${payload.aftercareConsent ? 'requested' : 'not requested'}`,
+    `Note: ${payload.note || '(not provided)'}`,
+    `Submission ID: ${payload.submissionId}`,
+    '',
+    'Venue gate remains human-approved. Do not book from this message alone.',
+  ]
+
+  const text = lines.join('\n')
+  const html = `<pre style="white-space:pre-wrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;line-height:1.6;color:#172033">${escapeHtml(text)}</pre>`
+  return { subject, text, html }
+}

--- a/lib/tallinn-interest/options.ts
+++ b/lib/tallinn-interest/options.ts
@@ -1,0 +1,12 @@
+export const TALLINN_ROLE_LENSES = [
+  'creator',
+  'solo-founder',
+  'team-leader',
+  'people-ops',
+  'other',
+] as const
+export const TALLINN_ATTENDANCE_INTENTS = [
+  'exploring',
+  'likely',
+  'ready-if-time-works',
+] as const

--- a/lib/tallinn-interest/schema.ts
+++ b/lib/tallinn-interest/schema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+import {
+  TALLINN_TIME_WINDOWS,
+  tallinnExperiences,
+} from '@/data/tallinn-experiences'
+import {
+  TALLINN_ATTENDANCE_INTENTS,
+  TALLINN_ROLE_LENSES,
+} from '@/lib/tallinn-interest/options'
+
+const experienceSlugs = new Set<string>(
+  tallinnExperiences.map((experience) => experience.slug),
+)
+const slotIds = new Set<string>(TALLINN_TIME_WINDOWS.map((slot) => slot.id))
+
+export const TallinnInterestSchema = z.object({
+  fullName: z.string().trim().min(1, 'Your name is required.').max(200),
+  email: z.string().trim().toLowerCase().email('Enter a valid email.').max(200),
+  experienceSlug: z
+    .string()
+    .trim()
+    .refine((value) => experienceSlugs.has(value), 'Choose a valid session.'),
+  variantId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(60)
+    .regex(/^[a-z0-9-]+$/, 'Invalid experiment variant.'),
+  roleLens: z.enum(TALLINN_ROLE_LENSES),
+  attendanceIntent: z.enum(TALLINN_ATTENDANCE_INTENTS),
+  slotIds: z
+    .array(z.string())
+    .min(1, 'Choose at least one possible time.')
+    .max(3, 'Choose no more than three times.')
+    .refine(
+      (values) => values.every((value) => slotIds.has(value)),
+      'Choose only listed times.',
+    ),
+  companyOrProject: z.string().trim().max(200).optional().or(z.literal('')),
+  note: z.string().trim().max(800).optional().or(z.literal('')),
+  aftercareConsent: z.boolean(),
+  consentToContact: z.literal(true, {
+    error: () => 'Consent is required to coordinate this session.',
+  }),
+  submissionId: z.string().uuid('Invalid submission ID.'),
+  // Honeypot: deliberately not constrained to empty. Filled submissions are
+  // silently dropped by the route so bots do not learn the filter.
+  website: z.string().max(200).optional().or(z.literal('')),
+})
+
+export type TallinnInterestPayload = z.infer<typeof TallinnInterestSchema>

--- a/lib/tallinn-interest/service.ts
+++ b/lib/tallinn-interest/service.ts
@@ -1,0 +1,262 @@
+import {
+  buildTallinnInterestReceipt,
+  buildTallinnOperatorNotification,
+} from '@/lib/email-templates-tallinn'
+import type { TallinnInterestPayload } from '@/lib/tallinn-interest/schema'
+
+export interface TallinnCaptureEnvironment {
+  notionToken: string
+  notionDatabaseId: string
+  resendApiKey?: string
+  operatorEmail: string
+}
+export interface TallinnCaptureDependencies {
+  fetchImpl?: typeof fetch
+  now?: () => Date
+}
+
+export interface TallinnCaptureResult {
+  stored: boolean
+  duplicate: boolean
+  receiptSent: boolean
+  operatorNotified: boolean
+  recordId?: string
+  error?: 'notion-query-failed' | 'notion-write-failed'
+}
+
+const NOTION_VERSION = '2022-06-28'
+const FROM_NOTIFY = 'FrankX Tallinn <notify@mail.frankx.ai>'
+const FROM_FRANK = 'Frank <frank@mail.frankx.ai>'
+
+function sourceKey(payload: TallinnInterestPayload) {
+  return `tallinn-2026|${payload.experienceSlug}|${payload.variantId}|${payload.submissionId}`
+}
+
+function structuredMessage(payload: TallinnInterestPayload, capturedAt: string) {
+  return [
+    'Tallinn Experience Foundry — independent 90-minute session interest',
+    `Experience: ${payload.experienceSlug}`,
+    `Variant: ${payload.variantId}`,
+    `Role lens: ${payload.roleLens}`,
+    `Attendance intent: ${payload.attendanceIntent}`,
+    `Slot IDs: ${payload.slotIds.join(', ')}`,
+    `Aftercare consent: ${payload.aftercareConsent ? 'yes' : 'no'}`,
+    `Contact consent: yes (${capturedAt})`,
+    `Privacy version: tallinn-interest-v1-2026-07-14`,
+    `Note: ${payload.note || '(none)'}`,
+  ].join('\n')
+}
+
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  input: string,
+  init: RequestInit,
+  timeoutMs = 5_000,
+) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetchImpl(input, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function findExistingRecord(
+  key: string,
+  env: TallinnCaptureEnvironment,
+  fetchImpl: typeof fetch,
+) {
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    `https://api.notion.com/v1/databases/${env.notionDatabaseId}/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.notionToken}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': NOTION_VERSION,
+      },
+      body: JSON.stringify({
+        page_size: 1,
+        filter: {
+          property: 'Source',
+          rich_text: { equals: key },
+        },
+      }),
+    },
+  )
+
+  if (!response.ok) return { ok: false as const }
+  const body = (await response.json()) as { results?: Array<{ id?: string }> }
+  return {
+    ok: true as const,
+    recordId: body.results?.[0]?.id,
+  }
+}
+
+async function createRecord(
+  payload: TallinnInterestPayload,
+  key: string,
+  capturedAt: string,
+  env: TallinnCaptureEnvironment,
+  fetchImpl: typeof fetch,
+) {
+  const response = await fetchWithTimeout(fetchImpl, 'https://api.notion.com/v1/pages', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.notionToken}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': NOTION_VERSION,
+    },
+    body: JSON.stringify({
+      parent: { database_id: env.notionDatabaseId },
+      properties: {
+        Name: { title: [{ text: { content: payload.fullName } }] },
+        Email: { email: payload.email },
+        Intent: { select: { name: 'Workshop (1-day team build)' } },
+        Stage: { select: { name: 'New' } },
+        Company: payload.companyOrProject
+          ? { rich_text: [{ text: { content: payload.companyOrProject } }] }
+          : { rich_text: [] },
+        Source: { rich_text: [{ text: { content: key } }] },
+        Message: {
+          rich_text: [
+            {
+              text: {
+                content: structuredMessage(payload, capturedAt).slice(0, 1_900),
+              },
+            },
+          ],
+        },
+      },
+    }),
+  })
+
+  if (!response.ok) return { ok: false as const }
+  const body = (await response.json()) as { id?: string }
+  return { ok: true as const, recordId: body.id }
+}
+
+async function sendEmail(
+  fetchImpl: typeof fetch,
+  apiKey: string | undefined,
+  input: {
+    from: string
+    to: string
+    replyTo: string
+    subject: string
+    text: string
+    html: string
+  },
+) {
+  if (!apiKey) return false
+  try {
+    const response = await fetchWithTimeout(fetchImpl, 'https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: input.from,
+        to: input.to,
+        reply_to: input.replyTo,
+        subject: input.subject,
+        text: input.text,
+        html: input.html,
+      }),
+    })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+export async function captureTallinnInterest(
+  payload: TallinnInterestPayload,
+  env: TallinnCaptureEnvironment,
+  dependencies: TallinnCaptureDependencies = {},
+): Promise<TallinnCaptureResult> {
+  const fetchImpl = dependencies.fetchImpl ?? fetch
+  const capturedAt = (dependencies.now?.() ?? new Date()).toISOString()
+  const key = sourceKey(payload)
+
+  let existing: Awaited<ReturnType<typeof findExistingRecord>>
+  try {
+    existing = await findExistingRecord(key, env, fetchImpl)
+  } catch {
+    return {
+      stored: false,
+      duplicate: false,
+      receiptSent: false,
+      operatorNotified: false,
+      error: 'notion-query-failed',
+    }
+  }
+  if (!existing.ok) {
+    return {
+      stored: false,
+      duplicate: false,
+      receiptSent: false,
+      operatorNotified: false,
+      error: 'notion-query-failed',
+    }
+  }
+  if (existing.recordId) {
+    return {
+      stored: true,
+      duplicate: true,
+      receiptSent: false,
+      operatorNotified: false,
+      recordId: existing.recordId,
+    }
+  }
+
+  let created: Awaited<ReturnType<typeof createRecord>>
+  try {
+    created = await createRecord(payload, key, capturedAt, env, fetchImpl)
+  } catch {
+    return {
+      stored: false,
+      duplicate: false,
+      receiptSent: false,
+      operatorNotified: false,
+      error: 'notion-write-failed',
+    }
+  }
+  if (!created.ok) {
+    return {
+      stored: false,
+      duplicate: false,
+      receiptSent: false,
+      operatorNotified: false,
+      error: 'notion-write-failed',
+    }
+  }
+
+  const receipt = buildTallinnInterestReceipt(payload)
+  const notification = buildTallinnOperatorNotification(payload)
+  const [receiptSent, operatorNotified] = await Promise.all([
+    sendEmail(fetchImpl, env.resendApiKey, {
+      from: FROM_FRANK,
+      to: payload.email,
+      replyTo: env.operatorEmail,
+      ...receipt,
+    }),
+    sendEmail(fetchImpl, env.resendApiKey, {
+      from: FROM_NOTIFY,
+      to: env.operatorEmail,
+      replyTo: payload.email,
+      ...notification,
+    }),
+  ])
+
+  return {
+    stored: true,
+    duplicate: false,
+    receiptSent,
+    operatorNotified,
+    recordId: created.recordId,
+  }
+}

--- a/lib/tallinn-interest/threshold.ts
+++ b/lib/tallinn-interest/threshold.ts
@@ -1,0 +1,40 @@
+import { TALLINN_VALIDATION_GATE } from '@/data/tallinn-experiences'
+
+export interface TallinnThresholdRecord {
+  normalizedEmail: string
+  experienceSlug: string
+  slotIds: string[]
+  attendanceIntent: 'exploring' | 'likely' | 'ready-if-time-works'
+  reconfirmed: boolean
+}
+export type TallinnThresholdState =
+  | 'keep-validating'
+  | 'review-venue'
+  | 'session-full'
+
+export function evaluateTallinnThreshold(
+  records: readonly TallinnThresholdRecord[],
+  experienceSlug: string,
+  slotId: string,
+): { state: TallinnThresholdState; confirmed: number } {
+  const unique = new Set(
+    records
+      .filter(
+        (record) =>
+          record.experienceSlug === experienceSlug &&
+          record.slotIds.includes(slotId) &&
+          record.attendanceIntent === 'ready-if-time-works' &&
+          record.reconfirmed,
+      )
+      .map((record) => record.normalizedEmail.trim().toLowerCase()),
+  )
+
+  const confirmed = unique.size
+  if (confirmed >= TALLINN_VALIDATION_GATE.roomCapacityTarget) {
+    return { state: 'session-full', confirmed }
+  }
+  if (confirmed >= TALLINN_VALIDATION_GATE.minimumConfirmed) {
+    return { state: 'review-venue', confirmed }
+  }
+  return { state: 'keep-validating', confirmed }
+}

--- a/scripts/tests/tallinn-experience-foundry-contract.test.mjs
+++ b/scripts/tests/tallinn-experience-foundry-contract.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import test from 'node:test'
+
+const root = process.cwd()
+const read = (path) => readFileSync(join(root, path), 'utf8')
+
+const registry = read('data/tallinn-experiences.ts')
+const hub = read('components/tallinn-experience/TallinnFoundryPage.tsx')
+const offer = read('components/tallinn-experience/TallinnOfferPage.tsx')
+const form = read('components/tallinn-experience/TallinnInterestForm.tsx')
+const route = read('app/api/tallinn-interest/route.ts')
+const service = read('lib/tallinn-interest/service.ts')
+const portfolio = read('docs/specs/tallinn-workshop-portfolio-2026-07-14.md')
+
+test('registry exposes exactly ten unique offer routes and five ranked reviews', () => {
+  const slugs = [...registry.matchAll(/\n\s{4}slug: '([^']+)'/g)].map((match) => match[1])
+  assert.equal(slugs.length, 10)
+  assert.equal(new Set(slugs).size, 10)
+
+  const reviewRanks = [...registry.matchAll(/\n\s{4}reviewRank: ([1-5]),/g)]
+    .map((match) => Number(match[1]))
+    .sort((a, b) => a - b)
+  assert.deepEqual(reviewRanks, [1, 2, 3, 4, 5])
+})
+
+test('portfolio contains thirty scored ideas and the five Ana-review formats', () => {
+  const numberedRows = portfolio.match(/^\| \d{1,2} \|/gm) ?? []
+  assert.equal(numberedRows.length, 30)
+
+  for (const title of [
+    'Purpose to Practice',
+    'Agentic Creator Studio',
+    'Build Your Agentic Team',
+    'Human + Agent Team Charter',
+    'Founder Integration Salon',
+  ]) {
+    assert.match(portfolio, new RegExp(title.replace(/[+]/g, '\\+')))
+  }
+})
+
+test('hub and offer pages preserve operational truth and affiliation boundary', () => {
+  assert.match(registry, /not affiliated with, sponsored by, or endorsed by Mindvalley/)
+  assert.match(registry, /no room is booked/)
+  assert.match(hub, /TALLINN_EVENT\.independenceNotice/)
+  assert.match(offer, /TALLINN_EVENT\.independenceNotice/)
+  assert.match(hub, /Venue not booked/)
+  assert.match(offer, /No room is booked/)
+  assert.match(hub, /Leave Tallinn with one thing running/)
+  assert.match(hub, /Human/)
+  assert.match(hub, /Practice/)
+  assert.match(hub, /System/)
+  assert.match(hub, /Team/)
+})
+
+test('preview mode is no-storage, dummy-email only, and does not create a marketing audience', () => {
+  assert.match(route, /TALLINN_CAPTURE_MODE === 'live'/)
+  assert.ok(route.includes("const REVIEW_EMAIL = /@example\\.com$/i"))
+  assert.match(route, /No data was stored and no email was sent/)
+  assert.doesNotMatch(service, /audiences|contacts|newsletter/i)
+  assert.match(form, /No newsletter or unrelated marketing/)
+})
+
+test('live capture stores first and sends only transactional mail afterward', () => {
+  const createIndex = service.indexOf('createRecord(payload')
+  const receiptIndex = service.indexOf('buildTallinnInterestReceipt(payload)')
+  assert.ok(createIndex > -1)
+  assert.ok(receiptIndex > createIndex)
+  assert.match(service, /Source/)
+  assert.match(service, /submissionId/)
+})
+
+test('unlisted routes remain noindex and generate all ten static paths', () => {
+  const hubRoute = read('app/experiences/tallinn-2026/page.tsx')
+  const offerRoute = read('app/experiences/tallinn-2026/[slug]/page.tsx')
+  assert.match(hubRoute, /noindex: true/)
+  assert.match(offerRoute, /noindex: true/)
+  assert.match(offerRoute, /generateStaticParams/)
+})


### PR DESCRIPTION
## What changed

- adds one unlisted Tallinn Experience Foundry hub and ten data-driven workshop offer pages
- selects Purpose to Practice as the first 90-minute pilot and adds a print-ready Human + AI Practice Map
- adds the 30-format portfolio, Ana review set, facilitator pack, six-day operating plan, venue gate, aftercare, and joint business pipeline
- adds an outcome router and one shared request form/API
- keeps every preview noindex and no-storage unless production plus an explicit live-capture flag are both enabled
- uses Notion-first durable capture and transactional Resend mail only after storage; no audience/newsletter enrollment
- preserves the independent-event disclaimer and keeps venue, spend, Ana claims/role, and data sharing human-gated

## Why

Mindvalley U begins in Tallinn on 20 July. This creates a reviewable, artifact-led demand test without implying official affiliation, booking Tallink before demand exists, forcing Ana into the spotlight, or activating personal-data capture prematurely.

## Validation

- `node --test scripts/tests/tallinn-experience-foundry-contract.test.mjs` — 6/6 passing
- premium design evidence manifest validator — passing
- `git diff --cached --check` — passing before commit
- staged gitleaks scan — no leaks
- local full build/typecheck intentionally not forced: machine-performance preflight returned HOLD (5.17 GB free vs 8 GB reserve)
- Vercel/Git checks and actual desktop/mobile inspection remain draft-PR gates

## Human approvals still required

- Ana role, credit, claims, IP, revenue share, and participant-data boundary
- privacy notice and any production live-capture environment
- external invitations or email sends
- official agenda compatibility
- Tallink quote, reservation, spend, participant charge, or payment flow
- production promotion or merge
