### PR TITLE
feat(accelerator): Venture Fabric + Portfolio OS public constellation

### DIFF
--- a/app/accelerator/arcanea/page.tsx
+++ b/app/accelerator/arcanea/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { GlowCard } from '@/components/ui/glow-card'
+import { AcceleratorSubnav } from '@/components/accelerator/AcceleratorSubnav'
+
+export const metadata: Metadata = {
+  title: 'Arcanea Track — Creative Thesis for Portfolio Programs',
+  description:
+    'Arcanea is the creative intelligence thesis inside FrankX Venture Fabric — media, worldbuilding, design taste, and creator OS packs for culture-heavy portfolios.',
+  alternates: { canonical: 'https://frankx.ai/accelerator/arcanea' },
+}
+
+export default function ArcaneaTrackPage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/80">
+      <AcceleratorSubnav active="/accelerator/arcanea" />
+
+      <section className="mx-auto max-w-6xl px-6 pb-16 pt-16 lg:pt-24">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-amber-400/60">
+          Thesis skin · Arcanea
+        </p>
+        <h1 className="max-w-3xl text-4xl font-bold tracking-tight text-white md:text-5xl">
+          Arcanea: the creative thesis.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-white/60">
+          Arcanea is premium creative intelligence — worlds, media, music, design systems, and
+          taste. Programs focused on creators, IP, entertainment, or culture-heavy products skin
+          Portfolio OS with Arcanea packs so amplification includes craft, not only ops automation.
+        </p>
+      </section>
+
+      <section className="border-t border-white/5 py-20">
+        <div className="mx-auto max-w-6xl px-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+          <GlowCard color="amber" className="p-6">
+            <h2 className="text-base font-semibold text-white">Creative OS</h2>
+            <p className="mt-2 text-sm text-white/60">
+              Creator OS kits, studio patterns, and agent packs for content and product storytelling.
+            </p>
+          </GlowCard>
+          <GlowCard color="violet" className="p-6">
+            <h2 className="text-base font-semibold text-white">Taste systems</h2>
+            <p className="mt-2 text-sm text-white/60">
+              Design contracts, visual intelligence, and quality gates so portfolio output stays
+              premium under speed.
+            </p>
+          </GlowCard>
+          <GlowCard color="white" className="p-6">
+            <h2 className="text-base font-semibold text-white">Later brand</h2>
+            <p className="mt-2 text-sm text-white/60">
+              &ldquo;Arcanea Accelerator&rdquo; may name a creative capital thesis later. Today it is
+              a track and kit family — not an open fundraise claim.
+            </p>
+          </GlowCard>
+        </div>
+        <div className="mx-auto mt-12 max-w-6xl px-6 flex flex-wrap gap-4">
+          <Link href="/accelerator/portfolio-os" className="text-sm font-semibold text-cyan-300">
+            Portfolio OS →
+          </Link>
+          <Link href="/accelerator/starlight" className="text-sm font-semibold text-violet-300">
+            Starlight systems thesis →
+          </Link>
+          <a
+            href="https://github.com/frankxai/agentic-creator-os"
+            rel="noopener"
+            className="text-sm font-semibold text-amber-300"
+          >
+            agentic-creator-os →
+          </a>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/accelerator/founders/page.tsx
+++ b/app/accelerator/founders/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { GlowCard } from '@/components/ui/glow-card'
+import { AcceleratorSubnav } from '@/components/accelerator/AcceleratorSubnav'
+
+export const metadata: Metadata = {
+  title: 'For Founders — FrankX Accelerator Route Map',
+  description:
+    'Founders and operators: get a single AI-native business OS via FrankX Foundry. Portfolio OS is for accelerators and funds equipping many companies.',
+  alternates: { canonical: 'https://frankx.ai/accelerator/founders' },
+}
+
+export default function AcceleratorFoundersPage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/80">
+      <AcceleratorSubnav active="/accelerator/founders" />
+
+      <section className="mx-auto max-w-6xl px-6 pb-20 pt-16 lg:pt-24">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-emerald-400/60">
+          Founder route
+        </p>
+        <h1 className="max-w-3xl text-4xl font-bold tracking-tight text-white md:text-5xl">
+          You probably want the Foundry — not a fund control plane.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-white/60">
+          If you are building one company, one studio, or one service practice, the right product is
+          an installed operating system for <em>your</em> brand. That is Foundry. Portfolio OS is for
+          people who equip many companies at once.
+        </p>
+        <div className="mt-10 flex flex-wrap gap-4">
+          <Link
+            href="/foundry"
+            className="rounded-full bg-emerald-400 px-8 py-3.5 text-sm font-semibold text-[#07120d] transition-colors hover:bg-emerald-300"
+          >
+            Go to Foundry
+          </Link>
+          <Link
+            href="/foundry/guide"
+            className="px-2 py-3.5 text-sm font-semibold text-white/60 hover:text-white"
+          >
+            Read the operating guide
+          </Link>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20">
+        <div className="mx-auto max-w-6xl px-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <GlowCard color="emerald" href="/foundry" className="p-8">
+            <p className="font-mono text-xs text-emerald-400/70">RIGHT FIT</p>
+            <h2 className="mt-2 text-xl font-semibold text-white">Foundry install</h2>
+            <ul className="mt-4 space-y-2 text-sm text-white/60">
+              <li>· One business, one brand, one OS</li>
+              <li>· Website + agent harness + claims gate + memory</li>
+              <li>· Weekly operating rhythm</li>
+              <li>· Application-only, evaluated installs</li>
+            </ul>
+          </GlowCard>
+          <GlowCard color="cyan" href="/accelerator/portfolio-os" className="p-8">
+            <p className="font-mono text-xs text-cyan-400/70">ONLY IF</p>
+            <h2 className="mt-2 text-xl font-semibold text-white">You run a program</h2>
+            <ul className="mt-4 space-y-2 text-sm text-white/60">
+              <li>· Accelerator, studio, fund, or partner network</li>
+              <li>· Need shared diligence + kits for many startups</li>
+              <li>· Want white-label machinery with human gates</li>
+              <li>· Apply on the Accelerator hub instead</li>
+            </ul>
+          </GlowCard>
+        </div>
+        <p className="mx-auto mt-10 max-w-6xl px-6 text-sm text-white/50">
+          Creator-heavy builders can also explore open modules at{' '}
+          <a
+            href="https://github.com/frankxai/agentic-creator-os"
+            rel="noopener"
+            className="text-emerald-400 hover:underline"
+          >
+            agentic-creator-os
+          </a>{' '}
+          and the broader product ladder on frankx.ai.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/app/accelerator/guide/page.tsx
+++ b/app/accelerator/guide/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AcceleratorSubnav } from '@/components/accelerator/AcceleratorSubnav'
+
+export const metadata: Metadata = {
+  title: 'Venture Fabric Guide — How FrankX Accelerator Works',
+  description:
+    'Operating model for FrankX Accelerator and Starlight Portfolio OS: layers, human gates, open modules, Foundry vs program routes, and what pilots include.',
+  alternates: { canonical: 'https://frankx.ai/accelerator/guide' },
+}
+
+export default function AcceleratorGuidePage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/70">
+      <AcceleratorSubnav active="/accelerator/guide" />
+      <article className="mx-auto max-w-3xl px-6 pb-32 pt-16 lg:pt-24">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+          Accelerator · Guide
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight text-white md:text-5xl">
+          How Venture Fabric works.
+        </h1>
+        <p className="mt-6 text-lg leading-relaxed text-white/60">
+          A plain-language operating model for programs, partners, and serious operators. No return
+          promises. No autonomous investing. Software, workflows, and human judgment.
+        </p>
+
+        <div className="mt-16 space-y-14 text-base leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-white">The problem</h2>
+            <p className="mt-4">
+              Accelerators and funds already know how to select and advise. What breaks at scale is
+              amplification: every founder reinvents AI tooling, diligence lives in scattered docs,
+              and partner time cannot clone. Venture Fabric turns amplification into infrastructure.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">The three layers</h2>
+            <ol className="mt-4 list-decimal space-y-3 pl-5">
+              <li>
+                <strong className="text-white">L1 Founder</strong> —{' '}
+                <Link href="/foundry" className="text-emerald-400 hover:underline">
+                  Foundry
+                </Link>{' '}
+                installs one OS into one business.
+              </li>
+              <li>
+                <strong className="text-white">L2 Portfolio</strong> —{' '}
+                <Link href="/accelerator/portfolio-os" className="text-cyan-400 hover:underline">
+                  Portfolio OS
+                </Link>{' '}
+                equips a program to support many companies.
+              </li>
+              <li>
+                <strong className="text-white">L3 Capital brands</strong> — Starlight / Arcanea
+                Accelerator names may attach capital theses later. They are not required to sell L1
+                or L2.
+              </li>
+            </ol>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">What a program pilot includes</h2>
+            <ul className="mt-4 space-y-2">
+              <li>· Fit evaluation and scope (diligence sprint <em>or</em> kit installs)</li>
+              <li>· Program control plane (Git-first) and agent role pack</li>
+              <li>· Day-0 OS kit pattern for portfolio companies</li>
+              <li>· Human gate list for money, outreach, and publication</li>
+              <li>· 30-day support loop template from Investor OS patterns</li>
+            </ul>
+            <p className="mt-4">
+              Pilots do not include automated capital allocation, custody, legal fund setup, or
+              guaranteed founder outcomes.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">Open modules you can inspect today</h2>
+            <ul className="mt-4 space-y-2">
+              <li>
+                <a
+                  href="https://github.com/frankxai/Starlight-Intelligence-System"
+                  rel="noopener"
+                  className="text-cyan-400 hover:underline"
+                >
+                  Starlight Intelligence System
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/frankxai/agentic-investor-os"
+                  rel="noopener"
+                  className="text-cyan-400 hover:underline"
+                >
+                  agentic-investor-os
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/frankxai/agentic-business-os"
+                  rel="noopener"
+                  className="text-cyan-400 hover:underline"
+                >
+                  agentic-business-os
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/frankxai/agentic-creator-os"
+                  rel="noopener"
+                  className="text-cyan-400 hover:underline"
+                >
+                  agentic-creator-os
+                </a>
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">Thesis skins</h2>
+            <p className="mt-4">
+              <Link href="/accelerator/starlight" className="text-violet-300 hover:underline">
+                Starlight
+              </Link>{' '}
+              emphasizes systems and operator infrastructure.{' '}
+              <Link href="/accelerator/arcanea" className="text-amber-300 hover:underline">
+                Arcanea
+              </Link>{' '}
+              emphasizes creative intelligence and taste. Same fabric, different kit emphasis.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">Next step</h2>
+            <p className="mt-4">
+              Programs:{' '}
+              <Link href="/accelerator#apply" className="text-cyan-400 hover:underline">
+                apply for a pilot
+              </Link>
+              . Founders:{' '}
+              <Link href="/foundry" className="text-emerald-400 hover:underline">
+                Foundry
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </article>
+    </main>
+  )
+}

--- a/app/accelerator/page.tsx
+++ b/app/accelerator/page.tsx
@@ -1,0 +1,313 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { GlowCard } from '@/components/ui/glow-card'
+import { AcceleratorApplicationForm } from '@/components/accelerator/AcceleratorApplicationForm'
+import { AcceleratorSubnav } from '@/components/accelerator/AcceleratorSubnav'
+import { ACCELERATOR_FAQS } from '@/lib/accelerator-faqs'
+
+export const metadata: Metadata = {
+  title: 'FrankX Accelerator — Venture Fabric for AI-Native Programs',
+  description:
+    'The accelerator for accelerators: shared intelligence systems, diligence workflows, agent swarms, and Day-0 founder OS kits programs install across every portfolio company. Software and operations — humans approve capital.',
+  alternates: { canonical: 'https://frankx.ai/accelerator' },
+  openGraph: {
+    title: 'FrankX Accelerator — Venture Fabric',
+    description:
+      'Equip accelerators and VCs with Portfolio OS: intelligence, swarms, and founder operating systems. No autonomous investing.',
+    url: 'https://frankx.ai/accelerator',
+    images: [
+      {
+        url: '/images/blog/agentic-os-family-hero.png',
+        width: 1200,
+        height: 675,
+        alt: 'Agentic OS architecture — Venture Fabric metaphor',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'FrankX Accelerator — Venture Fabric',
+    description: 'Infrastructure for AI-native accelerators and portfolio operators.',
+    images: ['/images/blog/agentic-os-family-hero.png'],
+  },
+}
+
+const routes = [
+  {
+    title: 'Programs & funds',
+    body: 'Install Portfolio OS: diligence fabric, program memory, agent swarms, and Day-0 kits for every company.',
+    href: '/accelerator/portfolio-os',
+    cta: 'Explore Portfolio OS',
+    color: 'cyan' as const,
+  },
+  {
+    title: 'Founders & operators',
+    body: 'You need one business OS, not a multi-tenant fund stack. Start at the Foundry.',
+    href: '/accelerator/founders',
+    cta: 'Founder route',
+    color: 'emerald' as const,
+  },
+  {
+    title: 'Starlight thesis',
+    body: 'Systems, agentic companies, CoE, and B2B infrastructure brands under Starlight.',
+    href: '/accelerator/starlight',
+    cta: 'Starlight track',
+    color: 'violet' as const,
+  },
+  {
+    title: 'Arcanea thesis',
+    body: 'Creative intelligence, media, worldbuilding, and taste-heavy portfolio skins.',
+    href: '/accelerator/arcanea',
+    cta: 'Arcanea track',
+    color: 'amber' as const,
+  },
+]
+
+const layers = [
+  {
+    n: 'L1',
+    title: 'Founder surface',
+    body: 'Foundry installs one AI-native OS into one business — website, harness, gates, memory.',
+    href: '/foundry',
+  },
+  {
+    n: 'L2',
+    title: 'Portfolio surface',
+    body: 'Portfolio OS equips the whole program so amplification is software, not only office hours.',
+    href: '/accelerator/portfolio-os',
+  },
+  {
+    n: 'L3',
+    title: 'Capital brands (later)',
+    body: 'Starlight Accelerator and Arcanea Accelerator name capital theses when proof and structure exist — not day-one marketing claims.',
+    href: '/accelerator/guide',
+  },
+]
+
+const stack = [
+  {
+    name: 'Starlight Intelligence System',
+    href: 'https://github.com/frankxai/Starlight-Intelligence-System',
+    note: 'Substrate: memory, skills, governance, multi-harness fleets.',
+  },
+  {
+    name: 'agentic-investor-os',
+    href: 'https://github.com/frankxai/agentic-investor-os',
+    note: 'Thesis → intake → diligence → memo → portfolio support (human gates).',
+  },
+  {
+    name: 'agentic-business-os',
+    href: 'https://github.com/frankxai/agentic-business-os',
+    note: 'Day-0 business OS kits programs issue to startups.',
+  },
+  {
+    name: 'agentic-creator-os',
+    href: 'https://github.com/frankxai/agentic-creator-os',
+    note: 'Creator-native packs for content, product, and media founders.',
+  },
+]
+
+export default function AcceleratorHubPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://frankx.ai' },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Accelerator',
+            item: 'https://frankx.ai/accelerator',
+          },
+        ],
+      },
+      {
+        '@type': 'Service',
+        name: 'FrankX Accelerator — Venture Fabric',
+        url: 'https://frankx.ai/accelerator',
+        provider: { '@type': 'Person', name: 'Frank', url: 'https://frankx.ai' },
+        description:
+          'Agentic infrastructure for accelerators and portfolio operators: shared intelligence, diligence workflows, agent swarms, and founder OS kits. Not automated investing.',
+        areaServed: 'Worldwide',
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: ACCELERATOR_FAQS.map((f) => ({
+          '@type': 'Question',
+          name: f.question,
+          acceptedAnswer: { '@type': 'Answer', text: f.answer },
+        })),
+      },
+    ],
+  }
+
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/80">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <AcceleratorSubnav active="/accelerator" />
+
+      <section className="mx-auto max-w-6xl px-6 pb-20 pt-16 lg:pt-24">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+          FrankX Accelerator · Venture Fabric
+        </p>
+        <h1 className="max-w-4xl text-4xl font-bold tracking-tight text-white md:text-6xl">
+          The accelerator for accelerators.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-white/60">
+          Give every portfolio company a shared intelligence system, agent swarms, diligence
+          workflows, and a Day-0 operating system — the same agentic architecture that runs frankx.ai,
+          packaged so programs amplify startups without inventing a platform team from scratch.
+        </p>
+        <div className="mt-10 flex flex-wrap items-center gap-4">
+          <Link
+            href="#apply"
+            className="rounded-full bg-white px-8 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+          >
+            Apply for a program pilot
+          </Link>
+          <Link
+            href="/accelerator/portfolio-os"
+            className="px-2 py-3.5 text-sm font-semibold text-white/60 transition-colors hover:text-white"
+          >
+            Portfolio OS details
+          </Link>
+          <Link
+            href="/foundry"
+            className="px-2 py-3.5 text-sm font-semibold text-emerald-400/80 transition-colors hover:text-emerald-300"
+          >
+            I&apos;m a founder → Foundry
+          </Link>
+        </div>
+        <p className="mt-8 font-mono text-xs text-white/45">
+          Software + operations · human capital gates · no return promises · open-core modules on
+          GitHub
+        </p>
+      </section>
+
+      <section className="border-t border-white/5 py-20 lg:py-28">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+            Choose your route
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Connected surfaces. One fabric.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2">
+            {routes.map((r) => (
+              <GlowCard key={r.href} color={r.color} href={r.href} className="p-7">
+                <h3 className="text-lg font-semibold text-white">{r.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{r.body}</p>
+                <p className="mt-4 text-sm font-semibold text-white/80">{r.cta} →</p>
+              </GlowCard>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20 lg:py-28">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+            Architecture
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Three layers. Don&apos;t collapse them.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 lg:grid-cols-3">
+            {layers.map((l) => (
+              <GlowCard key={l.n} color="white" href={l.href} className="p-7">
+                <p className="font-mono text-xs text-cyan-400/70">{l.n}</p>
+                <h3 className="mt-2 text-lg font-semibold text-white">{l.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{l.body}</p>
+              </GlowCard>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20 lg:py-28">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+            Open modules
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Verify the stack. Then apply for the install.
+          </h2>
+          <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {stack.map((s) => (
+              <div
+                key={s.name}
+                className="rounded-2xl border border-white/5 bg-white/[0.03] p-6"
+              >
+                <a
+                  href={s.href}
+                  rel="noopener"
+                  className="font-mono text-sm text-cyan-300 hover:underline"
+                >
+                  {s.name}
+                </a>
+                <p className="mt-2 text-sm text-white/55">{s.note}</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-8 text-sm text-white/50">
+            Operating model write-up:{' '}
+            <Link href="/accelerator/guide" className="text-cyan-400 hover:underline">
+              /accelerator/guide
+            </Link>
+            . Single-business installs remain at{' '}
+            <Link href="/foundry" className="text-emerald-400 hover:underline">
+              /foundry
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      <section id="apply" className="border-t border-white/5 py-20 lg:py-28">
+        <div className="mx-auto max-w-3xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+            Apply
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Program pilots only. Read personally.
+          </h2>
+          <p className="mt-3 max-w-xl text-base text-white/60">
+            Tell us what you run and what a 90-day pilot should improve. Pricing follows evaluation.
+            Founders who need one OS should{' '}
+            <Link href="/foundry" className="text-emerald-400 hover:underline">
+              apply to Foundry
+            </Link>{' '}
+            instead.
+          </p>
+          <div className="mt-10">
+            <AcceleratorApplicationForm />
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20 lg:py-28">
+        <div className="mx-auto max-w-3xl px-6">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+            FAQ
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
+            Straight answers.
+          </h2>
+          <div className="mt-12 space-y-10">
+            {ACCELERATOR_FAQS.map((f) => (
+              <div key={f.question}>
+                <h3 className="text-base font-semibold text-white">{f.question}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{f.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/accelerator/portfolio-os/page.tsx
+++ b/app/accelerator/portfolio-os/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { GlowCard } from '@/components/ui/glow-card'
+import { AcceleratorSubnav } from '@/components/accelerator/AcceleratorSubnav'
+
+export const metadata: Metadata = {
+  title: 'Starlight Portfolio OS — Infrastructure for Accelerators',
+  description:
+    'Program-level intelligence, diligence workflows, agent swarms, shared pattern libraries, and Day-0 founder OS kits. The product accelerators install to amplify portfolio companies.',
+  alternates: { canonical: 'https://frankx.ai/accelerator/portfolio-os' },
+  openGraph: {
+    title: 'Starlight Portfolio OS',
+    description:
+      'Shared AI infrastructure for accelerators and VCs — not automated investing.',
+    url: 'https://frankx.ai/accelerator/portfolio-os',
+  },
+}
+
+const capabilities = [
+  {
+    title: 'Program intelligence system',
+    body: 'Thesis, deal, portfolio, and ops memory vaults — one shared brain for the program, not forty disconnected chat threads.',
+  },
+  {
+    title: 'Diligence fabric',
+    body: 'Structured intake, evidence queues, memo drafts, and risk registers using Investor OS workflows. Partners remain the decision owners.',
+  },
+  {
+    title: 'Agent swarms',
+    body: 'Program roles (intake, diligence, support, finops, compliance) plus per-startup packs for ops, build, GTM, and creative work.',
+  },
+  {
+    title: 'Day-0 founder OS kits',
+    body: 'Every accepted company receives a derived Business or Creator OS: doctrine, design contract, gates, weekly rhythm, update channel.',
+  },
+  {
+    title: 'Shared institutional patterns',
+    body: 'Anonymized cohort learnings that compound across batches — never raw founder secrets in public datasets.',
+  },
+  {
+    title: 'Human approval gates',
+    body: 'Capital, outreach, publication, credentials, and production deploys stay human-gated. Agents draft; operators decide.',
+  },
+]
+
+const delivery = [
+  {
+    n: '01',
+    title: 'Pilot scope',
+    body: 'One cohort or a bounded diligence sprint — not a multi-year SaaS fantasy on week one.',
+  },
+  {
+    n: '02',
+    title: 'Program control plane',
+    body: 'Git-first program repo + agent fabric + board cadence. Hosted console only when tenancy is ready.',
+  },
+  {
+    n: '03',
+    title: 'Issue startup kits',
+    body: 'Each company gets instance-owned brand files and shared machinery with readable harness-update PRs.',
+  },
+  {
+    n: '04',
+    title: 'Support loop',
+    body: 'Weekly portfolio support plans, proof rituals, and spend envelopes — partners review, agents prepare.',
+  },
+]
+
+export default function PortfolioOsPage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/80">
+      <AcceleratorSubnav active="/accelerator/portfolio-os" />
+
+      <section className="mx-auto max-w-6xl px-6 pb-16 pt-16 lg:pt-24">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-400/60">
+          Product · L2 Portfolio surface
+        </p>
+        <h1 className="max-w-4xl text-4xl font-bold tracking-tight text-white md:text-5xl">
+          Starlight Portfolio OS
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-white/60">
+          The operating system accelerators and VCs run so every portfolio company inherits agentic
+          infrastructure — intelligence, swarms, diligence, and founder OS kits — without each
+          startup reinventing AI chaos alone.
+        </p>
+        <div className="mt-10 flex flex-wrap gap-4">
+          <Link
+            href="/accelerator#apply"
+            className="rounded-full bg-white px-8 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90"
+          >
+            Apply for a pilot
+          </Link>
+          <Link
+            href="https://github.com/frankxai/agentic-investor-os"
+            rel="noopener"
+            className="px-2 py-3.5 text-sm font-semibold text-cyan-400/80 hover:text-cyan-300"
+          >
+            Public Investor OS →
+          </Link>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="text-3xl font-bold tracking-tight text-white">What you equip</h2>
+          <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {capabilities.map((c) => (
+              <GlowCard key={c.title} color="cyan" className="p-6">
+                <h3 className="text-base font-semibold text-white">{c.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/60">{c.body}</p>
+              </GlowCard>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="text-3xl font-bold tracking-tight text-white">How a pilot lands</h2>
+          <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {delivery.map((d) => (
+              <div key={d.n} className="rounded-2xl border border-white/5 bg-white/[0.03] p-6">
+                <p className="font-mono text-xs text-cyan-400/60">{d.n}</p>
+                <h3 className="mt-2 text-base font-semibold text-white">{d.title}</h3>
+                <p className="mt-2 text-sm text-white/60">{d.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 py-20">
+        <div className="mx-auto max-w-6xl px-6">
+          <GlowCard color="white" className="p-8">
+            <h2 className="text-2xl font-bold text-white">Brand is theirs. Machinery is shared.</h2>
+            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-white/60">
+              The same contract that powers Foundry installs: founder-facing doctrine, voice, and
+              design tokens stay instance-owned and never auto-overwritten. Shared gates, agent
+              contracts, and workflows improve upstream and arrive as readable pull requests programs
+              and companies choose to merge. See the public harness doctrine in{' '}
+              <a
+                href="https://github.com/frankxai/agentic-business-os/blob/main/HARNESS.md"
+                rel="noopener"
+                className="text-cyan-400 hover:underline"
+              >
+                agentic-business-os HARNESS.md
+              </a>
+              .
+            </p>
+            <div className="mt-8 flex flex-wrap gap-4">
+              <Link href="/accelerator/starlight" className="text-sm font-semibold text-violet-300">
+                Starlight thesis →
+              </Link>
+              <Link href="/accelerator/arcanea" className="text-sm font-semibold text-amber-300">
+                Arcanea thesis →
+              </Link>
+              <Link href="/accelerator/guide" className="text-sm font-semibold text-white/70">
+                Operating guide →
+              </Link>
+            </div>
+          </GlowCard>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/accelerator/starlight/page.tsx
+++ b/app/accelerator/starlight/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { GlowCard } from '@/components/ui/glow-card'
+import { AcceleratorSubnav } from '@/components/accelerator/AcceleratorSubnav'
+
+export const metadata: Metadata = {
+  title: 'Starlight Track — Systems Thesis for Portfolio Programs',
+  description:
+    'Starlight is the systems, agentic-company, and infrastructure thesis inside FrankX Venture Fabric — substrate, OS family, and Portfolio OS for B2B and operator-heavy portfolios.',
+  alternates: { canonical: 'https://frankx.ai/accelerator/starlight' },
+}
+
+export default function StarlightTrackPage() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0b] text-white/80">
+      <AcceleratorSubnav active="/accelerator/starlight" />
+
+      <section className="mx-auto max-w-6xl px-6 pb-16 pt-16 lg:pt-24">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.25em] text-violet-400/60">
+          Thesis skin · Starlight
+        </p>
+        <h1 className="max-w-3xl text-4xl font-bold tracking-tight text-white md:text-5xl">
+          Starlight: the systems thesis.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-white/60">
+          Starlight is the intelligence substrate and agentic-company architecture. When a portfolio
+          is B2B, operator-led, CoE-shaped, or infrastructure-heavy, programs skin Portfolio OS with
+          Starlight kits — not a separate random product line.
+        </p>
+      </section>
+
+      <section className="border-t border-white/5 py-20">
+        <div className="mx-auto max-w-6xl px-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+          <GlowCard color="violet" className="p-6">
+            <h2 className="text-base font-semibold text-white">Substrate</h2>
+            <p className="mt-2 text-sm text-white/60">
+              Memory, skills, evals, multi-harness fleets —{' '}
+              <a
+                href="https://github.com/frankxai/Starlight-Intelligence-System"
+                rel="noopener"
+                className="text-violet-300 hover:underline"
+              >
+                Starlight Intelligence System
+              </a>
+              .
+            </p>
+          </GlowCard>
+          <GlowCard color="cyan" className="p-6">
+            <h2 className="text-base font-semibold text-white">Company OS</h2>
+            <p className="mt-2 text-sm text-white/60">
+              Business OS + Investor OS patterns for serious operators who need gates, not hype.
+            </p>
+          </GlowCard>
+          <GlowCard color="white" className="p-6">
+            <h2 className="text-base font-semibold text-white">Later brand</h2>
+            <p className="mt-2 text-sm text-white/60">
+              &ldquo;Starlight Accelerator&rdquo; may name a capital thesis after proof exists. Today
+              it is a track inside Venture Fabric — not a promise of funding.
+            </p>
+          </GlowCard>
+        </div>
+        <div className="mx-auto mt-12 max-w-6xl px-6 flex flex-wrap gap-4">
+          <Link href="/accelerator/portfolio-os" className="text-sm font-semibold text-cyan-300">
+            Portfolio OS →
+          </Link>
+          <Link href="/accelerator/arcanea" className="text-sm font-semibold text-amber-300">
+            Arcanea creative thesis →
+          </Link>
+          <Link href="/os" className="text-sm font-semibold text-white/60">
+            FrankX OS surface →
+          </Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/api/accelerator/apply/route.ts
+++ b/app/api/accelerator/apply/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { appendFile, mkdir } from 'fs/promises'
+import path from 'path'
+import { leadRatelimit, getClientIdentifier } from '@/lib/ratelimit'
+import {
+  acceleratorApplicationReceivedEmail,
+  acceleratorApplicationNotifyEmail,
+  type AcceleratorApplicationInput,
+} from '@/lib/email-templates-accelerator'
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY
+const AUDIENCE_ID = '4d2e913e-6903-4dd4-8749-c02cdb844331'
+
+const VALID_ROUTES = ['program', 'fund', 'partner', 'founder'] as const
+const VALID_SIZES = ['1-10', '11-30', '31-100', '100+', 'pre'] as const
+
+function applicationsPath() {
+  const dir = process.env.VERCEL ? '/tmp' : path.join(process.cwd(), 'private')
+  return { dir, file: path.join(dir, 'accelerator-applications.jsonl') }
+}
+
+async function sendEmails(input: AcceleratorApplicationInput) {
+  if (!RESEND_API_KEY) return
+
+  const send = (to: string, subject: string, text: string) =>
+    fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from: 'Frank <frank@mail.frankx.ai>', to, subject, text }),
+    })
+
+  const confirmation = acceleratorApplicationReceivedEmail(input)
+  const notification = acceleratorApplicationNotifyEmail(input)
+
+  await Promise.allSettled([
+    send(input.email, confirmation.subject, confirmation.plainText),
+    send('frank@frankx.ai', notification.subject, notification.plainText),
+  ])
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    try {
+      const { success } = await leadRatelimit.limit(getClientIdentifier(request))
+      if (!success) {
+        return NextResponse.json(
+          { error: 'Too many submissions. Please try again later.' },
+          { status: 429 }
+        )
+      }
+    } catch (err) {
+      console.error('Accelerator rate-limit check failed (continuing open):', err)
+    }
+
+    const body = await request.json()
+
+    if (typeof body.website === 'string' && body.website.trim() !== '') {
+      return NextResponse.json({ success: true, message: 'Application received.' })
+    }
+
+    const input: AcceleratorApplicationInput = {
+      name: String(body.name ?? '')
+        .slice(0, 200)
+        .trim(),
+      email: String(body.email ?? '')
+        .slice(0, 200)
+        .trim(),
+      organization: String(body.organization ?? '')
+        .slice(0, 200)
+        .trim(),
+      role: String(body.role ?? '')
+        .slice(0, 200)
+        .trim(),
+      route: String(body.route ?? '')
+        .slice(0, 50)
+        .trim(),
+      building: String(body.building ?? '')
+        .slice(0, 2000)
+        .trim(),
+      why: String(body.why ?? '')
+        .slice(0, 2000)
+        .trim(),
+      size: String(body.size ?? '')
+        .slice(0, 50)
+        .trim(),
+      link: body.link
+        ? String(body.link)
+            .slice(0, 500)
+            .trim()
+        : undefined,
+    }
+
+    if (!input.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
+      return NextResponse.json({ error: 'Please enter a valid email address' }, { status: 400 })
+    }
+    if (!input.name || !input.organization || !input.role || !input.building || !input.why) {
+      return NextResponse.json(
+        { error: 'Name, organization, role, program context, and why-now are required' },
+        { status: 400 }
+      )
+    }
+    if (!VALID_ROUTES.includes(input.route as (typeof VALID_ROUTES)[number])) {
+      return NextResponse.json({ error: 'Please select a route' }, { status: 400 })
+    }
+    if (!VALID_SIZES.includes(input.size as (typeof VALID_SIZES)[number])) {
+      return NextResponse.json({ error: 'Please select a program size' }, { status: 400 })
+    }
+
+    try {
+      const { dir, file } = applicationsPath()
+      await mkdir(dir, { recursive: true })
+      await appendFile(
+        file,
+        JSON.stringify({ ...input, receivedAt: new Date().toISOString() }) + '\n'
+      )
+    } catch (err) {
+      console.error('Accelerator application log write failed:', err)
+    }
+
+    if (RESEND_API_KEY) {
+      const res = await fetch(`https://api.resend.com/audiences/${AUDIENCE_ID}/contacts`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: input.email,
+          first_name: input.name || undefined,
+          unsubscribed: false,
+        }),
+      })
+      if (!res.ok && res.status !== 409) {
+        console.error('Resend contact creation failed for accelerator application:', await res.text())
+      }
+    } else {
+      console.error('RESEND_API_KEY not configured — accelerator application stored to log only')
+    }
+
+    sendEmails(input).catch((err) => console.error('Accelerator application email error:', err))
+
+    return NextResponse.json({
+      success: true,
+      message: 'Application received. Frank reads every one personally.',
+    })
+  } catch (error) {
+    console.error('Accelerator application error:', error)
+    return NextResponse.json(
+      { error: 'An unexpected error occurred. Please try again.' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/foundry/page.tsx
+++ b/app/foundry/page.tsx
@@ -62,9 +62,10 @@ const osFamily = [
   },
   {
     name: 'agentic-investor-os',
-    audience: 'For wealth',
-    status: 'in development' as const,
-    note: 'Portfolio intelligence and decision memory.',
+    audience: 'For wealth & programs',
+    status: 'live' as const,
+    href: 'https://github.com/frankxai/agentic-investor-os',
+    note: 'Thesis, diligence, memos, portfolio support — human gates. Used by Portfolio OS.',
   },
 ]
 
@@ -300,6 +301,19 @@ export default function FoundryPage() {
                 The human layer: evaluate, forge, stay connected. The templates are free and
                 MIT-licensed; the Foundry prices the install, the brand derivation, and the
                 connected relationship.
+              </p>
+            </GlowCard>
+
+            <GlowCard color="cyan" href="/accelerator" className="p-7">
+              <p className="font-mono text-xs text-cyan-400/70">LAYER 3 — PROGRAMS</p>
+              <h3 className="mt-2 text-lg font-semibold text-white">
+                Accelerator · Venture Fabric
+              </h3>
+              <p className="mt-2 max-w-2xl text-sm text-white/60">
+                Accelerators, funds, and studios equip many companies with Portfolio OS — shared
+                intelligence, diligence workflows, agent swarms, and Day-0 kits. Founders stay here;
+                programs go to{' '}
+                <span className="text-cyan-300">/accelerator</span>.
               </p>
             </GlowCard>
           </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -128,6 +128,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: '/music-lab', priority: 0.8, changeFrequency: 'weekly' as const },
     { url: '/foundry', priority: 0.9, changeFrequency: 'weekly' as const },
     { url: '/foundry/guide', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/accelerator', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/accelerator/portfolio-os', priority: 0.85, changeFrequency: 'weekly' as const },
+    { url: '/accelerator/founders', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/accelerator/starlight', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/accelerator/arcanea', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/accelerator/guide', priority: 0.75, changeFrequency: 'monthly' as const },
   ]
 
   // Tool pages

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -68,6 +68,8 @@ const NAV_COLUMNS = [
     links: [
       { label: 'Start Here', href: '/start' },
       { label: 'Foundry', href: '/foundry', accent: 'emerald' },
+      { label: 'Accelerator', href: '/accelerator', accent: 'emerald' },
+      { label: 'Portfolio OS', href: '/accelerator/portfolio-os' },
       { label: "Founder's Circle", href: '/founders-circle', accent: 'rose' },
       { label: 'Coaching', href: '/coaching' },
       { label: 'Licensing', href: '/licensing' },

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -98,6 +98,19 @@ const navItems: NavItem[] = [
       { name: 'Apply', href: '/foundry#apply' },
     ],
   },
+  {
+    name: 'Accelerator',
+    href: '/accelerator',
+    subItems: [
+      { name: 'Venture Fabric', href: '/accelerator' },
+      { name: 'Portfolio OS', href: '/accelerator/portfolio-os' },
+      { name: 'For Founders', href: '/accelerator/founders' },
+      { name: 'Starlight', href: '/accelerator/starlight' },
+      { name: 'Arcanea', href: '/accelerator/arcanea' },
+      { name: 'Guide', href: '/accelerator/guide' },
+      { name: 'Apply', href: '/accelerator#apply' },
+    ],
+  },
   { name: 'Blog', href: '/blog' },
   { name: 'About', href: '/about' },
 ]

--- a/components/accelerator/AcceleratorApplicationForm.tsx
+++ b/components/accelerator/AcceleratorApplicationForm.tsx
@@ -1,0 +1,262 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+
+const ROUTES = [
+  { value: 'program', label: 'Accelerator / venture studio / portfolio program' },
+  { value: 'fund', label: 'Fund / angel syndicate / micro-VC' },
+  { value: 'partner', label: 'White-label / regional partner' },
+  { value: 'founder', label: 'Founder — I may need Foundry instead' },
+] as const
+
+const SIZES = [
+  { value: '1-10', label: '1–10 companies / year' },
+  { value: '11-30', label: '11–30 companies / year' },
+  { value: '31-100', label: '31–100 companies / year' },
+  { value: '100+', label: '100+ companies / year' },
+  { value: 'pre', label: 'Pre-launch program' },
+] as const
+
+const inputClass =
+  'w-full px-4 py-3 bg-white/[0.04] border border-white/10 rounded-xl text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-cyan-500/60 focus:border-transparent disabled:opacity-50 transition-all'
+
+export function AcceleratorApplicationForm() {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    organization: '',
+    role: '',
+    route: '',
+    building: '',
+    why: '',
+    size: '',
+    link: '',
+    website: '', // honeypot
+  })
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const set = (key: keyof typeof form) => (e: { target: { value: string } }) =>
+    setForm((f) => ({ ...f, [key]: e.target.value }))
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setStatus('loading')
+    setErrorMessage('')
+    try {
+      const res = await fetch('/api/accelerator/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Something went wrong')
+      setStatus('success')
+    } catch (err) {
+      setStatus('error')
+      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div
+        aria-live="polite"
+        className="rounded-2xl border border-cyan-500/20 bg-cyan-500/5 p-8 text-center"
+      >
+        <p className="text-lg font-semibold text-white">Application received.</p>
+        <p className="mt-2 text-sm text-white/60">
+          Frank reads every one personally — you&apos;ll hear back within a few days, and a
+          confirmation is on its way to your inbox. No drip campaign follows.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div aria-hidden="true" className="absolute -left-[9999px] top-auto h-px w-px overflow-hidden">
+        <label htmlFor="accelerator-website">Website</label>
+        <input
+          id="accelerator-website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={form.website}
+          onChange={set('website')}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="accelerator-name" className="mb-2 block text-sm font-medium text-white/70">
+            Name
+          </label>
+          <input
+            id="accelerator-name"
+            required
+            className={inputClass}
+            value={form.name}
+            onChange={set('name')}
+            disabled={status === 'loading'}
+            autoComplete="name"
+          />
+        </div>
+        <div>
+          <label htmlFor="accelerator-email" className="mb-2 block text-sm font-medium text-white/70">
+            Email
+          </label>
+          <input
+            id="accelerator-email"
+            type="email"
+            required
+            className={inputClass}
+            value={form.email}
+            onChange={set('email')}
+            disabled={status === 'loading'}
+            autoComplete="email"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor="accelerator-organization"
+            className="mb-2 block text-sm font-medium text-white/70"
+          >
+            Organization
+          </label>
+          <input
+            id="accelerator-organization"
+            required
+            className={inputClass}
+            value={form.organization}
+            onChange={set('organization')}
+            disabled={status === 'loading'}
+          />
+        </div>
+        <div>
+          <label htmlFor="accelerator-role" className="mb-2 block text-sm font-medium text-white/70">
+            Your role
+          </label>
+          <input
+            id="accelerator-role"
+            required
+            className={inputClass}
+            placeholder="GP, program lead, studio partner…"
+            value={form.role}
+            onChange={set('role')}
+            disabled={status === 'loading'}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="accelerator-route" className="mb-2 block text-sm font-medium text-white/70">
+            Route
+          </label>
+          <select
+            id="accelerator-route"
+            required
+            className={inputClass}
+            value={form.route}
+            onChange={set('route')}
+            disabled={status === 'loading'}
+          >
+            <option value="">Select…</option>
+            {ROUTES.map((r) => (
+              <option key={r.value} value={r.value} className="bg-[#0a0a0b]">
+                {r.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="accelerator-size" className="mb-2 block text-sm font-medium text-white/70">
+            Program size
+          </label>
+          <select
+            id="accelerator-size"
+            required
+            className={inputClass}
+            value={form.size}
+            onChange={set('size')}
+            disabled={status === 'loading'}
+          >
+            <option value="">Select…</option>
+            {SIZES.map((s) => (
+              <option key={s.value} value={s.value} className="bg-[#0a0a0b]">
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="accelerator-link" className="mb-2 block text-sm font-medium text-white/70">
+          Site or portfolio link (optional)
+        </label>
+        <input
+          id="accelerator-link"
+          type="url"
+          className={inputClass}
+          placeholder="https://"
+          value={form.link}
+          onChange={set('link')}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="accelerator-building" className="mb-2 block text-sm font-medium text-white/70">
+          What program do you run — or want to equip?
+        </label>
+        <textarea
+          id="accelerator-building"
+          required
+          rows={4}
+          className={inputClass}
+          value={form.building}
+          onChange={set('building')}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="accelerator-why" className="mb-2 block text-sm font-medium text-white/70">
+          Why now? What should a pilot improve in 90 days?
+        </label>
+        <textarea
+          id="accelerator-why"
+          required
+          rows={4}
+          className={inputClass}
+          value={form.why}
+          onChange={set('why')}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      {status === 'error' ? (
+        <p className="text-sm text-rose-400" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={status === 'loading'}
+        className="w-full rounded-full bg-white px-8 py-3.5 text-sm font-semibold text-black transition-colors hover:bg-white/90 disabled:opacity-50 sm:w-auto"
+      >
+        {status === 'loading' ? 'Sending…' : 'Apply for a program pilot'}
+      </button>
+      <p className="text-xs text-white/40">
+        Application-only. No guaranteed funding, returns, or automatic investment decisions.
+        Software and operating systems only — humans approve capital and outreach.
+      </p>
+    </form>
+  )
+}

--- a/components/accelerator/AcceleratorSubnav.tsx
+++ b/components/accelerator/AcceleratorSubnav.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+
+export const acceleratorNav = [
+  { href: '/accelerator', label: 'Overview' },
+  { href: '/accelerator/portfolio-os', label: 'Portfolio OS' },
+  { href: '/accelerator/founders', label: 'For founders' },
+  { href: '/accelerator/starlight', label: 'Starlight' },
+  { href: '/accelerator/arcanea', label: 'Arcanea' },
+  { href: '/accelerator/guide', label: 'Guide' },
+] as const
+
+export function AcceleratorSubnav({ active }: { active: string }) {
+  return (
+    <nav
+      aria-label="Accelerator sections"
+      className="border-b border-white/5 bg-[#0a0a0b]/80 backdrop-blur-xl"
+    >
+      <div className="mx-auto flex max-w-6xl gap-1 overflow-x-auto px-6 py-3">
+        {acceleratorNav.map((item) => {
+          const isActive = active === item.href
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                isActive
+                  ? 'bg-white/10 text-white'
+                  : 'text-white/45 hover:bg-white/5 hover:text-white/80'
+              }`}
+            >
+              {item.label}
+            </Link>
+          )
+        })}
+        <Link
+          href="/accelerator#apply"
+          className="ml-auto whitespace-nowrap rounded-full bg-cyan-500/15 px-3 py-1.5 text-xs font-semibold text-cyan-300 transition-colors hover:bg-cyan-500/25"
+        >
+          Apply
+        </Link>
+        <Link
+          href="/foundry"
+          className="whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-medium text-emerald-400/70 transition-colors hover:text-emerald-300"
+        >
+          Foundry
+        </Link>
+      </div>
+    </nav>
+  )
+}

--- a/lib/accelerator-faqs.ts
+++ b/lib/accelerator-faqs.ts
@@ -1,0 +1,49 @@
+/** Public-safe FAQs for frankx.ai/accelerator. No return promises. No investment advice. */
+
+export type AcceleratorFaq = {
+  question: string
+  answer: string
+}
+
+export const ACCELERATOR_FAQS: AcceleratorFaq[] = [
+  {
+    question: 'Is this a traditional startup accelerator with funding?',
+    answer:
+      'No. FrankX Accelerator is the public home for Venture Fabric — infrastructure, operating systems, diligence workflows, and founder OS installs. Capital brands (Starlight Accelerator, Arcanea Accelerator) are longer-horizon thesis names. Investment decisions always stay with qualified humans; software does not allocate capital.',
+  },
+  {
+    question: 'Who is this for?',
+    answer:
+      'Two primary routes. Accelerators, micro-funds, venture studios, and portfolio operators who want shared intelligence and Day-0 kits for every company. Founders and operators who want a single AI-native business OS — those should start at the Foundry.',
+  },
+  {
+    question: 'What do accelerators actually get?',
+    answer:
+      'A program-level operating layer: thesis and deal workflows (Investor OS patterns), agent role packs, Day-0 founder OS kits derived from our open Agentic OS family, update channels that arrive as readable pull requests, and human approval gates for outreach, money, and publication.',
+  },
+  {
+    question: 'Is this open source?',
+    answer:
+      'Core modules are public starters — Starlight Intelligence System, agentic-business-os, agentic-creator-os, agentic-investor-os, and related frankxai repos. Paid work is evaluation, multi-tenant program install, brand derivation, training, and ongoing harness updates. Brand and customer data stay yours.',
+  },
+  {
+    question: 'Do agents make investment decisions?',
+    answer:
+      'No. Agents draft intake, evidence queues, memos, risk registers, and support plans. Partners and GPs approve, reject, publish, or spend. The Compliance Sentinel exists to block regulated claims and flag missing evidence — not to green-light deals.',
+  },
+  {
+    question: 'How is this different from Foundry?',
+    answer:
+      'Foundry installs one operating system into one business. Accelerator / Portfolio OS equips a whole program so many startups receive a consistent agentic stack. Founders start at /foundry. Programs start at /accelerator/portfolio-os.',
+  },
+  {
+    question: 'What about pricing?',
+    answer:
+      'Founding program pilots are application-only. Pricing follows a fit conversation after we understand cohort size, diligence vs install scope, and operating capacity. Public pages do not list invented rates or guaranteed outcomes.',
+  },
+  {
+    question: 'Can we white-label this?',
+    answer:
+      'Yes as a partner path. Your brand, doctrine, and founder-facing voice stay instance-owned. Shared machinery (gates, agent contracts, update channel) can improve upstream and arrive as pull requests you choose to merge.',
+  },
+]

--- a/lib/email-templates-accelerator.ts
+++ b/lib/email-templates-accelerator.ts
@@ -1,0 +1,64 @@
+/**
+ * Accelerator / Portfolio OS application emails — plain text.
+ * Mirrors Foundry: a person wrote this; no drip marketing.
+ */
+
+export interface AcceleratorApplicationInput {
+  name: string
+  email: string
+  organization: string
+  role: string
+  route: string
+  building: string
+  why: string
+  size: string
+  link?: string
+}
+
+export function acceleratorApplicationReceivedEmail(input: AcceleratorApplicationInput) {
+  return {
+    subject: 'Your Accelerator application is in',
+    plainText: `${input.name ? `${input.name} —` : 'Hey —'}
+
+Your application for FrankX Accelerator / Portfolio OS is in. I read every one personally — usually within a few days.
+
+What happens next:
+
+1. I evaluate fit: program stage, whether you need diligence fabric, founder OS installs, or both — and whether a pilot can succeed without inventing a full SaaS platform on day one.
+2. If it's a fit, you get a short call invite to scope a pilot (one cohort or a bounded diligence sprint).
+3. If it's not a fit right now, I'll tell you straight. Open modules stay free:
+   - https://github.com/frankxai/agentic-investor-os
+   - https://github.com/frankxai/agentic-business-os
+   - https://github.com/frankxai/Starlight-Intelligence-System
+
+Founders looking for a single-business install should use https://frankx.ai/foundry instead.
+
+No drip campaign follows this email. You'll hear from me about this application and nothing else.
+
+— Frank
+frankx.ai/accelerator`,
+  }
+}
+
+export function acceleratorApplicationNotifyEmail(input: AcceleratorApplicationInput) {
+  return {
+    subject: `Accelerator application: ${input.organization || input.name}`,
+    plainText: `New Accelerator / Portfolio OS application
+
+Name:          ${input.name}
+Email:         ${input.email}
+Organization:  ${input.organization}
+Role:          ${input.role}
+Route:         ${input.route}
+Program size:  ${input.size}
+Link:          ${input.link || '—'}
+
+What they run / want to build:
+${input.building}
+
+Why now:
+${input.why}
+
+Review queue: private/accelerator-applications.jsonl (local) · /tmp on Vercel`,
+  }
+}


### PR DESCRIPTION
## Summary
- Public hub at `/accelerator` for **accelerator-for-accelerators** (Venture Fabric / Portfolio OS)
- Connected pages: portfolio-os, founders → Foundry, starlight, arcanea, guide
- Application form + `/api/accelerator/apply` (Resend + honeypot + rate limit, mirrors Foundry)
- Nav, footer, sitemap, Foundry cross-link (Layer 3 programs)
- Claims-safe: software/ops only; no return promises; human capital gates

## Private strategy (local, not in this PR)
- `starlight/repos/_business-plans/starlight-agentic-venture-os-2026/ACCELERATOR-FOR-ACCELERATORS.md`
- `.../STARLIGHT-PORTFOLIO-OS-SPEC.md`

## Test plan
- [ ] Preview: `/accelerator` and all subroutes render
- [ ] Subnav + Foundry/Accelerator cross-links work
- [ ] Apply form validation + honeypot
- [ ] `npm run type-check` (passed locally)
- [ ] Claims audit / integrity pass before `gh pr ready`