### PR TITLE
fix(contact): replace bounced hello@frankx.ai with frank@frankx.ai (4 remaining files)

### DIFF
--- a/app/api/auctions/bid/route.ts
+++ b/app/api/auctions/bid/route.ts
@@ -4,7 +4,7 @@ import auctions from '@/data/auctions.json'
 const RESEND_API_KEY = process.env.RESEND_API_KEY
 const AUDIENCE_ID = '4d2e913e-6903-4dd4-8749-c02cdb844331'
 const FROM_EMAIL = 'Frank <frank@mail.frankx.ai>'
-const NOTIFY_EMAIL = process.env.OPERATOR_EMAIL || process.env.RESEND_FROM_EMAIL || 'hello@frankx.ai'
+const NOTIFY_EMAIL = process.env.OPERATOR_EMAIL || process.env.RESEND_FROM_EMAIL || 'frank@frankx.ai'
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/media-kit/page.tsx
+++ b/app/media-kit/page.tsx
@@ -94,7 +94,7 @@ const quickFacts = [
   ['Title', 'AI Architect'],
   ['Based in', 'Amsterdam, Netherlands'],
   ['Public hub', 'https://www.frankx.ai'],
-  ['Contact', 'hello@frankx.ai'],
+  ['Contact', 'frank@frankx.ai'],
 ]
 
 const boundaries = [
@@ -190,7 +190,7 @@ export default function MediaKitPage() {
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <a
-                href="mailto:hello@frankx.ai?subject=Media%20or%20speaking%20request"
+                href="mailto:frank@frankx.ai?subject=Media%20or%20speaking%20request"
                 className="group inline-flex h-14 items-center justify-center gap-2 rounded-2xl bg-emerald-500 px-7 py-4 text-sm font-semibold text-white shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-600"
               >
                 Book or interview Frank
@@ -379,11 +379,11 @@ export default function MediaKitPage() {
             conversations are specific enough to be useful.
           </p>
           <a
-            href="mailto:hello@frankx.ai?subject=Media%20or%20speaking%20request"
+            href="mailto:frank@frankx.ai?subject=Media%20or%20speaking%20request"
             className="mt-8 inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition hover:bg-white/90"
           >
             <Mail className="h-4 w-4" />
-            hello@frankx.ai
+            frank@frankx.ai
           </a>
         </div>
       </section>

--- a/app/portal/[slug]/llms.txt/route.ts
+++ b/app/portal/[slug]/llms.txt/route.ts
@@ -108,7 +108,7 @@ export async function GET(
 
   lines.push('## Engage')
   lines.push(`${partner.cta.label}: ${partner.cta.href.startsWith('http') ? partner.cta.href : `${SITE_URL}${partner.cta.href}`}`)
-  lines.push(`Email: hello@frankx.ai`)
+  lines.push(`Email: frank@frankx.ai`)
 
   return new NextResponse(lines.join('\n') + '\n', {
     headers: {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -153,11 +153,11 @@ export default function Footer() {
             </p>
             {/* Email — direct contact signal */}
             <a
-              href="mailto:hello@frankx.ai"
+              href="mailto:frank@frankx.ai"
               className="mt-3 inline-flex items-center gap-1.5 text-xs text-white/40 hover:text-white transition-colors"
             >
               <Mail className="w-3 h-3" />
-              hello@frankx.ai
+              frank@frankx.ai
             </a>
             {/* Social links */}
             <nav aria-label="Social profiles" className="mt-4 sm:mt-5 flex flex-wrap items-center gap-x-3 gap-y-1.5">


### PR DESCRIPTION
Completes the contact-email migration that #283 claimed repo-wide but whose production deploy ERRORed, leaving 4 live files on the bounced inbox. Verified via full-tree `git grep` on main:

- `components/Footer.tsx` (2 occurrences — user-facing site footer)
- `app/media-kit/page.tsx` (4 — press contact)
- `app/api/auctions/bid/route.ts` (1 — bid confirmation path)
- `app/portal/[slug]/llms.txt/route.ts` (1 — AI-crawler contact surface)

Out of scope, intentionally: `LICENSE`, one archived plan doc, `public/downloads/acos-complete.zip`, and the inert `public/reading/.worktrees/**` junk tree (flagged for the root-hygiene lane, not a contact surface).

Supersedes the email half of #209 (closed — its 44-file diff only covered 2 of these 4 files). Tracks #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)