### PR TITLE
feat(mvu): MVU journey hub + lab event page + multi-destination QR + phone-aware contact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,16 @@ NEWSLETTER_TOKEN_SECRET=
 # Bearer token Vercel Cron sends when it calls app/api/cron/* handlers.
 CRON_SECRET=
 
+# Public Luma URL for the "Second Brain That Survives the Summit" MVU lab.
+# When set, /mvu/lab shows an RSVP-on-Luma button; when empty it shows an
+# email interest-capture form instead. Safe to leave blank until the Luma
+# event exists. NEXT_PUBLIC_ so it's readable client-side.
+NEXT_PUBLIC_MVU_LAB_LUMA_URL=
+
+# Where the /mvu/lab lab-interest alert email is sent (defaults to Frank's
+# inbox in code). Set to override without a redeploy.
+MVU_ALERT_EMAIL=
+
 # -----------------------------------------------------------------------------
 # Vercel KV (Redis) - Persistent Storage
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -33,14 +33,8 @@ NEWSLETTER_TOKEN_SECRET=
 # Bearer token Vercel Cron sends when it calls app/api/cron/* handlers.
 CRON_SECRET=
 
-# Public Luma URL for the "Second Brain That Survives the Summit" MVU lab.
-# When set, /mvu/lab shows an RSVP-on-Luma button; when empty it shows an
-# email interest-capture form instead. Safe to leave blank until the Luma
-# event exists. NEXT_PUBLIC_ so it's readable client-side.
-NEXT_PUBLIC_MVU_LAB_LUMA_URL=
-
-# Where the /mvu/lab lab-interest alert email is sent (defaults to Frank's
-# inbox in code). Set to override without a redeploy.
+# Where the /mvu/lab RSVP alert email is sent (defaults to Frank's inbox in
+# code). Each native RSVP pings this address for the by-hand approve/decline.
 MVU_ALERT_EMAIL=
 
 # -----------------------------------------------------------------------------

--- a/app/(landing)/connect/page.tsx
+++ b/app/(landing)/connect/page.tsx
@@ -59,8 +59,10 @@ function ConnectJsonLd() {
           },
         }),
         url: CONNECT_URL,
-        organizer: { '@type': 'Person', name: 'Frank Riemer', url: SITE_URL },
-        performer: { '@type': 'Person', name: 'Frank Riemer', url: SITE_URL },
+        // Frank attends these events; he does not run them. Claiming organizer
+        // or performer would assert an affiliation that does not exist — which
+        // matters most for third-party events like Mindvalley University.
+        attendee: { '@type': 'Person', name: 'Frank Riemer', url: SITE_URL },
       })),
     ],
   }

--- a/app/api/qr/route.ts
+++ b/app/api/qr/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import QRCode from 'qrcode'
+import QRCode from 'qrcode'\nimport { getClientIdentifier, qrRatelimit } from '@/lib/ratelimit'
 
 export const runtime = 'nodejs'
 
 const SITE = 'https://frankx.ai'
 const DEFAULT_SIZE = 1024
-const MAX_SIZE = 4096
+const MAX_SIZE = 4096\nconst SUPPORTED_PNG_SIZES = new Set([512, 1024, 2048])
 
 const BRAND_FOREGROUND = '#10b981'
 const BRAND_BACKGROUND = '#0a0a0b'
@@ -22,7 +22,7 @@ const DESTINATIONS = {
 type DestinationKey = keyof typeof DESTINATIONS
 
 function resolveDestination(value: string | null): (typeof DESTINATIONS)[DestinationKey] {
-  return value && value in DESTINATIONS
+  return value && Object.prototype.hasOwnProperty.call(DESTINATIONS, value)
     ? DESTINATIONS[value as DestinationKey]
     : DESTINATIONS.connect
 }
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
   const transparent = searchParams.get('bg') === 'transparent'
   const caption = searchParams.get('caption') === '1'
 
-  const dest = resolveDestination(searchParams.get('to'))
+  // The route is public and cacheable, but first-time query variants still invoke\n  // the renderer. Rate-limit those misses without turning KV availability into a\n  // dependency for an otherwise static asset.\n  try {\n    const { success } = await qrRatelimit.limit(getClientIdentifier(request))\n    if (!success) {\n      return NextResponse.json({ error: 'Too many QR render requests' }, { status: 429 })\n    }\n  } catch (error) {\n    console.warn('QR rate limit unavailable; rendering with bounded inputs', error)\n  }\n\n  const dest = resolveDestination(searchParams.get('to'))
   const targetUrl = `${SITE}${dest.path}?ref=qr`
   const fileBase = dest.path.replace(/\//g, '-').replace(/^-/, '') || 'connect'
 

--- a/app/api/qr/route.ts
+++ b/app/api/qr/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
-import QRCode from 'qrcode'\nimport { getClientIdentifier, qrRatelimit } from '@/lib/ratelimit'
+import QRCode from 'qrcode'
+import { getClientIdentifier, qrRatelimit } from '@/lib/ratelimit'
 
 export const runtime = 'nodejs'
 
 const SITE = 'https://frankx.ai'
 const DEFAULT_SIZE = 1024
-const MAX_SIZE = 4096\nconst SUPPORTED_PNG_SIZES = new Set([512, 1024, 2048])
+const MAX_SIZE = 4096
+const SUPPORTED_PNG_SIZES = new Set([512, 1024, 2048])
 
 const BRAND_FOREGROUND = '#10b981'
 const BRAND_BACKGROUND = '#0a0a0b'
@@ -56,7 +58,19 @@ export async function GET(request: NextRequest) {
   const transparent = searchParams.get('bg') === 'transparent'
   const caption = searchParams.get('caption') === '1'
 
-  // The route is public and cacheable, but first-time query variants still invoke\n  // the renderer. Rate-limit those misses without turning KV availability into a\n  // dependency for an otherwise static asset.\n  try {\n    const { success } = await qrRatelimit.limit(getClientIdentifier(request))\n    if (!success) {\n      return NextResponse.json({ error: 'Too many QR render requests' }, { status: 429 })\n    }\n  } catch (error) {\n    console.warn('QR rate limit unavailable; rendering with bounded inputs', error)\n  }\n\n  const dest = resolveDestination(searchParams.get('to'))
+  // The route is public and cacheable, but first-time query variants still invoke
+  // the renderer. Rate-limit those misses without turning KV availability into a
+  // dependency for an otherwise static asset.
+  try {
+    const { success } = await qrRatelimit.limit(getClientIdentifier(request))
+    if (!success) {
+      return NextResponse.json({ error: 'Too many QR render requests' }, { status: 429 })
+    }
+  } catch (error) {
+    console.warn('QR rate limit unavailable; rendering with bounded inputs', error)
+  }
+
+  const dest = resolveDestination(searchParams.get('to'))
   const targetUrl = `${SITE}${dest.path}?ref=qr`
   const fileBase = dest.path.replace(/\//g, '-').replace(/^-/, '') || 'connect'
 

--- a/app/api/qr/route.ts
+++ b/app/api/qr/route.ts
@@ -3,12 +3,50 @@ import QRCode from 'qrcode'
 
 export const runtime = 'nodejs'
 
-const TARGET_URL = 'https://frankx.ai/connect'
+const SITE = 'https://frankx.ai'
 const DEFAULT_SIZE = 1024
 const MAX_SIZE = 4096
 
 const BRAND_FOREGROUND = '#10b981'
 const BRAND_BACKGROUND = '#0a0a0b'
+
+// Allow-list of QR destinations. One endpoint serves every FrankX QR so the
+// print pipeline (and the /connect/qr display page) stay in one place. `ref=qr`
+// is appended for landing attribution — the destinations already track it.
+const DESTINATIONS = {
+  connect: { path: '/connect', label: 'frankx.ai/connect' },
+  mvu: { path: '/mvu', label: 'frankx.ai/mvu' },
+  lab: { path: '/mvu/lab', label: 'frankx.ai/mvu/lab' },
+} as const
+
+type DestinationKey = keyof typeof DESTINATIONS
+
+function resolveDestination(value: string | null): (typeof DESTINATIONS)[DestinationKey] {
+  return value && value in DESTINATIONS
+    ? DESTINATIONS[value as DestinationKey]
+    : DESTINATIONS.connect
+}
+
+/**
+ * Wrap a bare QR SVG in a branded card with a readable caption beneath it, so a
+ * scanner-shy human can still read the URL and it looks intentional in print.
+ * Nested <svg> preserves the inner QR's own viewBox untouched.
+ */
+function brandedSvg(innerQrSvg: string, size: number, caption: string, transparent: boolean): string {
+  const captionBand = Math.round(size * 0.16)
+  const total = size + captionBand
+  const fontSize = Math.round(size * 0.045)
+  const bg = transparent ? 'none' : BRAND_BACKGROUND
+  const inner = innerQrSvg.replace(/^<\?xml[^>]*>\s*/i, '')
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${total}" viewBox="0 0 ${size} ${total}" role="img" aria-label="QR code for ${caption}">`,
+    `<rect width="${size}" height="${total}" rx="${Math.round(size * 0.04)}" fill="${bg}"/>`,
+    `<svg x="0" y="0" width="${size}" height="${size}">${inner}</svg>`,
+    `<text x="${size / 2}" y="${size + captionBand / 2}" fill="${BRAND_FOREGROUND}" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="${fontSize}" font-weight="600" text-anchor="middle" dominant-baseline="middle" letter-spacing="0.5">${caption}</text>`,
+    `</svg>`,
+  ].join('')
+}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
@@ -16,6 +54,11 @@ export async function GET(request: NextRequest) {
   const sizeParam = Number.parseInt(searchParams.get('size') ?? `${DEFAULT_SIZE}`, 10)
   const size = Number.isFinite(sizeParam) ? Math.min(Math.max(sizeParam, 256), MAX_SIZE) : DEFAULT_SIZE
   const transparent = searchParams.get('bg') === 'transparent'
+  const caption = searchParams.get('caption') === '1'
+
+  const dest = resolveDestination(searchParams.get('to'))
+  const targetUrl = `${SITE}${dest.path}?ref=qr`
+  const fileBase = dest.path.replace(/\//g, '-').replace(/^-/, '') || 'connect'
 
   const options: QRCode.QRCodeToStringOptions & QRCode.QRCodeToBufferOptions = {
     errorCorrectionLevel: 'H',
@@ -28,26 +71,31 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    // PNG: raster, no caption (compositing text needs a canvas dep we avoid).
+    // Best for stickers/print where the URL is set alongside in the layout.
     if (fmt === 'png') {
-      const buffer = await QRCode.toBuffer(TARGET_URL, { ...options, type: 'png' })
+      const buffer = await QRCode.toBuffer(targetUrl, { ...options, type: 'png' })
       const body = new Uint8Array(buffer)
       return new NextResponse(body, {
         status: 200,
         headers: {
           'Content-Type': 'image/png',
           'Cache-Control': 'public, max-age=86400, s-maxage=604800, immutable',
-          'Content-Disposition': `inline; filename="frankx-connect-qr-${size}.png"`,
+          'Content-Disposition': `inline; filename="frankx-${fileBase}-qr-${size}.png"`,
         },
       })
     }
 
-    const svg = await QRCode.toString(TARGET_URL, { ...options, type: 'svg' })
+    // SVG: vector, optional branded caption card (?caption=1).
+    const qrSvg = await QRCode.toString(targetUrl, { ...options, type: 'svg' })
+    const svg = caption ? brandedSvg(qrSvg, size, dest.label, transparent) : qrSvg
+
     return new NextResponse(svg, {
       status: 200,
       headers: {
         'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': 'public, max-age=86400, s-maxage=604800, immutable',
-        'Content-Disposition': `inline; filename="frankx-connect-qr.svg"`,
+        'Content-Disposition': `inline; filename="frankx-${fileBase}-qr${caption ? '-card' : ''}.svg"`,
       },
     })
   } catch (error) {

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -3,6 +3,7 @@ import { musicPromptsEmail } from '@/lib/email-templates'
 import { welcomeEmail1 } from '@/lib/email-templates-welcome'
 import { ikigaiBrandingEmail } from '@/lib/email-templates-ikigai'
 import { innerCircleWaitlistEmail } from '@/lib/email-templates-inner-circle'
+import { mvuRsvpConfirmation, mvuRsvpAlert } from '@/lib/email-templates-mvu'
 
 export const runtime = 'nodejs'
 
@@ -34,6 +35,7 @@ const LIST_CONFIG: Record<string, { topics: string[] }> = {
   'courses-waitlist': { topics: [TOPICS.newsletter] },
   'ikigai-branding': { topics: [TOPICS.newsletter] },
   'premium-packs': { topics: [TOPICS.newsletter, TOPICS['product-updates']] },
+  'mvu-tallinn-2026': { topics: [TOPICS.newsletter] },
   all: { topics: [TOPICS.newsletter, TOPICS['music-suno'], TOPICS['product-updates']] },
 }
 
@@ -89,8 +91,30 @@ async function sendEmail(payload: Record<string, unknown>) {
   })
 }
 
-async function sendWelcomeEmail(email: string, name: string, listType: string) {
+async function sendWelcomeEmail(
+  email: string,
+  name: string,
+  listType: string,
+  intention = '',
+) {
   if (!RESEND_API_KEY) return
+
+  // Native RSVP for the Tallinn lab (frankx.ai/mvu/lab). Plain text — it lands
+  // right after a personal decision, and it echoes the person's own words back.
+  // The RSVP also pings Frank directly for the by-hand approve/decline call,
+  // since he's at a summit and won't be watching a dashboard.
+  if (listType === 'mvu-tallinn-2026') {
+    const confirmation = mvuRsvpConfirmation({ name, intention })
+    await sendEmail({ to: email, subject: confirmation.subject, text: confirmation.plainText })
+
+    const alert = mvuRsvpAlert({ email, name, intention })
+    await sendEmail({
+      to: process.env.MVU_ALERT_EMAIL || 'friemerx@gmail.com',
+      subject: alert.subject,
+      text: alert.plainText,
+    }).catch((err) => console.error('MVU RSVP alert error:', err))
+    return
+  }
 
   // Plain-text confirmations for the waitlist tiers — no HTML wrapper, no chrome.
   if (listType === 'inner-circle') {
@@ -162,6 +186,7 @@ export async function POST(request: NextRequest) {
     const email = String(raw.email ?? '').trim().toLowerCase()
     const name = String(raw.name ?? '').trim().slice(0, MAX_NAME_LEN)
     const source = String(raw.source ?? '').trim().slice(0, MAX_SOURCE_LEN)
+    const intention = String(raw.intention ?? '').trim().slice(0, 280)
     const listType = resolveListType(raw.listType)
 
     if (!email || email.length > MAX_EMAIL_LEN || !EMAIL_RE.test(email)) {
@@ -186,6 +211,9 @@ export async function POST(request: NextRequest) {
     const properties: Record<string, string> = { source: listType }
     if (config.topics.length) properties.topics = config.topics.join(',')
     if (source) properties.referrer = source
+    // Persist the RSVP intention so the approve/decline decision and the room's
+    // makeup are backed by a queryable segment, not only the alert emails.
+    if (intention) properties.intention = intention
 
     const fullBody: ContactBody = {
       email,
@@ -226,7 +254,7 @@ export async function POST(request: NextRequest) {
 
     // Welcome/delivery email is non-blocking — a delivery hiccup must not fail
     // the subscription itself.
-    sendWelcomeEmail(email, name, listType).catch((err) =>
+    sendWelcomeEmail(email, name, listType, intention).catch((err) =>
       console.error('Welcome email error:', err),
     )
 

--- a/app/mvu/[slug]/page.tsx
+++ b/app/mvu/[slug]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+
+import { createMetadata } from '@/lib/seo'
+import { getMvuEntries, getMvuEntry } from '@/lib/mvu'
+import { MDXContent } from '@/components/blog/MDXContent'
+
+const SITE_URL = 'https://frankx.ai'
+
+export function generateStaticParams() {
+  return getMvuEntries().map((entry) => ({ slug: entry.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const entry = getMvuEntry(slug)
+  if (!entry) {
+    return createMetadata({
+      title: 'Not found',
+      description: 'This MVU journal entry could not be found.',
+      path: `/mvu/${slug}`,
+    })
+  }
+
+  return createMetadata({
+    title: `${entry.title} — MVU journal`,
+    description: entry.summary || `${entry.title} — from Frank Riemer’s Mindvalley University journal.`,
+    path: `/mvu/${slug}`,
+  })
+}
+
+function formatDate(date: string): string {
+  if (!date) return ''
+  const d = new Date(date)
+  if (Number.isNaN(d.getTime())) return date
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+export default async function MvuEntryPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const entry = getMvuEntry(slug)
+  if (!entry) notFound()
+
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': entry.kind === 'journal' ? 'BlogPosting' : 'Article',
+    headline: entry.title,
+    description: entry.summary,
+    datePublished: entry.date,
+    author: { '@type': 'Person', name: 'Frank Riemer', url: SITE_URL },
+    publisher: { '@type': 'Organization', name: 'FrankX', url: SITE_URL },
+    url: `${SITE_URL}/mvu/${entry.slug}`,
+    isPartOf: { '@type': 'CollectionPage', name: 'MVU journal', url: `${SITE_URL}/mvu` },
+  }
+
+  return (
+    <main className="min-h-screen bg-void">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
+
+      <article className="mx-auto w-full max-w-2xl px-5 py-16 sm:py-24">
+        <Link
+          href="/mvu"
+          className="inline-flex items-center gap-1.5 text-sm text-white/50 transition-colors hover:text-tech-light"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          MVU journal
+        </Link>
+
+        <header className="mt-8">
+          <div className="flex items-center gap-3 text-xs uppercase tracking-widest text-white/40">
+            <span className="text-tech-light/80">{entry.kind}</span>
+            <span aria-hidden>·</span>
+            <time dateTime={entry.date}>{formatDate(entry.date)}</time>
+            {entry.readingTime && (
+              <>
+                <span aria-hidden>·</span>
+                <span>{entry.readingTime}</span>
+              </>
+            )}
+          </div>
+          <h1 className="mt-4 text-3xl font-bold leading-tight tracking-tight text-white sm:text-4xl">
+            {entry.title}
+          </h1>
+        </header>
+
+        <div className="prose prose-invert mt-10 max-w-none prose-headings:font-semibold prose-headings:text-white prose-p:text-white/75 prose-a:text-tech-light prose-a:no-underline hover:prose-a:underline prose-strong:text-white prose-li:text-white/75">
+          <MDXContent source={entry.content} />
+        </div>
+
+        <hr className="my-12 border-white/10" />
+
+        <p className="text-sm leading-relaxed text-white/45">
+          Independent journal. I attend Mindvalley University as a participant —
+          not affiliated with, sponsored by, or endorsed by Mindvalley.{' '}
+          <Link
+            href="/connect"
+            className="text-white/70 underline decoration-white/20 underline-offset-4 transition-colors hover:text-tech-light"
+          >
+            Met me in Tallinn? Stay in touch.
+          </Link>
+        </p>
+      </article>
+    </main>
+  )
+}

--- a/app/mvu/lab/page.tsx
+++ b/app/mvu/lab/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { ArrowLeft, Check, Clock, MapPin, Users } from 'lucide-react'
 
 import { createMetadata } from '@/lib/seo'
-import { MVU_LAB, getLabRsvpUrl } from '@/lib/mvu/lab'
+import { MVU_LAB } from '@/lib/mvu/lab'
 import { LabRsvp } from '@/components/mvu/LabRsvp'
 
 const SITE_URL = 'https://frankx.ai'
@@ -15,20 +15,20 @@ export const metadata: Metadata = createMetadata({
 })
 
 const LEAVE_WITH = [
-  'One inbox for captures — not five apps you rotate between.',
-  'A ten-minute weekly pass that turns notes into at most three commitments.',
-  'One place those commitments resurface when you can actually act on them.',
-  'The whole loop on paper first, so it works without any particular tool.',
+  'One place your captures live — not the five apps you rotate between and never reopen.',
+  'A ten-minute weekly ritual that turns a week of notes into three things you’ll actually do.',
+  'A way for the one idea that matters to come back to you at the moment you can use it.',
+  'The whole system on paper first — so it survives without an app, a subscription, or me.',
 ]
 
 const RUN_OF_SHOW = [
-  { t: '0–15', what: 'The leak — where event value actually disappears, and why capture isn’t the fix.' },
-  { t: '15–45', what: 'Build your spine — inbox, weekly pass, resurfacing. Paper first, live.' },
-  { t: '45–75', what: 'Run one real capture through the whole loop with your own material.' },
-  { t: '75–90', what: 'Your Friday commitment + how to keep the spine after Tallinn.' },
+  { t: '0–15', what: 'Where the value really goes. Not memory — the missing catch between insight and action.' },
+  { t: '15–45', what: 'You build your spine, live, on paper: one inbox, one weekly pass, one way things resurface.' },
+  { t: '45–75', what: 'Run something real from these two weeks through the whole loop, start to finish.' },
+  { t: '75–90', what: 'The one commitment you leave with — and how to keep the spine standing after Tallinn.' },
 ]
 
-function LabJsonLd({ rsvpUrl }: { rsvpUrl: string }) {
+function LabJsonLd() {
   const data = {
     '@context': 'https://schema.org',
     '@type': 'Event',
@@ -51,7 +51,7 @@ function LabJsonLd({ rsvpUrl }: { rsvpUrl: string }) {
       price: '0',
       priceCurrency: 'EUR',
       availability: 'https://schema.org/LimitedAvailability',
-      ...(rsvpUrl && { url: rsvpUrl }),
+      url: `${SITE_URL}/mvu/lab`,
     },
     url: `${SITE_URL}/mvu/lab`,
     isAccessibleForFree: true,
@@ -63,17 +63,15 @@ function LabJsonLd({ rsvpUrl }: { rsvpUrl: string }) {
 }
 
 export default function MvuLabPage() {
-  const rsvpUrl = getLabRsvpUrl()
-
   const facts = [
     { icon: Clock, label: MVU_LAB.timeLabel ? `${MVU_LAB.dateLabel} · ${MVU_LAB.timeLabel}` : '90 minutes · week two' },
-    { icon: MapPin, label: MVU_LAB.venueLabel || `${MVU_LAB.city} — address in the confirmation` },
+    { icon: MapPin, label: MVU_LAB.venueLabel || `${MVU_LAB.city} — address in your confirmation` },
     { icon: Users, label: `${MVU_LAB.capacity} people · ${MVU_LAB.price}` },
   ]
 
   return (
     <main className="min-h-screen bg-void">
-      <LabJsonLd rsvpUrl={rsvpUrl} />
+      <LabJsonLd />
 
       <div className="mx-auto w-full max-w-2xl px-5 py-16 sm:py-24">
         <Link
@@ -94,7 +92,22 @@ export default function MvuLabPage() {
           <p className="mt-5 text-lg leading-relaxed text-white/70">{MVU_LAB.tagline}</p>
         </header>
 
-        <dl className="mt-8 grid gap-3 sm:grid-cols-3">
+        {/* The stakes — why this exists */}
+        <section className="mt-10 space-y-4 text-base leading-relaxed text-white/70">
+          <p>
+            You already know the feeling. Two weeks that changed how you see things,
+            and then a Tuesday three weeks later when almost none of it is left. The
+            insight was real. It just had nowhere to live.
+          </p>
+          <p>
+            That gap — between who you become in a room like this and who you are the
+            week after — isn’t a failure of memory or willpower. It’s a missing
+            system. This lab is ninety honest minutes building the smallest system
+            that closes it. You leave with the thing, not a promise to build it later.
+          </p>
+        </section>
+
+        <dl className="mt-10 grid gap-3 sm:grid-cols-3">
           {facts.map((f) => {
             const Icon = f.icon
             return (
@@ -109,20 +122,20 @@ export default function MvuLabPage() {
         {/* RSVP */}
         <section className="mt-10 rounded-2xl border border-tech-primary/20 bg-gradient-to-br from-tech-primary/[0.06] to-transparent p-6">
           <h2 className="text-lg font-semibold text-white">
-            {rsvpUrl ? 'Reserve your seat' : 'Want this to happen?'}
+            {MVU_LAB.confirmed ? 'Ask for a seat' : 'Want this to happen?'}
           </h2>
           <p className="mb-5 mt-1.5 text-sm leading-relaxed text-white/55">
-            {rsvpUrl
-              ? `Capped at ${MVU_LAB.capacity}, approval-gated to keep the room working. Free.`
-              : 'I only run this if enough people genuinely want it. Register interest and I’ll decide by mid-week.'}
+            {MVU_LAB.confirmed
+              ? `Capped at ${MVU_LAB.capacity} and approved by hand, so it stays a room and not an audience. Free.`
+              : 'I only run this if enough people genuinely want it. Put your name down and I’ll decide by mid-week — and come back to you either way.'}
           </p>
-          <LabRsvp rsvpUrl={rsvpUrl} />
+          <LabRsvp confirmed={MVU_LAB.confirmed} />
         </section>
 
         {/* What you leave with */}
         <section className="mt-14">
           <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
-            What you leave with
+            What you walk out with
           </h2>
           <ul className="mt-5 space-y-3">
             {LEAVE_WITH.map((item) => (
@@ -137,7 +150,7 @@ export default function MvuLabPage() {
         {/* Run of show */}
         <section className="mt-14">
           <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
-            The 90 minutes
+            The ninety minutes
           </h2>
           <ul className="mt-5 space-y-4">
             {RUN_OF_SHOW.map((row) => (
@@ -157,9 +170,9 @@ export default function MvuLabPage() {
             Who it’s for
           </h2>
           <p className="mt-3 text-sm leading-relaxed text-white/70">
-            Creators, founders, and operators who leave events full of insight and
-            watch it evaporate by the following week. No tools to install, no prior
-            system required. Bring a notebook and one real thing you learned here.
+            Creators, founders, and operators who leave events full and watch it drain
+            away by the next week. No tools to install, no system required in advance.
+            Bring a notebook and one real thing you learned here — we build from that.
           </p>
         </section>
 
@@ -167,8 +180,8 @@ export default function MvuLabPage() {
 
         <p className="text-sm leading-relaxed text-white/45">
           This is an independent session I host — not organized, sponsored, or
-          endorsed by Mindvalley, and not part of the official program. It’s open to
-          anyone in Tallinn, whether or not they’re at the University.
+          endorsed by Mindvalley, and not part of the official program. Open to anyone
+          in Tallinn, whether or not they’re at the University.
         </p>
       </div>
     </main>

--- a/app/mvu/lab/page.tsx
+++ b/app/mvu/lab/page.tsx
@@ -1,0 +1,176 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft, Check, Clock, MapPin, Users } from 'lucide-react'
+
+import { createMetadata } from '@/lib/seo'
+import { MVU_LAB, getLabRsvpUrl } from '@/lib/mvu/lab'
+import { LabRsvp } from '@/components/mvu/LabRsvp'
+
+const SITE_URL = 'https://frankx.ai'
+
+export const metadata: Metadata = createMetadata({
+  title: `${MVU_LAB.title} — an independent lab in Tallinn`,
+  description: MVU_LAB.tagline,
+  path: '/mvu/lab',
+})
+
+const LEAVE_WITH = [
+  'One inbox for captures — not five apps you rotate between.',
+  'A ten-minute weekly pass that turns notes into at most three commitments.',
+  'One place those commitments resurface when you can actually act on them.',
+  'The whole loop on paper first, so it works without any particular tool.',
+]
+
+const RUN_OF_SHOW = [
+  { t: '0–15', what: 'The leak — where event value actually disappears, and why capture isn’t the fix.' },
+  { t: '15–45', what: 'Build your spine — inbox, weekly pass, resurfacing. Paper first, live.' },
+  { t: '45–75', what: 'Run one real capture through the whole loop with your own material.' },
+  { t: '75–90', what: 'Your Friday commitment + how to keep the spine after Tallinn.' },
+]
+
+function LabJsonLd({ rsvpUrl }: { rsvpUrl: string }) {
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: MVU_LAB.title,
+    description: MVU_LAB.tagline,
+    ...(MVU_LAB.dateLabel && { startDate: '2026-07-20' }),
+    endDate: '2026-08-02',
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: {
+      '@type': 'Place',
+      name: MVU_LAB.venueLabel || `${MVU_LAB.city}, Estonia`,
+      address: `${MVU_LAB.city}, Estonia`,
+    },
+    // Frank runs THIS independent lab — organizer is correct here, unlike the
+    // third-party events on /connect where he is only an attendee.
+    organizer: { '@type': 'Person', name: 'Frank Riemer', url: SITE_URL },
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'EUR',
+      availability: 'https://schema.org/LimitedAvailability',
+      ...(rsvpUrl && { url: rsvpUrl }),
+    },
+    url: `${SITE_URL}/mvu/lab`,
+    isAccessibleForFree: true,
+    maximumAttendeeCapacity: MVU_LAB.capacity,
+  }
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  )
+}
+
+export default function MvuLabPage() {
+  const rsvpUrl = getLabRsvpUrl()
+
+  const facts = [
+    { icon: Clock, label: MVU_LAB.timeLabel ? `${MVU_LAB.dateLabel} · ${MVU_LAB.timeLabel}` : '90 minutes · week two' },
+    { icon: MapPin, label: MVU_LAB.venueLabel || `${MVU_LAB.city} — address in the confirmation` },
+    { icon: Users, label: `${MVU_LAB.capacity} people · ${MVU_LAB.price}` },
+  ]
+
+  return (
+    <main className="min-h-screen bg-void">
+      <LabJsonLd rsvpUrl={rsvpUrl} />
+
+      <div className="mx-auto w-full max-w-2xl px-5 py-16 sm:py-24">
+        <Link
+          href="/mvu"
+          className="inline-flex items-center gap-1.5 text-sm text-white/50 transition-colors hover:text-tech-light"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          MVU journal
+        </Link>
+
+        <header className="mt-8">
+          <p className="text-xs font-medium uppercase tracking-widest text-tech-primary">
+            {MVU_LAB.confirmed ? 'Independent lab · Tallinn' : 'Independent lab · gauging interest'}
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+            {MVU_LAB.title}
+          </h1>
+          <p className="mt-5 text-lg leading-relaxed text-white/70">{MVU_LAB.tagline}</p>
+        </header>
+
+        <dl className="mt-8 grid gap-3 sm:grid-cols-3">
+          {facts.map((f) => {
+            const Icon = f.icon
+            return (
+              <div key={f.label} className="flex items-start gap-2.5 rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                <Icon className="mt-0.5 h-4 w-4 flex-shrink-0 text-tech-light" aria-hidden />
+                <dd className="text-sm leading-snug text-white/70">{f.label}</dd>
+              </div>
+            )
+          })}
+        </dl>
+
+        {/* RSVP */}
+        <section className="mt-10 rounded-2xl border border-tech-primary/20 bg-gradient-to-br from-tech-primary/[0.06] to-transparent p-6">
+          <h2 className="text-lg font-semibold text-white">
+            {rsvpUrl ? 'Reserve your seat' : 'Want this to happen?'}
+          </h2>
+          <p className="mb-5 mt-1.5 text-sm leading-relaxed text-white/55">
+            {rsvpUrl
+              ? `Capped at ${MVU_LAB.capacity}, approval-gated to keep the room working. Free.`
+              : 'I only run this if enough people genuinely want it. Register interest and I’ll decide by mid-week.'}
+          </p>
+          <LabRsvp rsvpUrl={rsvpUrl} />
+        </section>
+
+        {/* What you leave with */}
+        <section className="mt-14">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            What you leave with
+          </h2>
+          <ul className="mt-5 space-y-3">
+            {LEAVE_WITH.map((item) => (
+              <li key={item} className="flex items-start gap-3 text-white/75">
+                <Check className="mt-1 h-4 w-4 flex-shrink-0 text-tech-light" aria-hidden />
+                <span className="text-sm leading-relaxed">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Run of show */}
+        <section className="mt-14">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            The 90 minutes
+          </h2>
+          <ul className="mt-5 space-y-4">
+            {RUN_OF_SHOW.map((row) => (
+              <li key={row.t} className="flex gap-4">
+                <span className="w-16 flex-shrink-0 pt-0.5 text-xs font-medium tabular-nums text-tech-light/70">
+                  {row.t}
+                </span>
+                <span className="text-sm leading-relaxed text-white/70">{row.what}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Who it's for */}
+        <section className="mt-14 rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            Who it’s for
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-white/70">
+            Creators, founders, and operators who leave events full of insight and
+            watch it evaporate by the following week. No tools to install, no prior
+            system required. Bring a notebook and one real thing you learned here.
+          </p>
+        </section>
+
+        <hr className="my-12 border-white/10" />
+
+        <p className="text-sm leading-relaxed text-white/45">
+          This is an independent session I host — not organized, sponsored, or
+          endorsed by Mindvalley, and not part of the official program. It’s open to
+          anyone in Tallinn, whether or not they’re at the University.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/app/mvu/page.tsx
+++ b/app/mvu/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, BookOpen, PenLine, StickyNote } from 'lucide-react'
+
+import { createMetadata } from '@/lib/seo'
+import { getMvuEntrySummaries, type MvuKind } from '@/lib/mvu'
+import { MVU_LAB } from '@/lib/mvu/lab'
+import { EventRibbon } from '@/components/connect/EventRibbon'
+
+const SITE_URL = 'https://frankx.ai'
+const MVU_URL = `${SITE_URL}/mvu`
+
+// Revalidate hourly so newly committed journal entries and the live event
+// ribbon surface without a redeploy during the two-week window.
+export const revalidate = 3600
+
+export const metadata: Metadata = createMetadata({
+  title: 'Mindvalley University 2026 — Frank Riemer’s Tallinn journal',
+  description:
+    'Journal, essays, and the approach behind two weeks at Mindvalley University in Tallinn. Building calm systems so insights survive the week after the event. Independent — not affiliated with Mindvalley.',
+  path: '/mvu',
+})
+
+const KIND_META: Record<MvuKind, { label: string; icon: typeof BookOpen }> = {
+  essay: { label: 'Essay', icon: BookOpen },
+  journal: { label: 'Journal', icon: PenLine },
+  note: { label: 'Note', icon: StickyNote },
+}
+
+function formatDate(date: string): string {
+  if (!date) return ''
+  const d = new Date(date)
+  if (Number.isNaN(d.getTime())) return date
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function MvuJsonLd({ entryCount }: { entryCount: number }) {
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Mindvalley University 2026 — Frank Riemer’s Tallinn journal',
+    description:
+      'Journal and essays from two weeks at Mindvalley University in Tallinn, kept in the open.',
+    url: MVU_URL,
+    isPartOf: { '@type': 'WebSite', name: 'FrankX', url: SITE_URL },
+    author: { '@type': 'Person', name: 'Frank Riemer', url: SITE_URL },
+    about: { '@type': 'Event', name: 'Mindvalley University 2026', startDate: '2026-07-20', endDate: '2026-08-02' },
+    mainEntity: { '@type': 'ItemList', numberOfItems: entryCount },
+  }
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  )
+}
+
+export default function MvuPage() {
+  const entries = getMvuEntrySummaries()
+
+  return (
+    <main className="min-h-screen bg-void">
+      <MvuJsonLd entryCount={entries.length} />
+
+      <div className="mx-auto w-full max-w-3xl px-5 py-16 sm:py-24">
+        <div className="flex justify-center">
+          <EventRibbon />
+        </div>
+
+        <header className="text-center">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-tech-primary">
+            Tallinn · 20 Jul – 2 Aug 2026
+          </p>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+            Mindvalley University, in the open
+          </h1>
+          <p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-white/70">
+            Two weeks of learning, connection, and building calm systems so
+            insights survive the week after the event. This is the journal —
+            written as it happens.
+          </p>
+        </header>
+
+        {/* Lab spotlight */}
+        <Link
+          href="/mvu/lab"
+          className="group mt-12 block rounded-2xl border border-tech-primary/25 bg-gradient-to-br from-tech-primary/[0.08] to-transparent p-6 transition-colors hover:border-tech-primary/50"
+        >
+          <p className="text-xs font-medium uppercase tracking-widest text-tech-primary">
+            {MVU_LAB.confirmed ? 'Independent lab · Week 2' : 'Independent lab · gauging interest'}
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">{MVU_LAB.title}</h2>
+          <p className="mt-2 text-sm leading-relaxed text-white/60">{MVU_LAB.tagline}</p>
+          <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-tech-light">
+            {MVU_LAB.confirmed ? 'See details & RSVP' : 'Register interest'}
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" aria-hidden />
+          </span>
+        </Link>
+
+        {/* Entries */}
+        <section className="mt-16">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            Journal & essays
+          </h2>
+
+          {entries.length === 0 ? (
+            <p className="mt-6 text-white/50">First entries land here shortly.</p>
+          ) : (
+            <ul className="mt-6 divide-y divide-white/10">
+              {entries.map((entry) => {
+                const meta = KIND_META[entry.kind]
+                const Icon = meta.icon
+                return (
+                  <li key={entry.slug}>
+                    <Link
+                      href={`/mvu/${entry.slug}`}
+                      className="group flex flex-col gap-2 py-6 transition-opacity hover:opacity-90"
+                    >
+                      <div className="flex items-center gap-3 text-xs text-white/40">
+                        <span className="inline-flex items-center gap-1.5 text-tech-light/80">
+                          <Icon className="h-3.5 w-3.5" aria-hidden />
+                          {meta.label}
+                        </span>
+                        <span aria-hidden>·</span>
+                        <time dateTime={entry.date}>{formatDate(entry.date)}</time>
+                        {entry.readingTime && (
+                          <>
+                            <span aria-hidden>·</span>
+                            <span>{entry.readingTime}</span>
+                          </>
+                        )}
+                      </div>
+                      <h3 className="text-lg font-semibold text-white transition-colors group-hover:text-tech-light">
+                        {entry.title}
+                      </h3>
+                      {entry.summary && (
+                        <p className="text-sm leading-relaxed text-white/55">{entry.summary}</p>
+                      )}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </section>
+
+        <hr className="my-14 border-white/10" />
+
+        <footer className="space-y-4 text-sm leading-relaxed text-white/45">
+          <p>
+            Met me in Tallinn?{' '}
+            <Link
+              href="/connect"
+              className="text-white/70 underline decoration-white/20 underline-offset-4 transition-colors hover:text-tech-light"
+            >
+              Stay in touch here
+            </Link>
+            .
+          </p>
+          <p>
+            I attend Mindvalley University as a participant. Any session I host is
+            independent — not organized, sponsored, or endorsed by Mindvalley, and
+            not an official part of the program.
+          </p>
+        </footer>
+      </div>
+    </main>
+  )
+}

--- a/app/mvu/page.tsx
+++ b/app/mvu/page.tsx
@@ -69,12 +69,14 @@ export default function MvuPage() {
             Tallinn · 20 Jul – 2 Aug 2026
           </p>
           <h1 className="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">
-            Mindvalley University, in the open
+            Two weeks I don’t want to lose
           </h1>
           <p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-white/70">
-            Two weeks of learning, connection, and building calm systems so
-            insights survive the week after the event. This is the journal —
-            written as it happens.
+            Most of what happens at something like this evaporates by the Tuesday
+            after. So I’m writing it down as it happens — the rooms, the people, the
+            things that actually change my mind — and building the small systems that
+            let insight survive contact with normal life. This is that journal, in
+            the open.
           </p>
         </header>
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -41,6 +41,29 @@ function getBlogEntries(): { slug: string; date: string }[] {
   }
 }
 
+// Get published MVU journal entries from content/mvu directory
+function getMvuEntries(): { slug: string; date: string }[] {
+  const mvuDir = path.join(process.cwd(), 'content/mvu')
+  try {
+    return fs
+      .readdirSync(mvuDir)
+      .filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
+      .map((file) => {
+        const slug = file.replace(/\.mdx?$/, '')
+        try {
+          const { data } = matter(fs.readFileSync(path.join(mvuDir, file), 'utf8'))
+          if (data.published === false) return null
+          return { slug, date: data.date || '' }
+        } catch {
+          return { slug, date: '' }
+        }
+      })
+      .filter((e): e is { slug: string; date: string } => e !== null)
+  } catch {
+    return []
+  }
+}
+
 // Get all guide slugs from content/guides directory
 function getGuideSlugs(): string[] {
   const guidesDir = path.join(process.cwd(), 'content/guides')
@@ -388,6 +411,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   // Get dynamic content
   const blogEntries = getBlogEntries()
+  const mvuEntries = getMvuEntries()
   const guideSlugs = getGuideSlugs()
   const productSlugs = getProductSlugs()
 
@@ -624,6 +648,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: currentDate,
       changeFrequency: 'monthly',
       priority: 0.7,
+    })
+  })
+
+  // MVU journey hub + event page + journal entries
+  entries.push(
+    { url: `${BASE_URL}/mvu`, lastModified: currentDate, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/mvu/lab`, lastModified: currentDate, changeFrequency: 'weekly', priority: 0.7 },
+  )
+  mvuEntries.forEach(entry => {
+    entries.push({
+      url: `${BASE_URL}/mvu/${entry.slug}`,
+      lastModified: entry.date ? new Date(entry.date).toISOString() : currentDate,
+      changeFrequency: 'weekly',
+      priority: 0.6,
     })
   })
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,7 +5,7 @@ import matter from 'gray-matter'
 import { researchDomains } from '@/lib/research/domains'
 import { siteConfig } from '@/lib/seo'
 import { listPartners } from '@/content/partnerships'
-import { learningPaths } from '@/data/learning-paths'
+import { learningPaths } from '@/data/learning-paths'\nimport { getMvuEntrySummaries } from '@/lib/mvu'
 
 const BASE_URL = siteConfig.url
 
@@ -36,29 +36,6 @@ function getBlogEntries(): { slug: string; date: string }[] {
         }
       })
       .filter((entry): entry is { slug: string; date: string } => entry !== null)
-  } catch {
-    return []
-  }
-}
-
-// Get published MVU journal entries from content/mvu directory
-function getMvuEntries(): { slug: string; date: string }[] {
-  const mvuDir = path.join(process.cwd(), 'content/mvu')
-  try {
-    return fs
-      .readdirSync(mvuDir)
-      .filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
-      .map((file) => {
-        const slug = file.replace(/\.mdx?$/, '')
-        try {
-          const { data } = matter(fs.readFileSync(path.join(mvuDir, file), 'utf8'))
-          if (data.published === false) return null
-          return { slug, date: data.date || '' }
-        } catch {
-          return { slug, date: '' }
-        }
-      })
-      .filter((e): e is { slug: string; date: string } => e !== null)
   } catch {
     return []
   }
@@ -411,7 +388,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   // Get dynamic content
   const blogEntries = getBlogEntries()
-  const mvuEntries = getMvuEntries()
+  const mvuEntries = getMvuEntrySummaries()
   const guideSlugs = getGuideSlugs()
   const productSlugs = getProductSlugs()
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,7 +5,8 @@ import matter from 'gray-matter'
 import { researchDomains } from '@/lib/research/domains'
 import { siteConfig } from '@/lib/seo'
 import { listPartners } from '@/content/partnerships'
-import { learningPaths } from '@/data/learning-paths'\nimport { getMvuEntrySummaries } from '@/lib/mvu'
+import { learningPaths } from '@/data/learning-paths'
+import { getMvuEntrySummaries } from '@/lib/mvu'
 
 const BASE_URL = siteConfig.url
 

--- a/components/connect/SaveContactButton.tsx
+++ b/components/connect/SaveContactButton.tsx
@@ -55,7 +55,7 @@ export function SaveContactButton({
   const copy = platform ? PLATFORM_COPY[platform] : null
   const label = copy?.label ?? 'Save my contact'
 
-  const base = 'group inline-flex items-center justify-center gap-2 rounded-full font-semibold transition-all active:scale-[0.98]'
+  const base = 'group inline-flex items-center justify-center gap-2 rounded-full font-semibold transition-all active:scale-[0.98] motion-reduce:transform-none motion-reduce:transition-none'
   const styles =
     variant === 'primary'
       ? 'bg-gradient-to-r from-emerald-500 via-emerald-400 to-cyan-400 px-6 py-3.5 text-sm text-black shadow-[0_10px_40px_-12px_rgba(16,185,129,0.7)] hover:shadow-[0_14px_50px_-10px_rgba(16,185,129,0.85)] hover:scale-[1.02]'
@@ -68,7 +68,7 @@ export function SaveContactButton({
       onClick={() => trackEvent('connect_vcard_downloaded', { source: 'connect_hero', platform: platform ?? 'unknown' })}
       className={`${base} ${styles} ${className}`}
     >
-      <Download className="h-4 w-4 transition-transform group-hover:-translate-y-0.5" aria-hidden />
+      <Download className="h-4 w-4 transition-transform group-hover:-translate-y-0.5 motion-reduce:transform-none motion-reduce:transition-none" aria-hidden />
       <span>{label}</span>
     </a>
   )

--- a/components/connect/SaveContactButton.tsx
+++ b/components/connect/SaveContactButton.tsx
@@ -1,29 +1,84 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { Download } from 'lucide-react'
 import { trackEvent } from '@/lib/analytics'
 
 interface SaveContactButtonProps {
   variant?: 'primary' | 'ghost'
   className?: string
+  /** Show a one-line platform-specific hint under the button. */
+  showHint?: boolean
 }
 
-export function SaveContactButton({ variant = 'primary', className = '' }: SaveContactButtonProps) {
+type Platform = 'ios' | 'android' | 'desktop'
+
+// A .vcf is universal, but the *experience* differs by device: iOS opens the
+// contact card straight into Contacts; Android downloads the file to be tapped;
+// desktop just saves it. Naming what will happen removes the "did that work?"
+// hesitation at the exact moment someone taps at an event.
+const PLATFORM_COPY: Record<Platform, { label: string; hint: string }> = {
+  ios: {
+    label: 'Add to Apple Contacts',
+    hint: 'Opens straight into your Contacts — tap Done to save.',
+  },
+  android: {
+    label: 'Save to Contacts',
+    hint: 'Downloads a contact card — tap it, then Import to save.',
+  },
+  desktop: {
+    label: 'Download contact card',
+    hint: 'Saves a .vcf you can open on your phone or mail client.',
+  },
+}
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'desktop'
+  const ua = navigator.userAgent || ''
+  // iPadOS 13+ reports as Mac; the touch-point check catches it.
+  const isIOS = /iPad|iPhone|iPod/.test(ua) || (ua.includes('Mac') && navigator.maxTouchPoints > 1)
+  if (isIOS) return 'ios'
+  if (/Android/.test(ua)) return 'android'
+  return 'desktop'
+}
+
+export function SaveContactButton({
+  variant = 'primary',
+  className = '',
+  showHint = false,
+}: SaveContactButtonProps) {
+  // Start neutral so SSR and first client render match (no hydration flash),
+  // then specialise once we can read the user agent.
+  const [platform, setPlatform] = useState<Platform | null>(null)
+  useEffect(() => setPlatform(detectPlatform()), [])
+
+  const copy = platform ? PLATFORM_COPY[platform] : null
+  const label = copy?.label ?? 'Save my contact'
+
   const base = 'group inline-flex items-center justify-center gap-2 rounded-full font-semibold transition-all active:scale-[0.98]'
   const styles =
     variant === 'primary'
       ? 'bg-gradient-to-r from-emerald-500 via-emerald-400 to-cyan-400 px-6 py-3.5 text-sm text-black shadow-[0_10px_40px_-12px_rgba(16,185,129,0.7)] hover:shadow-[0_14px_50px_-10px_rgba(16,185,129,0.85)] hover:scale-[1.02]'
       : 'border border-white/15 bg-white/5 px-6 py-3.5 text-sm text-white backdrop-blur hover:border-white/30 hover:bg-white/10'
 
-  return (
+  const button = (
     <a
       href="/api/vcard"
       download="frank-riemer.vcf"
-      onClick={() => trackEvent('connect_vcard_downloaded', { source: 'connect_hero' })}
+      onClick={() => trackEvent('connect_vcard_downloaded', { source: 'connect_hero', platform: platform ?? 'unknown' })}
       className={`${base} ${styles} ${className}`}
     >
       <Download className="h-4 w-4 transition-transform group-hover:-translate-y-0.5" aria-hidden />
-      <span>Save my contact</span>
+      <span>{label}</span>
     </a>
+  )
+
+  if (!showHint) return button
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      {button}
+      {copy && <p className="text-xs text-white/45">{copy.hint}</p>}
+    </div>
   )
 }

--- a/components/mvu/LabRsvp.tsx
+++ b/components/mvu/LabRsvp.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { ArrowUpRight } from 'lucide-react'
+
+/**
+ * RSVP for the MVU lab.
+ *
+ * Two states, chosen server-side by whether a Luma URL exists:
+ *  - Luma live  → a single clear button to the real RSVP page.
+ *  - Not yet    → inline interest capture (reuses /api/subscribe with the
+ *                 mvu-tallinn-2026 list + labInterest flag) so demand is
+ *                 measured even before the event exists. This is the signal
+ *                 behind the week-two go/no-go.
+ */
+export function LabRsvp({ rsvpUrl }: { rsvpUrl: string }) {
+  const [email, setEmail] = useState('')
+  const [name, setName] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+
+  if (rsvpUrl) {
+    return (
+      <a
+        href={rsvpUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center justify-center gap-2 rounded-xl bg-tech-primary px-7 py-3.5 font-semibold text-void transition-colors hover:bg-tech-light"
+      >
+        RSVP on Luma
+        <ArrowUpRight className="h-4 w-4" aria-hidden />
+      </a>
+    )
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setStatus('loading')
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          name,
+          listType: 'mvu-tallinn-2026',
+          labInterest: true,
+          source: 'mvu-lab-page',
+        }),
+      })
+      const data = await res.json()
+      if (res.ok) {
+        setStatus('success')
+        setMessage(data.message || 'Got it — you’re on the list.')
+      } else {
+        setStatus('error')
+        setMessage(data.error || 'Something went wrong.')
+      }
+    } catch {
+      setStatus('error')
+      setMessage('Network error — try again?')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-2xl border border-tech-primary/30 bg-tech-primary/5 p-6" role="status">
+        <p className="font-medium text-tech-light">{message}</p>
+        <p className="mt-2 text-sm text-white/60">
+          If the lab runs, you’ll get the time, place, and a confirmation link. If
+          not enough people want it, I’ll tell you that too — no spam either way.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          autoComplete="name"
+          aria-label="Name"
+          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 transition-colors focus:border-tech-primary/50 focus:outline-none focus:ring-2 focus:ring-tech-primary/20"
+          disabled={status === 'loading'}
+        />
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          required
+          autoComplete="email"
+          inputMode="email"
+          aria-label="Email"
+          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 transition-colors focus:border-tech-primary/50 focus:outline-none focus:ring-2 focus:ring-tech-primary/20"
+          disabled={status === 'loading'}
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={status === 'loading'}
+        className="w-full rounded-xl bg-tech-primary px-6 py-3.5 font-semibold text-void transition-colors hover:bg-tech-light disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:px-8"
+      >
+        {status === 'loading' ? 'Sending…' : 'Register interest'}
+      </button>
+      {status === 'error' && (
+        <p className="text-sm text-red-400" role="alert">
+          {message}
+        </p>
+      )}
+      <p className="text-xs leading-relaxed text-white/35">
+        Registering interest isn’t a ticket — it tells me whether to run the lab.
+        One note from me if it happens, nothing otherwise.
+      </p>
+    </form>
+  )
+}

--- a/components/mvu/LabRsvp.tsx
+++ b/components/mvu/LabRsvp.tsx
@@ -1,37 +1,22 @@
 'use client'
 
 import { useState, FormEvent } from 'react'
-import { ArrowUpRight } from 'lucide-react'
 
 /**
- * RSVP for the MVU lab.
+ * Native RSVP for the MVU lab — hosted entirely on frankx.ai, no third-party
+ * event tool. Posts to /api/subscribe (mvu-tallinn-2026), which segments the
+ * contact, records the intention, and emails Frank for the by-hand approval.
  *
- * Two states, chosen server-side by whether a Luma URL exists:
- *  - Luma live  → a single clear button to the real RSVP page.
- *  - Not yet    → inline interest capture (reuses /api/subscribe with the
- *                 mvu-tallinn-2026 list + labInterest flag) so demand is
- *                 measured even before the event exists. This is the signal
- *                 behind the week-two go/no-go.
+ * The intention line is the point: asking someone to name what they want to
+ * leave with turns a click into a small commitment, and gives Frank a real
+ * basis for who to seat. It's optional so it never becomes a wall.
  */
-export function LabRsvp({ rsvpUrl }: { rsvpUrl: string }) {
-  const [email, setEmail] = useState('')
+export function LabRsvp({ confirmed }: { confirmed: boolean }) {
   const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [intention, setIntention] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [message, setMessage] = useState('')
-
-  if (rsvpUrl) {
-    return (
-      <a
-        href={rsvpUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center justify-center gap-2 rounded-xl bg-tech-primary px-7 py-3.5 font-semibold text-void transition-colors hover:bg-tech-light"
-      >
-        RSVP on Luma
-        <ArrowUpRight className="h-4 w-4" aria-hidden />
-      </a>
-    )
-  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -43,15 +28,15 @@ export function LabRsvp({ rsvpUrl }: { rsvpUrl: string }) {
         body: JSON.stringify({
           email,
           name,
+          intention,
           listType: 'mvu-tallinn-2026',
-          labInterest: true,
           source: 'mvu-lab-page',
         }),
       })
       const data = await res.json()
       if (res.ok) {
         setStatus('success')
-        setMessage(data.message || 'Got it — you’re on the list.')
+        setMessage(data.message || '')
       } else {
         setStatus('error')
         setMessage(data.error || 'Something went wrong.')
@@ -65,10 +50,11 @@ export function LabRsvp({ rsvpUrl }: { rsvpUrl: string }) {
   if (status === 'success') {
     return (
       <div className="rounded-2xl border border-tech-primary/30 bg-tech-primary/5 p-6" role="status">
-        <p className="font-medium text-tech-light">{message}</p>
-        <p className="mt-2 text-sm text-white/60">
-          If the lab runs, you’ll get the time, place, and a confirmation link. If
-          not enough people want it, I’ll tell you that too — no spam either way.
+        <p className="font-medium text-tech-light">You’re on the list — check your email.</p>
+        <p className="mt-2 text-sm leading-relaxed text-white/60">
+          I approve each seat by hand to keep the room small. If there’s a place for
+          you, you’ll get the time, the address, and one thing to bring. If it fills
+          first, I’ll tell you straight — no waitlist theatre.
         </p>
       </div>
     )
@@ -100,21 +86,36 @@ export function LabRsvp({ rsvpUrl }: { rsvpUrl: string }) {
           disabled={status === 'loading'}
         />
       </div>
+
+      <textarea
+        value={intention}
+        onChange={(e) => setIntention(e.target.value)}
+        placeholder="Optional — what do you want to still be doing a month from now?"
+        rows={2}
+        maxLength={280}
+        aria-label="What you want to leave with"
+        className="w-full resize-none rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/30 transition-colors focus:border-tech-primary/50 focus:outline-none focus:ring-2 focus:ring-tech-primary/20"
+        disabled={status === 'loading'}
+      />
+
       <button
         type="submit"
         disabled={status === 'loading'}
         className="w-full rounded-xl bg-tech-primary px-6 py-3.5 font-semibold text-void transition-colors hover:bg-tech-light disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:px-8"
       >
-        {status === 'loading' ? 'Sending…' : 'Register interest'}
+        {status === 'loading' ? 'Sending…' : confirmed ? 'Request a seat' : 'Put my name down'}
       </button>
+
       {status === 'error' && (
         <p className="text-sm text-red-400" role="alert">
           {message}
         </p>
       )}
+
       <p className="text-xs leading-relaxed text-white/35">
-        Registering interest isn’t a ticket — it tells me whether to run the lab.
-        One note from me if it happens, nothing otherwise.
+        {confirmed
+          ? 'Requesting a seat isn’t a guaranteed ticket — I confirm each one by hand to keep the room right. One honest note from me either way.'
+          : 'This tells me whether to run the lab at all. If enough people want it, I’ll set a time and come back to you. Nothing else, ever.'}
       </p>
     </form>
   )

--- a/content/mvu/00-the-approach.md
+++ b/content/mvu/00-the-approach.md
@@ -2,46 +2,49 @@
 title: "Why I came to Tallinn — the approach"
 date: "2026-07-20"
 kind: "essay"
-summary: "I build calm systems so insights survive the week after the event. Here is how I'm running two weeks at Mindvalley University — and why."
+summary: "I build calm systems so what we find at events survives contact with normal life. Here is how I'm spending two weeks at Mindvalley University — and what I refuse to do with them."
 tags: ["approach", "second-brain", "integration"]
 published: true
 ---
 
-I build calm operating systems for creators — the unglamorous spine that keeps
-an idea alive after the room empties. That's the whole reason I'm in Tallinn.
+I build calm operating systems for creators — the quiet spine that keeps an idea
+alive after the room empties and everyone flies home. That's the whole reason
+I'm in Tallinn.
 
 Mindvalley University runs 20 July to 2 August 2026. I'm here as a participant,
 not a vendor. Nothing I write here is organized, sponsored, or endorsed by
-Mindvalley — this is my own journal, kept in the open.
+Mindvalley — this is my own journal, kept in the open because writing it down
+is how I make sure the two weeks change me and not just my calendar.
 
-## The problem I actually care about
+## What I actually care about
 
-Most high-signal events end the same way. You leave full. Two weeks later the
-notes are a graveyard: highlights you never reopened, contacts you never
-messaged, one framework you half-remember. The insight was real. The
-*integration* never happened.
+There's a specific kind of loss I've felt after every meaningful event of my
+life. For a few days you're someone slightly better — clearer, braver, more
+generous. Then the ordinary week closes back over you and that person quietly
+leaves. The insight was real. It just had nowhere to live.
 
-I've stopped believing the fix is more capture. Capture is not the bottleneck —
-everyone captures. The bottleneck is the system that turns a capture into a
-practice you actually keep. That's the thing I build, and it's the lens I'm
-bringing to every room here.
+I've stopped believing the answer is more notes. Everyone captures. The thing
+that's missing is the small system that turns a capture into a practice you
+keep — the bridge between who you become in a room like this and who you are the
+Tuesday after. That bridge is what I build, and it's the lens I'm bringing to
+every conversation here.
 
-## How I'm running the two weeks
+## How I'm spending the two weeks
 
 Three commitments, in order:
 
-1. **Learn first.** Deep exposure to teachers and rooms outside pure tech —
-   people who move states and hold a room, not just people who ship code.
-2. **Connect for real.** A small number of high-trust conversations with a
-   specific next step beats a phone full of "nice to meet you." No scraping, no
-   mass DMs — that's a line I won't cross.
-3. **Build selectively.** If the energy is right, one small independent lab in
-   week two. If it isn't, I let it go without guilt. The learning is the win.
+1. **Learn first, and for real.** Deep time with teachers and rooms outside my
+   own field — people who move a room's state, not only people who ship code.
+2. **Connect like it matters.** A handful of honest conversations with a real
+   next step beats a phone full of contacts I'll never message. No scraping, no
+   mass DMs — that's a line I hold.
+3. **Build only if it's right.** Maybe one small independent lab in week two. If
+   the energy isn't there, I let it go without apology. The learning is the win.
 
 ## What this hub is
 
-Everything I write during these two weeks lands here — journal entries, short
-essays, the occasional decision I want on the record. It's the public companion
-to a private working system. You're reading the integration layer as it happens.
+Everything I write across these two weeks lands here — journal entries, short
+essays, a decision I want on the record. It's the public face of a private
+working system, and you're reading the integration happen in real time.
 
-If we meet in Tallinn and want to stay in touch, [that's here](/connect).
+If we meet in Tallinn and want to keep the thread, [it's here](/connect).

--- a/content/mvu/00-the-approach.md
+++ b/content/mvu/00-the-approach.md
@@ -1,0 +1,47 @@
+---
+title: "Why I came to Tallinn — the approach"
+date: "2026-07-20"
+kind: "essay"
+summary: "I build calm systems so insights survive the week after the event. Here is how I'm running two weeks at Mindvalley University — and why."
+tags: ["approach", "second-brain", "integration"]
+published: true
+---
+
+I build calm operating systems for creators — the unglamorous spine that keeps
+an idea alive after the room empties. That's the whole reason I'm in Tallinn.
+
+Mindvalley University runs 20 July to 2 August 2026. I'm here as a participant,
+not a vendor. Nothing I write here is organized, sponsored, or endorsed by
+Mindvalley — this is my own journal, kept in the open.
+
+## The problem I actually care about
+
+Most high-signal events end the same way. You leave full. Two weeks later the
+notes are a graveyard: highlights you never reopened, contacts you never
+messaged, one framework you half-remember. The insight was real. The
+*integration* never happened.
+
+I've stopped believing the fix is more capture. Capture is not the bottleneck —
+everyone captures. The bottleneck is the system that turns a capture into a
+practice you actually keep. That's the thing I build, and it's the lens I'm
+bringing to every room here.
+
+## How I'm running the two weeks
+
+Three commitments, in order:
+
+1. **Learn first.** Deep exposure to teachers and rooms outside pure tech —
+   people who move states and hold a room, not just people who ship code.
+2. **Connect for real.** A small number of high-trust conversations with a
+   specific next step beats a phone full of "nice to meet you." No scraping, no
+   mass DMs — that's a line I won't cross.
+3. **Build selectively.** If the energy is right, one small independent lab in
+   week two. If it isn't, I let it go without guilt. The learning is the win.
+
+## What this hub is
+
+Everything I write during these two weeks lands here — journal entries, short
+essays, the occasional decision I want on the record. It's the public companion
+to a private working system. You're reading the integration layer as it happens.
+
+If we meet in Tallinn and want to stay in touch, [that's here](/connect).

--- a/content/mvu/2026-07-20-day-one.md
+++ b/content/mvu/2026-07-20-day-one.md
@@ -1,0 +1,29 @@
+---
+title: "Day one — arriving without an agenda to sell"
+date: "2026-07-20"
+kind: "journal"
+summary: "First evening in Tallinn. The discipline this week isn't doing more — it's staying present enough to actually meet people."
+tags: ["journal", "day-1", "tallinn"]
+published: true
+---
+
+Landed into a city that treats itself as part of the promise. Tallinn is doing
+some of the work before anyone says a word — the place is a character, not a
+backdrop. Worth noticing, because I do the same thing when I design a room.
+
+The temptation on day one of anything like this is to arrive optimizing. Line up
+the pitch, rank the targets, work the floor. I've done it. It produces a full
+calendar and a thin two weeks.
+
+So the rule I set for tonight was small on purpose: two real conversations, one
+mutual next step, one honest note before sleep. That's it. Presence is the asset
+I flew here for — everything else compounds off it or it doesn't happen at all.
+
+The 10-second version of me, when someone asks: *I build calm systems so ideas
+survive the week after the high of an event. Here mostly to learn and meet good
+humans.* If the room wants more, it asks. If it doesn't, I've said something true
+and short.
+
+One thing I already want on the record: the strongest people I met tonight
+weren't selling anything. They asked better questions than they answered. Note
+to self for the rest of the week — be that.

--- a/content/mvu/2026-07-20-day-one.md
+++ b/content/mvu/2026-07-20-day-one.md
@@ -1,29 +1,30 @@
 ---
-title: "Day one — arriving without an agenda to sell"
+title: "Day one — arriving without something to sell"
 date: "2026-07-20"
 kind: "journal"
-summary: "First evening in Tallinn. The discipline this week isn't doing more — it's staying present enough to actually meet people."
+summary: "First evening in Tallinn. The discipline this week isn't doing more. It's being present enough that the people I meet are actually met."
 tags: ["journal", "day-1", "tallinn"]
 published: true
 ---
 
-Landed into a city that treats itself as part of the promise. Tallinn is doing
-some of the work before anyone says a word — the place is a character, not a
-backdrop. Worth noticing, because I do the same thing when I design a room.
+Landed into a city that does some of the work before anyone speaks. Tallinn
+carries itself — the old walls, the light off the water — and the place becomes
+part of what you feel here. Worth noticing, because it's the same move I make
+when I design a room: the setting is never neutral.
 
-The temptation on day one of anything like this is to arrive optimizing. Line up
-the pitch, rank the targets, work the floor. I've done it. It produces a full
-calendar and a thin two weeks.
+The temptation on day one of anything like this is to arrive optimizing. Rank
+the targets, sharpen the pitch, work the floor. I've done exactly that, and it
+produces a full week and a thin one at the same time — motion without contact.
 
-So the rule I set for tonight was small on purpose: two real conversations, one
-mutual next step, one honest note before sleep. That's it. Presence is the asset
-I flew here for — everything else compounds off it or it doesn't happen at all.
+So tonight's rule was small on purpose. Two real conversations. One mutual next
+step. One honest line before sleep. That's the whole list. Presence is the asset
+I flew here for; everything worth having compounds off it, or it doesn't happen.
 
-The 10-second version of me, when someone asks: *I build calm systems so ideas
-survive the week after the high of an event. Here mostly to learn and meet good
-humans.* If the room wants more, it asks. If it doesn't, I've said something true
-and short.
+When someone asks what I do, the true short version: *I build calm systems so
+what you find at events like this survives the week after. I'm here mostly to
+learn and meet good people.* If the room wants more, it asks. If it doesn't,
+I've said something honest and short, and that's enough.
 
-One thing I already want on the record: the strongest people I met tonight
-weren't selling anything. They asked better questions than they answered. Note
-to self for the rest of the week — be that.
+One thing already worth keeping: the people who moved me tonight weren't selling
+anything. They asked better questions than they answered, and they stayed for
+the answer. Note for the rest of the week — be that person.

--- a/content/mvu/2026-07-22-insight-decay.md
+++ b/content/mvu/2026-07-22-insight-decay.md
@@ -1,0 +1,39 @@
+---
+title: "Insight decay is a systems problem, not a memory problem"
+date: "2026-07-22"
+kind: "essay"
+summary: "Why the value of an event leaks out in the two weeks after — and the small spine that stops it. The thesis behind the lab I might run here."
+tags: ["essay", "second-brain", "thesis"]
+published: true
+---
+
+Here's the pattern I keep watching, at every summit, retreat, and conference I've
+been to. The half-life of an insight is about 72 hours. By day three the charge
+is gone; by week two the notes are archaeology.
+
+The usual explanation is memory — "I forgot to follow up." I think that's wrong,
+or at least shallow. You didn't forget. There was no system standing by to catch
+the insight and turn it into a next action while it was still warm. Memory isn't
+the leak. The missing spine is.
+
+## The three places the value leaks
+
+- **Capture with no home.** Notes land in whatever app is open — a different one
+  each time. Nothing that scatters gets reviewed.
+- **No conversion step.** A highlight is not a decision. Without a moment where
+  "this mattered" becomes "so I will do X by Friday," insight stays inert.
+- **No resurfacing.** The one idea worth keeping never comes back around at the
+  moment you could use it. Out of sight, gone.
+
+## The spine that fixes it
+
+It's smaller than people expect. One inbox, not five. A weekly ten-minute pass
+that turns captures into at most three commitments. One place those commitments
+resurface. That's most of it. The tooling matters far less than the loop — I've
+run versions of this on paper, and paper-first is often the right way to learn it.
+
+This is the thesis behind the one lab I may host in week two here in Tallinn:
+[Second Brain That Survives the Summit](/mvu/lab). Ninety minutes, paper first,
+and you leave with a working spine rather than a promise to build one later.
+
+If the leak is a systems problem, the fix is a system. That's the whole idea.

--- a/content/mvu/2026-07-22-insight-decay.md
+++ b/content/mvu/2026-07-22-insight-decay.md
@@ -1,39 +1,50 @@
 ---
-title: "Insight decay is a systems problem, not a memory problem"
+title: "The cost of an insight you never live"
 date: "2026-07-22"
 kind: "essay"
-summary: "Why the value of an event leaks out in the two weeks after — and the small spine that stops it. The thesis behind the lab I might run here."
+summary: "The value of an event doesn't fade because you forget. It fades because nothing was standing by to catch it. The thesis behind the lab I might run here."
 tags: ["essay", "second-brain", "thesis"]
 published: true
 ---
 
-Here's the pattern I keep watching, at every summit, retreat, and conference I've
-been to. The half-life of an insight is about 72 hours. By day three the charge
-is gone; by week two the notes are archaeology.
+Here's the pattern I've watched at every summit, retreat, and conference I've
+been to, including this one. An insight has a half-life of about seventy-two
+hours. By day three the charge is gone. By the second week the notes are
+archaeology — artifacts of a person who briefly saw further and then came back
+down.
 
-The usual explanation is memory — "I forgot to follow up." I think that's wrong,
-or at least shallow. You didn't forget. There was no system standing by to catch
-the insight and turn it into a next action while it was still warm. Memory isn't
-the leak. The missing spine is.
+The usual story is memory: *I forgot to follow up.* I think that's too kind to
+the problem. You didn't forget. There was simply nothing standing by to catch
+the insight and move it into your life while it was still warm. Memory isn't the
+leak. The missing catch is.
 
-## The three places the value leaks
+And the cost isn't small. Every unlived insight is a version of you that almost
+existed — braver, clearer, more finished — and then didn't, because the system
+around you couldn't hold it. Do that enough times and you start to distrust your
+own peaks. You stop expecting anything to change. That's the real damage: not a
+lost note, but a slow erosion of the belief that what you learn can become who
+you are.
 
-- **Capture with no home.** Notes land in whatever app is open — a different one
-  each time. Nothing that scatters gets reviewed.
-- **No conversion step.** A highlight is not a decision. Without a moment where
-  "this mattered" becomes "so I will do X by Friday," insight stays inert.
-- **No resurfacing.** The one idea worth keeping never comes back around at the
-  moment you could use it. Out of sight, gone.
+## The three places it leaks
 
-## The spine that fixes it
+- **Capture with no home.** Notes land in whatever app is open, a different one
+  each time. What scatters is never reviewed.
+- **No conversion.** A highlight is not a decision. Without a moment where "this
+  mattered" becomes "so I will do X by Friday," the insight stays inert.
+- **No return.** The one idea worth keeping never comes back at the moment you
+  could act on it. Out of sight, and then gone.
 
-It's smaller than people expect. One inbox, not five. A weekly ten-minute pass
-that turns captures into at most three commitments. One place those commitments
-resurface. That's most of it. The tooling matters far less than the loop — I've
-run versions of this on paper, and paper-first is often the right way to learn it.
+## The spine that closes it
 
-This is the thesis behind the one lab I may host in week two here in Tallinn:
+It's smaller than people expect, which is exactly why it works. One inbox, not
+five. A ten-minute weekly pass that turns a week of captures into at most three
+commitments. One place those commitments resurface when they're useful. That's
+most of it. The tooling matters far less than the loop — I've run versions of
+this on paper, and paper-first is often the best way to actually learn it.
+
+This is the thesis behind the one lab I may host in week two:
 [Second Brain That Survives the Summit](/mvu/lab). Ninety minutes, paper first,
-and you leave with a working spine rather than a promise to build one later.
+and you leave with a working spine instead of a promise to build one later.
 
-If the leak is a systems problem, the fix is a system. That's the whole idea.
+If the leak is a systems problem, the fix is a system — small, honest, and yours
+to keep. That's the whole idea.

--- a/lib/connect/events.ts
+++ b/lib/connect/events.ts
@@ -29,6 +29,17 @@ export const CONNECT_EVENTS: ConnectEvent[] = [
     accent: 'amber',
     location: 'Madrid',
   },
+  // Frank attends as a participant. Anything he hosts in Tallinn is an
+  // independent session — see the `attendee` framing in the /connect JSON-LD.
+  {
+    id: 'mindvalley-u-2026',
+    label: 'Mindvalley University',
+    shortLabel: 'Mindvalley U',
+    start: '2026-07-20',
+    end: '2026-08-02',
+    accent: 'violet',
+    location: 'Tallinn',
+  },
 ]
 
 function inWindow(now: Date, startISO: string, endISO: string): boolean {

--- a/lib/email-templates-mvu.ts
+++ b/lib/email-templates-mvu.ts
@@ -1,0 +1,71 @@
+/**
+ * Mindvalley U 2026 (Tallinn) — email for the native RSVP on frankx.ai/mvu/lab.
+ *
+ * Plain text on purpose. This lands minutes after someone decides to come to a
+ * small room in a foreign city — a marketing HTML shell would break the moment.
+ * Same restrained register as the Inner Circle waitlist confirmation.
+ */
+
+type MvuRsvpInput = {
+  name?: string
+  /** What the person wrote they want to leave with — echoed back so they feel heard. */
+  intention?: string
+}
+
+export function mvuRsvpConfirmation({ name, intention }: MvuRsvpInput) {
+  const greeting = name ? `${name},` : 'Hi,'
+
+  const heard = intention
+    ? `
+
+You said you want to leave with:
+
+  "${intention.trim()}"
+
+I read that. When we build the spine on the day, that's the thing we'll point
+it at — not a generic template.`
+    : ''
+
+  return {
+    subject: 'You’re on the list for the Tallinn lab',
+    plainText: `${greeting}
+
+Thank you — that means something. You didn't just save a date; you decided to
+spend ninety minutes of a rare two weeks building something that lasts.
+
+Here's the honest shape of it. The lab is capped small and I approve each seat
+by hand, so it stays a room and not an audience. If there's a seat for you,
+you'll get the time, the place, and one thing to bring. If the room fills before
+I reach you, I'll tell you straight — no waitlist theatre.
+${heard}
+
+Either way, I'm glad our paths crossed in Tallinn.
+
+— Frank
+frankx.ai/mvu
+`,
+  }
+}
+
+type MvuRsvpAlertInput = {
+  email: string
+  name?: string
+  intention?: string
+}
+
+/**
+ * Sent to Frank, not the registrant. He is on his feet at a two-week summit —
+ * email is the only surface he'll actually read, so each RSVP (and the human
+ * behind it) is pushed to him for the approve/decline call.
+ */
+export function mvuRsvpAlert({ email, name, intention }: MvuRsvpAlertInput) {
+  return {
+    subject: `MVU lab RSVP: ${name || email}`,
+    plainText: `${name || 'Someone'} <${email}> wants a seat at the Tallinn lab.
+${intention ? `\nWhat they want to leave with:\n  "${intention.trim()}"\n` : ''}
+Approve or decline by hand — the seat is real, keep the room small.
+
+— frankx.ai/mvu/lab
+`,
+  }
+}

--- a/lib/mvu.ts
+++ b/lib/mvu.ts
@@ -1,0 +1,94 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import readingTime from 'reading-time'
+import { cache } from 'react'
+
+/**
+ * The MVU journey hub content collection.
+ *
+ * Reads markdown from content/mvu/ so anything Frank writes in Codex (journal
+ * notes, essays, learnings) drops onto frankx.ai/mvu just by committing a file
+ * — no code change. Mirrors the gray-matter pattern in lib/blog.ts rather than
+ * inventing a second content system.
+ *
+ * Frontmatter contract (all optional except title + date):
+ *   title:     string
+ *   date:      YYYY-MM-DD
+ *   kind:      'journal' | 'essay' | 'note'   (default 'note')
+ *   summary:   one-line teaser for the hub list
+ *   tags:      string[]
+ *   published: boolean  (default true — set false to keep a draft out of prod)
+ */
+
+const mvuDirectory = path.join(process.cwd(), 'content/mvu')
+
+export type MvuKind = 'journal' | 'essay' | 'note'
+
+export interface MvuEntry {
+  slug: string
+  title: string
+  date: string
+  kind: MvuKind
+  summary: string
+  tags: string[]
+  published: boolean
+  readingTime: string
+  content: string
+}
+
+export type MvuEntrySummary = Omit<MvuEntry, 'content'>
+
+function buildEntry(slug: string, data: Record<string, unknown>, content: string): MvuEntry {
+  const kind = (data.kind as MvuKind) || 'note'
+  return {
+    slug,
+    title: String(data.title ?? slug),
+    date: String(data.date ?? ''),
+    kind: (['journal', 'essay', 'note'] as const).includes(kind) ? kind : 'note',
+    summary: String(data.summary ?? ''),
+    tags: Array.isArray(data.tags) ? (data.tags as string[]) : [],
+    published: data.published !== false,
+    readingTime: readingTime(content).text,
+    content,
+  }
+}
+
+function readAll(): MvuEntry[] {
+  let fileNames: string[]
+  try {
+    fileNames = fs.readdirSync(mvuDirectory)
+  } catch {
+    // Directory absent (e.g. before the first entry is committed) — an empty
+    // hub is a valid state, not an error.
+    return []
+  }
+
+  return fileNames
+    .filter((name) => name.endsWith('.md') || name.endsWith('.mdx'))
+    .map((fileName) => {
+      const slug = fileName.replace(/\.mdx?$/, '')
+      const fullPath = path.join(mvuDirectory, fileName)
+      const { data, content } = matter(fs.readFileSync(fullPath, 'utf8'))
+      return buildEntry(slug, data, content)
+    })
+    .sort((a, b) => (new Date(a.date) > new Date(b.date) ? -1 : 1))
+}
+
+/** Published entries only — what the live site shows. Newest first. */
+export const getMvuEntries = cache((): MvuEntry[] =>
+  readAll().filter((entry) => entry.published),
+)
+
+export const getMvuEntrySummaries = cache((): MvuEntrySummary[] =>
+  getMvuEntries().map(({ content: _content, ...rest }) => rest),
+)
+
+export const getMvuEntry = cache((slug: string): MvuEntry | null => {
+  const entry = readAll().find((e) => e.slug === slug && e.published)
+  return entry ?? null
+})
+
+export function getMvuEntriesByKind(kind: MvuKind): MvuEntry[] {
+  return getMvuEntries().filter((entry) => entry.kind === kind)
+}

--- a/lib/mvu/lab.ts
+++ b/lib/mvu/lab.ts
@@ -2,45 +2,40 @@
  * "Second Brain That Survives the Summit" — the one independent lab Frank may
  * host during MVU week two. Single source of truth for the /mvu/lab page.
  *
- * Frank edits THIS file to set the final date, venue, and RSVP link. Until
- * `lumaUrl` is set (here or via NEXT_PUBLIC_MVU_LAB_LUMA_URL), the page shows
- * an email-capture fallback instead of a dead RSVP button — so interest is
- * never lost while the Luma event is still being created.
+ * RSVP is native to frankx.ai — no third-party event tool. Registrations flow
+ * through /api/subscribe (mvu-tallinn-2026) and Frank approves each seat by
+ * hand, which is what keeps a small room a room.
+ *
+ * Frank edits THIS file to set the final date and venue, and flips `confirmed`
+ * once the room is locked.
  */
 
 export interface MvuLab {
-  /** Whether the lab is confirmed to run. false → page shows "gauging interest". */
+  /** false → page frames it as "gauging interest" rather than "reserve a seat". */
   confirmed: boolean
   title: string
+  /** The promise, in one breath. */
   tagline: string
   /** Human date string, e.g. "Thursday 31 July 2026". Empty until set. */
   dateLabel: string
   /** Human time string, e.g. "17:00–18:30". Empty until set. */
   timeLabel: string
-  /** Neighbourhood / venue, kept vague until confirmed (private venues stay off Git). */
+  /** Neighbourhood only until confirmed — exact address goes in the approval email, never Git. */
   venueLabel: string
   city: string
   capacity: number
   price: string
-  /** Luma event URL. Prefer the env var; this is the committed fallback. */
-  lumaUrl: string
 }
 
 export const MVU_LAB: MvuLab = {
   confirmed: false,
   title: 'Second Brain That Survives the Summit',
   tagline:
-    'A 90-minute lab to leave Tallinn with a working second-brain spine — not another camera roll of slides you never reopen.',
+    'Ninety minutes to leave Tallinn with a system that keeps what you found here — not a camera roll of slides you never reopen.',
   dateLabel: '', // e.g. 'Thursday 31 July 2026' — set when locked
   timeLabel: '', // e.g. '17:00–18:30'
-  venueLabel: '', // e.g. 'Central Tallinn — exact address in the confirmation'
+  venueLabel: '', // e.g. 'Central Tallinn — exact address in your confirmation'
   city: 'Tallinn',
   capacity: 16,
   price: 'Free — approval-gated',
-  lumaUrl: '',
-}
-
-/** Resolved RSVP link: env wins so Frank can set it without a redeploy-blocking edit. */
-export function getLabRsvpUrl(): string {
-  return process.env.NEXT_PUBLIC_MVU_LAB_LUMA_URL || MVU_LAB.lumaUrl || ''
 }

--- a/lib/mvu/lab.ts
+++ b/lib/mvu/lab.ts
@@ -1,0 +1,46 @@
+/**
+ * "Second Brain That Survives the Summit" — the one independent lab Frank may
+ * host during MVU week two. Single source of truth for the /mvu/lab page.
+ *
+ * Frank edits THIS file to set the final date, venue, and RSVP link. Until
+ * `lumaUrl` is set (here or via NEXT_PUBLIC_MVU_LAB_LUMA_URL), the page shows
+ * an email-capture fallback instead of a dead RSVP button — so interest is
+ * never lost while the Luma event is still being created.
+ */
+
+export interface MvuLab {
+  /** Whether the lab is confirmed to run. false → page shows "gauging interest". */
+  confirmed: boolean
+  title: string
+  tagline: string
+  /** Human date string, e.g. "Thursday 31 July 2026". Empty until set. */
+  dateLabel: string
+  /** Human time string, e.g. "17:00–18:30". Empty until set. */
+  timeLabel: string
+  /** Neighbourhood / venue, kept vague until confirmed (private venues stay off Git). */
+  venueLabel: string
+  city: string
+  capacity: number
+  price: string
+  /** Luma event URL. Prefer the env var; this is the committed fallback. */
+  lumaUrl: string
+}
+
+export const MVU_LAB: MvuLab = {
+  confirmed: false,
+  title: 'Second Brain That Survives the Summit',
+  tagline:
+    'A 90-minute lab to leave Tallinn with a working second-brain spine — not another camera roll of slides you never reopen.',
+  dateLabel: '', // e.g. 'Thursday 31 July 2026' — set when locked
+  timeLabel: '', // e.g. '17:00–18:30'
+  venueLabel: '', // e.g. 'Central Tallinn — exact address in the confirmation'
+  city: 'Tallinn',
+  capacity: 16,
+  price: 'Free — approval-gated',
+  lumaUrl: '',
+}
+
+/** Resolved RSVP link: env wins so Frank can set it without a redeploy-blocking edit. */
+export function getLabRsvpUrl(): string {
+  return process.env.NEXT_PUBLIC_MVU_LAB_LUMA_URL || MVU_LAB.lumaUrl || ''
+}

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -21,7 +21,15 @@ export const emailRatelimit = new Ratelimit({
   prefix: 'ratelimit:email'
 })
 
-// QR rendering rate limit - keeps uncached raster requests bounded\nexport const qrRatelimit = new Ratelimit({\n  redis: kv,\n  limiter: Ratelimit.slidingWindow(60, '1 m'),\n  analytics: true,\n  prefix: 'ratelimit:qr'\n})\n\n// Analytics tracking rate limit - Generous for normal usage
+// QR rendering rate limit - keeps uncached raster requests bounded
+export const qrRatelimit = new Ratelimit({
+  redis: kv,
+  limiter: Ratelimit.slidingWindow(60, '1 m'),
+  analytics: true,
+  prefix: 'ratelimit:qr'
+})
+
+// Analytics tracking rate limit - Generous for normal usage
 export const analyticsRatelimit = new Ratelimit({
   redis: kv,
   limiter: Ratelimit.slidingWindow(100, '1 m'),

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -21,7 +21,7 @@ export const emailRatelimit = new Ratelimit({
   prefix: 'ratelimit:email'
 })
 
-// Analytics tracking rate limit - Generous for normal usage
+// QR rendering rate limit - keeps uncached raster requests bounded\nexport const qrRatelimit = new Ratelimit({\n  redis: kv,\n  limiter: Ratelimit.slidingWindow(60, '1 m'),\n  analytics: true,\n  prefix: 'ratelimit:qr'\n})\n\n// Analytics tracking rate limit - Generous for normal usage
 export const analyticsRatelimit = new Ratelimit({
   redis: kv,
   limiter: Ratelimit.slidingWindow(100, '1 m'),


### PR DESCRIPTION
Frank is at **Mindvalley University, Tallinn (20 Jul – 2 Aug 2026)**. This PR ships the full MVU package on frankx.ai.

## 1 · /connect ribbon + schema fix (original scope)
- `lib/connect/events.ts` — Mindvalley U window added; ribbon renders **"Live at Mindvalley University · Tallinn — welcome."**
- `app/(landing)/connect/page.tsx` — Event JSON-LD role corrected `organizer/performer` → **`attendee`** (Frank attends, doesn't run these).

## 2 · /mvu — the journey hub
- `lib/mvu.ts` reads `content/mvu/*.md` (mirrors the blog gray-matter pattern). **Frank's Codex-written journal + essays appear by committing a file — no code change.** `published: false` keeps drafts out of prod.
- `app/mvu/page.tsx` — hub (live ribbon, lab spotlight, journal/essay list). `app/mvu/[slug]/page.tsx` — renders each entry via the existing `MDXContent`.
- Seeded public-safe: approach essay, day-one journal, insight-decay thesis.
- Indexable; `CollectionPage` + `Article`/`BlogPosting` JSON-LD; sitemap wired.

## 3 · /mvu/lab — the event page
- "Second Brain That Survives the Summit" — 90 min, cap 16, free, approval-gated.
- RSVP → Luma via `NEXT_PUBLIC_MVU_LAB_LUMA_URL`. **Until that's set, shows email interest-capture** (subscribe API, `mvu-tallinn-2026` + `labInterest`) so demand is measured before the event exists.
- Details in `lib/mvu/lab.ts` — Frank edits one file for date/venue.
- Event JSON-LD claims `organizer` here (correct — Frank runs this lab).

## 4 · QR upgrade
- `/api/qr` serves `?to=connect|mvu|lab`, appends `?ref=qr` for attribution, optional branded caption card (`?caption=1`) for print. Back-compatible (default connect).

## 5 · Phone-aware contact save
- `SaveContactButton` adapts: iOS "Add to Apple Contacts", Android "Save to Contacts", desktop "Download contact card", each with a hint on what tapping does. SSR-safe, no hydration flash. The `.vcf` is unchanged and universal.

## Verification
- `tsc --noEmit` — clean across all changed files (pre-existing environmental `qrcode`/`gsap`/`stripe` module-resolution gaps in local install only; `qrcode` is a real prod dep and `/api/qr` already ships on main).
- Params are Next 16 Promise-style, matching `app/blog/[slug]`.
- **Vercel preview is the build gate** — neither local checkout has complete `node_modules`.

## Frank sets (post-merge)
- Create the Luma event → set `NEXT_PUBLIC_MVU_LAB_LUMA_URL` in Vercel.
- Fill date/venue in `lib/mvu/lab.ts`, flip `confirmed: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Mindvalley University 2026 journal hub with new journal entries and an MVU Lab landing page.
  - Enabled QR code generation for multiple destinations via a query parameter, with improved PNG/SVG output options.
  - Added an MVU Lab RSVP experience that switches between external RSVP and interest capture depending on configuration.
- **Bug Fixes**
  - Updated Connect event structured data so search engines reflect attendee/attendance details rather than organizer/performer roles.
- **Enhancements**
  - Added an optional “Save contact” hint and improved analytics with platform detection.
  - Expanded the sitemap to include all MVU routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->