### PR TITLE
obs(vercel-cost): 2026-W30 snapshot — RED

### DIFF
--- a/data/observability/vercel-cost/2026-W30.json
+++ b/data/observability/vercel-cost/2026-W30.json
@@ -1,0 +1,45 @@
+{
+  "week": "2026-W30",
+  "generatedAt": "2026-07-20T07:06:49Z",
+  "projectId": "prj_NHVIKZtglNidOE1FJiq6eYx5QjIL",
+  "windowDays": 7,
+  "windowStart": "2026-07-13T07:06:49Z",
+  "windowEnd": "2026-07-20T07:06:49Z",
+  "metrics": {
+    "count_total": 20,
+    "count_production": 0,
+    "count_preview": 20,
+    "count_skipped": 3,
+    "count_error": 0,
+    "count_ready": 17,
+    "duration_p50_seconds": 547,
+    "duration_p95_seconds": 612,
+    "duration_max_seconds": 623,
+    "total_build_minutes": 158,
+    "duration_method": "readyAt_minus_buildingAt",
+    "ready_deploys_sampled": 17,
+    "ready_deploys_total": 17,
+    "duration_note": "17/17 READY deploys sampled via get_deployment (Jul 13–20). Max outlier: dpl_Bhs98Z2D4NrWme4Ca2SC9GWghy9V (623s, creator-media category infra commit, Jul 17). p95=612s via linear interpolation at position 15.2."
+  },
+  "deltas_vs_prior_week": {
+    "prior_week": "2026-W29",
+    "count_total": -80,
+    "count_total_pct": "-80.0%",
+    "count_production": -20,
+    "count_preview": -60,
+    "count_error": -1,
+    "count_error_pct": "-100.0%",
+    "count_skipped": -9,
+    "count_skipped_pct": "-75.0%",
+    "duration_p50_seconds": -23,
+    "duration_p50_pct": "-4.0%",
+    "total_build_minutes": -659,
+    "total_build_minutes_pct": "-80.7%"
+  },
+  "verdict": "RED",
+  "alerts": [
+    "duration_p50=547s > 360s RED threshold. Marginal improvement from W29's 570s (-23s, -4.0%). Build times remain structurally elevated — Turbopack + large Next.js content site averaging ~559s/build. p50 needs to fall below 360s to exit RED; currently ~52% above threshold. Max outlier=623s (dpl_Bhs98Z2D4NrWme4Ca2SC9GWghy9V, creator-media category infra, Jul 17).",
+    "count_total=20 vs 100 (W29), -80%. Zero production deploys in window — all 20 are preview/PR branch builds. Low volume consistent with a PR-heavy, merge-light week; branch claude/ai-architecture-templates-65188c dominated with 12 of 20 deploys. No production regression risk, but zero main-branch merges for 7d is worth monitoring.",
+    "count_error=0 (was 1 W29). Clean build week across all 17 READY deploys. count_skipped=3 (CANCELED, likely superseded by rapid successive pushes on the same branch)."
+  ]
+}


### PR DESCRIPTION
## /vercel-cost-watch — 2026-W30

Project: frankx-ai-vercel-website · Window: 2026-07-13T07:06Z → 2026-07-20T07:06Z (7d)

| Metric | This week | Last week | Δ | Verdict |
|---|---|---|---|---|
| Total deploys | 20 | 100 | -80 | ↓ |
| Production | 0 | 20 | -20 | ⚠️ zero merges to main |
| Preview | 20 | 80 | -60 | ↓ |
| Skipped (ignoreCommand/CANCELED) | 3 | 12 | -9 | ↓ |
| Errors | 0 | 1 | -1 | ✅ |
| Build duration p50 | 547s | 570s | -23s | 🔴 > 360s |
| Build duration p95 | 612s | 663s | -51s | 🔴 > 360s |
| Build duration max | 623s | 663s | -40s | — |
| Total build minutes | 158 | 817 | -659 | ✅ < 1500 |

**Verdict: RED** — p50=547s remains ~52% above the 360s threshold. Marginal improvement vs W29 (-23s, -4.0%), but build times are structurally elevated. All 20 deploys are preview/PR builds; zero production merges this window.

### Alerts

1. **Build duration RED (p50=547s > 360s)** — Turbopack + large Next.js content site averaging ~559s/build across 17/17 sampled READY deploys. Max outlier: `dpl_Bhs98Z2D4NrWme4Ca2SC9GWghy9V` (623s, creator-media category infra, Jul 17). p95 improved to 612s from W29's 663s tail.

2. **Zero production deploys** — All 20 deploys are preview/PR-branch builds. Branch `claude/ai-architecture-templates-65188c` dominated with 12 of 20 deploys. No production regressions possible, but no main-branch merges for 7d is worth monitoring if this persists into W31.

3. **Clean build week** — count_error=0 (was 1 in W29). count_skipped=3 (CANCELED, likely superseded by rapid same-branch pushes). All builds region: iad1.

### Methodology

- Duration: `readyAt − buildingAt` from `get_deployment` (17/17 READY deploys, full census — no sampling)
- p95: linear interpolation at position 15.2 of 17 sorted values
- Thresholds: GREEN < 270s p50; YELLOW 271–360s; RED > 360s (calibrated to May 2026 baseline)

Snapshot: `data/observability/vercel-cost/2026-W30.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACwH1RfSEa6uZ65LAyt72p)_