### PR TITLE
feat(ana): connect HR method to official Codex plugins

### DIFF
--- a/components/ana/AnaPluginInstall.tsx
+++ b/components/ana/AnaPluginInstall.tsx
@@ -22,10 +22,16 @@ export function AnaPluginInstall() {
           <p className="mt-6 text-sm font-medium text-ana-gold">Shared Codex plugin</p>
           <h2 id="install-title" className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">Install the same operating method across the team.</h2>
           <p className="mt-5 text-base leading-7 text-ana-cream/65">The marketplace points every teammate to one maintained source. The plugin carries reusable instructions and checks; private working files remain in the tools Ana approves.</p>
-          <a href={anaLinks.kitRepo} target="_blank" rel="noopener noreferrer" className="mt-7 inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-5 py-2.5 text-sm font-semibold text-ana-cream transition hover:border-white/30">
-            Open the GitHub source
-            <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          </a>
+          <div className="mt-7 flex flex-wrap gap-3">
+            <a href={anaLinks.kitRepo} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-5 py-2.5 text-sm font-semibold text-ana-cream transition hover:border-white/30">
+              Open the GitHub source
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </a>
+            <a href={anaLinks.officialPluginStack} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center gap-2 rounded-full border border-ana-gold/25 bg-ana-gold/[0.07] px-5 py-2.5 text-sm font-semibold text-ana-cream transition hover:border-ana-gold/45">
+              Choose the team plugin stack
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </div>
         </div>
 
         <div className="border-t border-white/10 bg-black/25 p-5 sm:p-7 lg:border-l lg:border-t-0">
@@ -45,6 +51,14 @@ export function AnaPluginInstall() {
             <li><span className="text-ana-gold">2.</span> Install the team plugin.</li>
             <li><span className="text-ana-gold">3.</span> Open a new Codex task.</li>
           </ol>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <a href={anaLinks.codexAnaPlugin} className="inline-flex min-h-11 items-center rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-ana-cream transition hover:border-white/30">
+              Open Ana HR Operations in Codex
+            </a>
+            <a href={anaLinks.codexPluginDirectory} className="inline-flex min-h-11 items-center rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-ana-cream/70 transition hover:border-white/30 hover:text-ana-cream">
+              Browse official plugins
+            </a>
+          </div>
           <p className="mt-5 text-xs leading-5 text-ana-cream/40">Updates come from the maintained GitHub source. Workspace approvals may still be required in managed team environments.</p>
         </div>
       </div>

--- a/data/ana-collaboration.ts
+++ b/data/ana-collaboration.ts
@@ -46,6 +46,10 @@ export const anaLinks = {
     'https://github.com/frankxai/ana-ai-business-kit/blob/main/docs/WHO-READS-WHAT.md',
   installGuide:
     'https://github.com/frankxai/ana-ai-business-kit/blob/main/docs/FORK-AND-INSTALL-CODEX.md',
+  officialPluginStack:
+    'https://github.com/frankxai/ana-ai-business-kit/blob/main/docs/OFFICIAL-CODEX-PLUGIN-STACK.md',
+  codexPluginDirectory: 'codex://plugins/install/?marketplace=openai-curated',
+  codexAnaPlugin: 'codex://plugins/ana-hr-operations@ana-business-kit',
   kitRelease:
     'https://github.com/frankxai/ana-ai-business-kit/releases/tag/v1.1.0',
   kitManifest:

--- a/scripts/tests/ana-collaboration-hub-contract.test.mjs
+++ b/scripts/tests/ana-collaboration-hub-contract.test.mjs
@@ -37,3 +37,14 @@ test('the generic Codex team article contains no Ana-specific material', async (
   const article = await read('content/blog/codex-plugins-for-teams.mdx')
   assert.doesNotMatch(article, /Ana Cancino|Ana Cecilia|ana-hr-operations|ana-ai-business-kit|Cecilia/i)
 })
+
+test('the Ana install panel links the method to official Codex plugins and team learning', async () => {
+  const component = await read('components/ana/AnaPluginInstall.tsx')
+  const links = await read('data/ana-collaboration.ts')
+
+  assert.match(component, /Choose the team plugin stack/)
+  assert.match(component, /Browse official plugins/)
+  assert.match(links, /OFFICIAL-CODEX-PLUGIN-STACK\.md/)
+  assert.match(links, /codex:\/\/plugins\/install\/\?marketplace=openai-curated/)
+  assert.match(links, /codex:\/\/plugins\/ana-hr-operations@ana-business-kit/)
+})


### PR DESCRIPTION
## Summary
- connect Ana's maintained HR operating method to the official/OpenAI-curated Codex plugin directory
- add direct Codex app links for the Ana plugin and curated marketplace
- link the role-based plugin and team-learning guide from the private-indexed Ana hub
- protect the integration with a focused hub contract test

## Verification
- 
ode --test scripts/tests/ana-collaboration-hub-contract.test.mjs
- targeted ESLint on changed files
- git diff --check

The Ana routes remain 
oindex; the generic public Codex article remains free of Ana/client-specific material.