### PR TITLE
feat(business): align portfolio around recurring value

### DIFF
--- a/app/business-plan/page.tsx
+++ b/app/business-plan/page.tsx
@@ -1,174 +1,496 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+import {
+  ArrowRight,
+  BookOpen,
+  Boxes,
+  Cpu,
+  Globe2,
+  Repeat2,
+  Sparkles,
+  Target,
+  Workflow,
+} from 'lucide-react'
+import {
+  operatingLoop,
+  portfolioBrands,
+  portfolioPrograms,
+  recurringValueTests,
+  revenueEvents,
+  type PortfolioAccent,
+  type PortfolioBrand,
+} from '@/data/portfolio'
 
-export const metadata = {
-  title: 'Vision & Business | FrankX',
-  description: 'How FrankX operates: the ecosystem, the products, the mission. A transparent look at what we\'re building and why.',
+export const metadata: Metadata = {
+  title: 'Business Architecture — From Expertise to Recurring Value',
+  description:
+    'The FrankX public operating model: verified customer-facing brands, explicit recurring-value experiments, and a measurable path from natural advantage to scalable impact.',
+  alternates: { canonical: 'https://frankx.ai/business-plan' },
+  openGraph: {
+    title: 'The FrankX Business Architecture',
+    description:
+      'How the portfolio turns distinct advantage into owned assets, repeat customer value, and measurable impact.',
+    type: 'website',
+  },
 }
 
-const pillars = [
-  {
-    title: 'Knowledge Layer',
-    description: '70+ technical articles, 7 research portals, validated sources. Free, deep, and built for search engines and AI citations.',
-    stat: '70+ articles',
-    accent: 'text-emerald-400',
+const accentStyles: Record<
+  PortfolioAccent,
+  { text: string; border: string; background: string }
+> = {
+  emerald: {
+    text: 'text-emerald-300',
     border: 'border-emerald-500/20',
+    background: 'bg-emerald-500/[0.04]',
   },
-  {
-    title: 'Operating Systems',
-    description: 'Three interconnected platforms: Vibe OS (creative state), GenCreator OS (multi-modal production), ACOS (agentic orchestration with 75+ skills).',
-    stat: '3 platforms',
-    accent: 'text-cyan-400',
+  cyan: {
+    text: 'text-cyan-300',
     border: 'border-cyan-500/20',
+    background: 'bg-cyan-500/[0.04]',
   },
-  {
-    title: 'Products & Programs',
-    description: 'Digital products, prompt libraries, courses, and high-touch programs. From free lead magnets to premium engagements.',
-    stat: '$0 to $12k+',
-    accent: 'text-purple-400',
-    border: 'border-purple-500/20',
+  sky: {
+    text: 'text-sky-300',
+    border: 'border-sky-500/20',
+    background: 'bg-sky-500/[0.04]',
   },
-  {
-    title: 'Community',
-    description: 'Inner Circle for serious builders. Coaching for individuals ready to go deep. A network of creators who ship.',
-    stat: 'High-touch',
-    accent: 'text-amber-400',
+  violet: {
+    text: 'text-violet-300',
+    border: 'border-violet-500/20',
+    background: 'bg-violet-500/[0.04]',
+  },
+  amber: {
+    text: 'text-amber-300',
     border: 'border-amber-500/20',
+    background: 'bg-amber-500/[0.04]',
   },
-]
+}
 
-const revenue = [
-  { tier: 'Free', products: 'Soulbook, Vibe OS, Blog, Sample Packs', purpose: 'Lead generation & trust' },
-  { tier: '$27-97', products: 'Prompt Libraries, Creative AI Toolkit', purpose: 'First purchase, qualification' },
-  { tier: '$297-997', products: 'Creation Chronicles, Creator Lab OS', purpose: 'Core revenue, transformation' },
-  { tier: '$2.5k-12k+', products: 'Enterprise Programs, Creator Studio, Residency', purpose: 'Premium, high-touch' },
-]
+const brandIcons: Record<PortfolioBrand['id'], typeof Sparkles> = {
+  frankx: Sparkles,
+  gencreator: Boxes,
+  'agentic-income': Repeat2,
+  starlight: Cpu,
+  arcanea: BookOpen,
+}
 
-const principles = [
-  { title: 'Ship Before Perfect', body: 'A working product beats a polished deck. We launch, learn, iterate.' },
-  { title: 'Depth Over Breadth', body: 'Go deeper on fewer things rather than surface-level on many.' },
-  { title: 'Build in Public', body: 'Transparent development via /changelog and /feed. Show the process, not just the result.' },
-  { title: 'AI-Native Operations', body: 'Every workflow uses AI. Not as a feature — as the foundation.' },
-  { title: 'Let the Work Speak', body: 'No hype. No guru energy. Results, craft, and genuine value.' },
-]
+const decisionStyles = {
+  'Keep distinct': 'border-sky-500/20 bg-sky-500/[0.06] text-sky-300',
+  Embed: 'border-emerald-500/20 bg-emerald-500/[0.06] text-emerald-300',
+  Incubate: 'border-amber-500/20 bg-amber-500/[0.06] text-amber-300',
+} as const
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-5 flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.25em] text-white/60">
+      <span className="h-px w-6 bg-emerald-400/60" aria-hidden="true" />
+      {children}
+    </div>
+  )
+}
+
+function Detail({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-[11px] font-medium uppercase tracking-[0.14em] text-white/55">
+        {label}
+      </dt>
+      <dd className="mt-1.5 text-sm leading-relaxed text-white/70">{children}</dd>
+    </div>
+  )
+}
+
+function BusinessSchema() {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'AboutPage',
+    name: 'The FrankX Business Architecture',
+    description:
+      'The public operating model for FrankX, GenCreator, Agentic Income, Starlight Intelligence System, and Arcanea.',
+    url: 'https://frankx.ai/business-plan',
+    author: {
+      '@type': 'Person',
+      name: 'Frank Riemer',
+      url: 'https://frankx.ai',
+      jobTitle: 'AI Architect',
+    },
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  )
+}
 
 export default function BusinessPlanPage() {
   return (
-    <div className="min-h-screen bg-[#0a0a0b]">
-      {/* Header */}
-      <section className="border-b border-white/5">
-        <div className="max-w-4xl mx-auto px-6 pt-24 pb-12">
+    <main className="min-h-screen bg-[#0a0a0b] text-white">
+      <BusinessSchema />
+
+      <section className="relative overflow-hidden border-b border-white/[0.05]">
+        <div
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_75%_20%,rgba(16,185,129,0.08),transparent_32%)]"
+          aria-hidden="true"
+        />
+        <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-28 lg:pb-32 lg:pt-36">
           <Link
             href="/"
-            className="text-white/40 hover:text-white/70 text-sm transition-colors mb-6 inline-block"
+            className="mb-12 inline-flex items-center gap-2 text-sm text-white/60 transition-colors hover:text-white/80"
           >
-            Home
+            FrankX
+            <span aria-hidden="true">/</span>
+            Business architecture
           </Link>
-          <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
-            Vision & Business
+
+          <Eyebrow>Public operating model · July 2026</Eyebrow>
+          <h1 className="max-w-5xl text-5xl font-semibold leading-[1.02] tracking-[-0.04em] text-white sm:text-6xl lg:text-7xl">
+            Build assets that keep creating value.
           </h1>
-          <p className="text-white/50 text-lg max-w-2xl">
-            A transparent look at how FrankX operates. What we build, why we build it,
-            and the business model that sustains it.
+          <p className="mt-8 max-w-3xl text-lg leading-relaxed text-white/65 sm:text-xl">
+            Natural ability creates an edge. A consequential problem creates demand. A repeatable
+            system turns both into wealth and measurable impact. This page separates what exists now
+            from what must earn the right to become recurring.
           </p>
-        </div>
-      </section>
 
-      {/* Mission */}
-      <section className="max-w-4xl mx-auto px-6 py-16 border-b border-white/5">
-        <h2 className="text-2xl font-bold mb-4">Mission</h2>
-        <p className="text-white/60 text-lg leading-relaxed max-w-3xl">
-          Help creators and technologists build real things with AI. Not hype — working systems,
-          shipped products, and sustainable businesses. FrankX exists at the intersection of
-          AI architecture, music production, and the creator economy.
-        </p>
-      </section>
-
-      {/* Ecosystem Pillars */}
-      <section className="max-w-4xl mx-auto px-6 py-16 border-b border-white/5">
-        <h2 className="text-2xl font-bold mb-8">Ecosystem</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {pillars.map((pillar) => (
-            <div
-              key={pillar.title}
-              className={`rounded-xl border ${pillar.border} bg-white/[0.02] p-6`}
-            >
-              <div className="flex items-baseline justify-between mb-3">
-                <h3 className="text-lg font-semibold">{pillar.title}</h3>
-                <span className={`text-xs font-mono ${pillar.accent}`}>{pillar.stat}</span>
-              </div>
-              <p className="text-white/50 text-sm leading-relaxed">
-                {pillar.description}
-              </p>
+          <div className="mt-12 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.035] p-6 sm:p-8">
+            <div className="font-mono text-xs uppercase tracking-[0.18em] text-emerald-300/80">
+              The operating equation
             </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Value Ladder */}
-      <section className="max-w-4xl mx-auto px-6 py-16 border-b border-white/5">
-        <h2 className="text-2xl font-bold mb-2">Value Ladder</h2>
-        <p className="text-white/40 text-sm mb-8">How products connect from free to premium</p>
-        <div className="space-y-3">
-          {revenue.map((tier) => (
+            <p className="sr-only">
+              Wealth equals distinct advantage multiplied by problem value, people helped, recurring
+              value, retention, and value captured.
+            </p>
             <div
-              key={tier.tier}
-              className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4"
+              className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-2 text-xl font-medium text-white/90 sm:text-2xl"
+              aria-hidden="true"
             >
-              <span className="text-emerald-400 font-mono text-sm font-semibold w-24 shrink-0">
-                {tier.tier}
-              </span>
-              <span className="text-white/70 text-sm flex-1">{tier.products}</span>
-              <span className="text-white/30 text-xs shrink-0">{tier.purpose}</span>
+              <span>Distinct advantage</span>
+              <span className="text-emerald-400">×</span>
+              <span>problem value</span>
+              <span className="text-emerald-400">×</span>
+              <span>people helped</span>
+              <span className="text-emerald-400">×</span>
+              <span>recurring value</span>
+              <span className="text-emerald-400">×</span>
+              <span>retention</span>
+              <span className="text-emerald-400">×</span>
+              <span>value captured</span>
             </div>
-          ))}
-        </div>
-      </section>
+          </div>
 
-      {/* Operating Principles */}
-      <section className="max-w-4xl mx-auto px-6 py-16 border-b border-white/5">
-        <h2 className="text-2xl font-bold mb-8">Operating Principles</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {principles.map((principle) => (
-            <div
-              key={principle.title}
-              className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-5"
-            >
-              <h3 className="text-sm font-semibold mb-2">{principle.title}</h3>
-              <p className="text-white/40 text-xs leading-relaxed">{principle.body}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="max-w-4xl mx-auto px-6 py-16">
-        <div className="text-center">
-          <h2 className="text-2xl font-bold mb-4">Want to work together?</h2>
-          <p className="text-white/40 text-sm mb-6 max-w-md mx-auto">
-            Whether you're building with AI, creating content, or scaling a creator business.
-          </p>
-          <div className="flex justify-center gap-4 flex-wrap">
+          <div className="mt-10 flex flex-wrap items-center gap-5">
             <Link
-              href="/inner-circle"
-              className="text-sm px-5 py-2.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10 hover:border-white/20 transition-all"
+              href="https://gencreator.ai/products/diagnostic?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model"
+              className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-colors hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
             >
-              Inner Circle
+              Run the GenCreator diagnostic
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
             </Link>
             <Link
-              href="/coaching"
-              className="text-sm px-5 py-2.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10 hover:border-white/20 transition-all"
+              href="https://agenticincome.ai/?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model"
+              className="text-sm text-white/65 underline decoration-white/30 underline-offset-4 transition-colors hover:text-white/85 hover:decoration-white/60"
             >
-              Coaching
-            </Link>
-            <Link
-              href="/products"
-              className="text-sm px-5 py-2.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10 hover:border-white/20 transition-all"
-            >
-              Products
+              Explore Agentic Income
             </Link>
           </div>
         </div>
       </section>
-    </div>
+
+      <section className="border-b border-white/[0.05] py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <Eyebrow>Five core operating engines</Eyebrow>
+          <div className="grid gap-6 lg:grid-cols-[0.72fr_1.28fr] lg:gap-16">
+            <div>
+              <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+                Each brand needs a buyer, a costly repeat problem, and proof.
+              </h2>
+              <p className="mt-5 max-w-lg leading-relaxed text-white/65">
+                “Current value” describes the canonical live surface. “Recurring experiment” states
+                whether an offer is active, service-led, or pre-launch. Nothing on this page creates a
+                new plan beyond what the operating brand already publishes.
+              </p>
+            </div>
+
+            <div className="divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {portfolioBrands.map((brand) => {
+                const Icon = brandIcons[brand.id]
+                const styles = accentStyles[brand.accent]
+
+                return (
+                  <article key={brand.id} className="py-9 first:pt-0 last:pb-0">
+                    <div className="grid gap-6 sm:grid-cols-[190px_1fr]">
+                      <div>
+                        <div className="flex items-center gap-2.5">
+                          <span className={`rounded-lg border p-2 ${styles.border} ${styles.background}`}>
+                            <Icon className={`h-4 w-4 ${styles.text}`} aria-hidden="true" />
+                          </span>
+                          <div>
+                            <h3 className="font-semibold text-white">{brand.name}</h3>
+                            <p className={`mt-0.5 font-mono text-[11px] ${styles.text}`}>
+                              {brand.domain}
+                            </p>
+                          </div>
+                        </div>
+                        <p className="mt-3 text-xs font-medium uppercase tracking-[0.16em] text-white/60">
+                          {brand.role}
+                        </p>
+                        <Link
+                          href={brand.href}
+                          className={`mt-5 inline-flex items-center gap-1.5 text-xs font-medium underline decoration-white/20 underline-offset-4 hover:decoration-white/60 ${styles.text}`}
+                        >
+                          {brand.ctaLabel}
+                          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </Link>
+                      </div>
+
+                      <dl className="space-y-5">
+                        <div className="grid gap-5 sm:grid-cols-2">
+                          <Detail label="Buyer">{brand.buyer}</Detail>
+                          <Detail label="Recurring problem">{brand.recurringProblem}</Detail>
+                        </div>
+                        <div className="grid gap-5 border-t border-white/[0.06] pt-5 sm:grid-cols-2">
+                          <Detail label="Acquisition path">{brand.acquisitionPath}</Detail>
+                          <Detail label="Activation">{brand.activation}</Detail>
+                        </div>
+                        <div className="grid gap-5 border-t border-white/[0.06] pt-5 sm:grid-cols-2">
+                          <Detail label="Current value">{brand.currentValue}</Detail>
+                          <Detail label="Recurring experiment">{brand.recurringExperiment}</Detail>
+                        </div>
+                        <div className="grid gap-5 border-t border-white/[0.06] pt-5 sm:grid-cols-2">
+                          <Detail label="Fulfillment system">{brand.fulfillmentSystem}</Detail>
+                          <Detail label="Proof metric">{brand.proofMetric}</Detail>
+                        </div>
+                      </dl>
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.05] bg-white/[0.012] py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <Eyebrow>Portfolio discipline</Eyebrow>
+          <div className="max-w-3xl">
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+              A name can be a program without becoming another company.
+            </h2>
+            <p className="mt-5 leading-relaxed text-white/65">
+              A dedicated business requires a distinct buyer, repeat job, distribution advantage,
+              and accountable economics. Inactive, defensive, legal, partner, and client domains stay
+              in the private registry; publishing them would not help a customer decide what to do.
+            </p>
+          </div>
+
+          <div className="mt-12 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+            {portfolioPrograms.map((program) => (
+              <div
+                key={program.name}
+                className="grid gap-4 py-6 md:grid-cols-[220px_1fr_180px] md:items-start"
+              >
+                <div>
+                  <h3 className="font-medium text-white/90">{program.name}</h3>
+                  {program.domain && program.href ? (
+                    <Link
+                      href={program.href}
+                      className="mt-1 inline-flex items-center gap-1 font-mono text-[11px] text-sky-300 underline decoration-white/20 underline-offset-4 hover:decoration-white/60"
+                    >
+                      {program.domain}
+                      <ArrowRight className="h-3 w-3" aria-hidden="true" />
+                    </Link>
+                  ) : null}
+                  <span
+                    className={`block w-fit rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${program.domain ? 'mt-3' : 'mt-2'} ${decisionStyles[program.decision]}`}
+                  >
+                    {program.decision}
+                  </span>
+                </div>
+                <p className="text-sm leading-relaxed text-white/70">{program.rule}</p>
+                <p className="text-xs leading-relaxed text-white/60 md:text-right">
+                  Operating home
+                  <br />
+                  <span className="text-white/75">{program.parent}</span>
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.05] py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <Eyebrow>Marketing → sales → systemization</Eyebrow>
+          <div className="grid gap-12 lg:grid-cols-[0.78fr_1.22fr] lg:gap-16">
+            <div>
+              <Workflow className="h-7 w-7 text-emerald-300" aria-hidden="true" />
+              <h2 className="mt-5 text-3xl font-semibold tracking-tight sm:text-4xl">
+                One loop governs every business.
+              </h2>
+              <p className="mt-5 max-w-lg leading-relaxed text-white/65">
+                Marketing earns the next diagnostic action. Sales converts a verified problem into a
+                bounded outcome. Systemization makes that outcome repeatable and measurable.
+              </p>
+            </div>
+
+            <ol className="divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {operatingLoop.map(([stage, description], index) => (
+                <li key={stage} className="grid gap-3 py-5 sm:grid-cols-[44px_110px_1fr] sm:items-start">
+                  <span className="font-mono text-xs text-emerald-300">0{index + 1}</span>
+                  <h3 className="text-sm font-medium text-white/90">{stage}</h3>
+                  <p className="text-sm leading-relaxed text-white/70">{description}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.05] bg-white/[0.012] py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <Eyebrow>Revenue architecture</Eyebrow>
+          <div className="grid gap-12 lg:grid-cols-[0.78fr_1.22fr] lg:gap-16">
+            <div>
+              <Target className="h-7 w-7 text-emerald-300" aria-hidden="true" />
+              <h2 className="mt-5 text-3xl font-semibold tracking-tight sm:text-4xl">
+                Charge for the value event that actually exists.
+              </h2>
+              <p className="mt-5 max-w-lg leading-relaxed text-white/65">
+                A finished transformation belongs in a one-time product. ARR starts when a specific
+                repeat job continues to produce a customer outcome—not when static content receives a
+                monthly payment schedule.
+              </p>
+            </div>
+
+            <div className="overflow-hidden rounded-2xl border border-white/[0.08]">
+              {revenueEvents.map((item, index) => (
+                <div
+                  key={item.model}
+                  className="grid gap-3 border-b border-white/[0.07] p-5 last:border-b-0 sm:grid-cols-[34px_1fr_1fr] sm:gap-5"
+                >
+                  <span className="font-mono text-xs text-emerald-300">0{index + 1}</span>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.14em] text-white/55">{item.event}</p>
+                    <h3 className="mt-2 text-sm font-medium text-white/90">{item.model}</h3>
+                  </div>
+                  <p className="text-sm leading-relaxed text-white/70">{item.standard}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-16 border-t border-white/[0.08] pt-12">
+            <div className="max-w-3xl">
+              <h3 className="text-2xl font-semibold">The recurring-value test</h3>
+              <p className="mt-3 leading-relaxed text-white/65">
+                One primary recurring job with repeat use and willingness to pay is mandatory. The
+                other mechanisms strengthen retention; they are not a feature checklist for an MVP.
+              </p>
+            </div>
+            <div className="mt-8 grid gap-px overflow-hidden rounded-2xl border border-white/[0.08] bg-white/[0.08] md:grid-cols-5">
+              {recurringValueTests.map(([title, description], index) => (
+                <div key={title} className="bg-[#0a0a0b] p-5">
+                  <p className="font-mono text-[10px] text-emerald-300">0{index + 1}</p>
+                  <h4 className="mt-3 text-sm font-medium text-white/90">{title}</h4>
+                  <p className="mt-2 text-xs leading-relaxed text-white/65">{description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.05] py-24 lg:py-32">
+        <div className="mx-auto max-w-6xl px-6">
+          <Eyebrow>One million lives</Eyebrow>
+          <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:gap-16">
+            <div>
+              <Globe2 className="h-7 w-7 text-emerald-300" aria-hidden="true" />
+              <h2 className="mt-5 text-4xl font-semibold tracking-tight sm:text-5xl">
+                Impact scales through people who can teach and build without you.
+              </h2>
+              <div className="mt-8 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.035] p-6 font-mono text-lg text-white/85 sm:text-xl">
+                10,000 builders × 100 people enabled = 1,000,000 lives
+              </div>
+              <p className="mt-6 max-w-2xl leading-relaxed text-white/65">
+                Reach is not impact. A life counts when someone ships an asset, earns from owned work,
+                deploys a useful system, teaches another person, or produces a verified social outcome.
+              </p>
+            </div>
+
+            <div className="border-l border-white/[0.08] pl-6 sm:pl-8">
+              <h3 className="text-lg font-semibold">The next-generation curriculum</h3>
+              <ol className="mt-6 space-y-5">
+                {[
+                  ['Creator', 'Discover asymmetric strengths and create with judgment.'],
+                  ['Builder', 'Choose consequential problems and ship useful artifacts.'],
+                  ['Owner', 'Turn work into systems, IP, distribution, and recurring economics.'],
+                  ['Steward', 'Govern agents, incentives, rights, and impact.'],
+                  ['Teacher', 'Transfer the system so capability multiplies beyond the founder.'],
+                ].map(([stage, description], index) => (
+                  <li key={stage} className="grid grid-cols-[28px_1fr] gap-3">
+                    <span className="font-mono text-xs text-emerald-300">0{index + 1}</span>
+                    <div>
+                      <h4 className="text-sm font-medium text-white/85">{stage}</h4>
+                      <p className="mt-1 text-xs leading-relaxed text-white/65">{description}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-24 lg:py-32">
+        <div className="mx-auto max-w-5xl px-6 text-center">
+          <Eyebrow>Validation order</Eyebrow>
+          <h2 className="text-3xl font-semibold tracking-tight sm:text-5xl">
+            Instrument first. Prove repetition second. Monetize recurrence last.
+          </h2>
+          <div className="mt-12 grid gap-px overflow-hidden rounded-2xl border border-white/[0.08] bg-white/[0.08] text-left md:grid-cols-3">
+            {[
+              [
+                'Now',
+                'Reconcile FrankX with the live GenCreator, Arcanea, and Agentic Income surfaces. Baseline diagnostic, purchase, activation, and week-four behavior for every published door.',
+              ],
+              [
+                'Next',
+                'Strengthen the existing diagnostic with advantage and problem validation. Track packets as one-time revenue, Circle as recurring, Studio as service, and Arcanea as pre-launch.',
+              ],
+              [
+                'Later',
+                'Scale recurring offers only when cohorts prove repeat value. Add licenses, marketplaces, or new memberships one verified customer job at a time.',
+              ],
+            ].map(([phase, action]) => (
+              <div key={phase} className="bg-[#0a0a0b] p-6 sm:p-8">
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-emerald-300">
+                  {phase}
+                </p>
+                <p className="mt-4 text-sm leading-relaxed text-white/70">{action}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 flex flex-wrap justify-center gap-4">
+            <Link
+              href="https://gencreator.ai/products/diagnostic?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model"
+              className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-colors hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0b]"
+            >
+              Run the GenCreator diagnostic
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+            <Link
+              href="/ecosystem"
+              className="inline-flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/40 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+            >
+              Inspect the system map
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
   )
 }

--- a/content/blog/frankx-business-plan-canvas.mdx
+++ b/content/blog/frankx-business-plan-canvas.mdx
@@ -1,85 +1,140 @@
 ---
-title: "FrankX Business Plan Canvas"
-description: "The concise business model behind the Agentic Creator OS and the FrankX product ladder."
+title: "Recurring Revenue Starts With a Recurring Job"
+description: "Why natural advantage, consequential problems, owned assets, and repeat customer outcomes must come before subscription pricing."
 date: "2025-03-01"
+lastUpdated: "2026-07-21"
 author: "Frank"
 category: "Intelligence Dispatches"
-image: "/images/blog/frankx-business-plan-canvas-hero-v7.jpg"
-tags: ["Business Model", "Product Strategy", "Creator Economy"]
+canonical: "https://frankx.ai/business-plan"
+tags: ["Business Model", "Recurring Revenue", "Product Strategy", "Creator Economy", "AI Business"]
+tldr: "Wealth compounds when a distinct advantage solves a consequential problem through an owned system. A subscription is justified only when one specific customer job repeats and produces measurable value. The FrankX portfolio will validate that behavior before adding or scaling further recurring offers."
 featured: false
 ---
 
-# FrankX Business Plan Canvas
+# Recurring Revenue Starts With a Recurring Job
 
-Subtitle: The concise business model behind the Agentic Creator OS and the FrankX product ladder.
+Most people are taught to exchange time for money. They are rarely taught how to identify an asymmetric strength, choose a problem worth solving, turn the solution into an owned asset, and design a system that keeps delivering value after the first sale.
 
-## Problem
+That is the capability I want to build—and the capability I want the next generation to inherit.
 
-- Creators and entrepreneurs are overwhelmed by fragmented AI tools.
-- Most AI systems feel generic or too complex to adopt.
-- There is no central hub that unifies premium products, prompts, funnels, and agentic strategy.
+## The three triangles
 
-## Customer segments
+Durable wealth sits at the overlap of three decisions.
 
-- AI-curious creators, coaches, and entrepreneurs.
-- Professionals who want to monetize knowledge with AI.
-- Students and startups seeking fast, practical guidance.
-- Community builders pursuing freedom and leverage.
+### 1. Distinct advantage
 
-## Unique value proposition
+What work gives you unusual energy? What have you practiced long enough to see what others miss? Where do judgment, evidence, and natural inclination reinforce each other?
 
-**FrankX.ai = Your Agentic Creator OS** — a hub for digital products, daily insights, and intelligent systems that scale freedom, income, and impact.
+Natural ability is not a guarantee of wealth. It lowers the energy cost of mastery and makes sustained excellence more likely.
 
-## Solution
+### 2. Consequential problem
 
-- Digital products: prompt packs, templates, systems, courses, and ebooks.
-- SEO-driven content hub and newsletter funnel.
-- Micro-sites for specific offers (music, Arcanea, AI courses, coaching).
-- Agentic workflows that execute daily tasks and expand reach.
+The economic value of a solution rises with the severity, frequency, and reach of the problem. A large audience with a mild inconvenience may be less valuable than a smaller audience facing a recurring, expensive failure.
 
-## Channels
+The key question is not, “What can I sell?” It is, “Which recurring failure am I structurally equipped to remove?”
 
-- FrankX.ai hub (free and paid).
-- SEO, blog, and newsletter.
-- Social funnels across LinkedIn, X, and Instagram.
-- Affiliate programs and community partnerships.
+### 3. Compounding delivery
 
-## Revenue streams
+One excellent delivery creates income once. A product, license, marketplace, royalty stream, or operating system can create and capture value repeatedly.
 
-- Paid digital products (micro offers to premium tiers).
-- Affiliate commissions from aligned AI tools.
-- Membership or subscription experiences.
-- Consulting and mentorship engagements.
+The complete equation is:
 
-## Cost structure
+> **Wealth = distinct advantage × problem value × people helped × recurring value × retention × value captured**
 
-- Hosting and CMS infrastructure.
-- AI tools and APIs.
-- Marketing, design, and content production.
-- Agentic system development and maintenance.
+Remove any term and the system weakens. No credible advantage produces commodity work. No painful problem produces weak demand. No distribution limits impact. No recurring value caps the relationship at one transaction.
 
-## Key metrics
+## Passive income is the result, not the offer
 
-- Monthly recurring revenue.
-- Email subscriber growth.
-- Funnel conversion rate.
-- SEO traffic compounding.
-- Product downloads and upgrades.
+“Passive income” obscures the mechanism. The honest model is **asset-based recurring income**: revenue produced by owned work and maintained by a governed system.
 
-## Unfair advantage
+A book can earn royalties. A workflow can be licensed. A marketplace can collect a share of exchange. Software can earn a subscription because it performs recurring work. A catalog can continue producing value across many releases and formats.
 
-- A distinct founder voice: cinematic, visionary, and practical.
-- Daily co-creation with AI to keep shipping velocity high.
-- The fusion of AI expertise, lifestyle freedom, and creative artistry.
+None of these are effort-free. The labor moves from repeated delivery into architecture, quality control, distribution, maintenance, and stewardship.
 
-### Next step
+## Apply the thesis without inventing products
 
-If you want to go deeper, explore the Agent Collective Operating System and the Creation Chronicles to see how this plan turns into daily output.
+The portfolio needs explicit roles, but it must distinguish current value from future experiments.
 
----
+| Brand | Current customer-facing role | Recurring decision |
+| --- | --- | --- |
+| **FrankX.ai** | Public research, tools, books, and architecture notes | Remain the authority and routing layer unless behavior proves a separate repeat job |
+| **GenCreator.ai** | Free activation/workspace tools, $19–149 self-serve packets, OS Circle at $49/month, and capped Studio review at $297/month | Measure Circle as recurring revenue; report Studio as service revenue rather than self-service ARR |
+| **AgenticIncome.ai** | A distinct home for agentic revenue systems and asset-based recurring income | Preserve its public positioning; share infrastructure with GenCreator only when migration evidence exists |
+| **Starlight Intelligence System** | Free, MIT-licensed, portable intelligence substrate | Keep the open core unrestricted; validate any team governance or update service as a separate layer |
+| **Arcanea.ai** | Free open core plus published $12/month Cloud Sync and $39/month Studio Bench plans in limited pre-launch | Treat the plans as waitlist/pre-launch experiments until paid cohorts prove repeat use |
 
-## Related Articles
+The Agentic Income network also has two verified public spokes: Agentic Passive Income for inspectable automation loops and Disruptive Passive Income for compounding wealth architecture. Each can keep a focused pack and knowledge base without creating a new account or billing stack.
 
-- [FrankX Vision, Mission, Values](/blog/frankx-vision-mission-values) — The foundation
-- [Agentic Creator OS](/blog/agentic-creator-os-complete-guide) — The system in action
-- [Golden Age of Intelligence](/blog/golden-age-of-intelligence) — The broader vision
+Other programs can live inside the operating brands without becoming new platforms. Reality Architect can remain a FrankX publication franchise. Music and creator pathways can strengthen GenCreator. Anime, clubs, and creative worlds can strengthen Arcanea. AI architecture education can build on Starlight. Blue Life and ocean intelligence can publish open knowledge until a reliable cadence or committed institutional partner exists.
+
+Inactive, defensive, legal, client, and partner domains belong in a private operating registry. They should not be published as customer-facing products merely because the names exist.
+
+## Sell once when the transformation ends
+
+A one-time product is correct when the customer completes a bounded transformation: a decision, a blueprint, an installed capability, a published asset, or a finished body of knowledge.
+
+A subscription is correct when one primary customer job repeats, the product performs that job again, and the customer chooses to return and pay for the continuing outcome.
+
+Four mechanisms can strengthen that recurring job:
+
+| Strengthening mechanism | What can bring the customer back |
+| --- | --- |
+| **Fresh value** | New intelligence, templates, releases, quests, or data |
+| **Accumulated value** | Assets, history, progression, benchmarks, or reputation become more useful over time |
+| **Operational value** | Agents and workflows keep performing work |
+| **Network value** | Collaboration, distribution, access, or exchange improves with participation |
+
+These are not an MVP feature checklist. One durable repeat job with demonstrated use and willingness to pay is the gate. A static course placed behind monthly billing is still a one-time product with an inconvenient payment schedule.
+
+## The first self-service validation path
+
+The current entry points are the canonical GenCreator workspace and readiness diagnostic, plus the distinct three-property Agentic Income network. Paid doors already exist. The next step is not another tier; it is consistent measurement of one activation event:
+
+> A person identifies a credible advantage, validates a costly recurring problem, and ships the first useful asset, offer, or installed revenue loop.
+
+Every business can use the same operating sequence:
+
+1. **Discover** — earn attention through useful research, stories, tools, and proof.
+2. **Diagnose** — identify the recurring problem and credible founder advantage.
+3. **Activate** — help the person ship a useful asset, decision, or installed capability.
+4. **Operate** — support one repeat job through a documented workflow and cadence.
+5. **Prove** — measure return behavior, customer outcome, retention, and economics.
+6. **Expand** — only then add subscriptions, licenses, marketplaces, or royalties.
+
+The product core stays self-service. GenCreator Studio is a current capped guided-service offer and should be reported as service revenue, not ARR. No consulting-led core is required to learn whether the diagnostic is completed, an artifact is shipped, and the person returns four weeks later.
+
+## A million lives requires multiplication
+
+A million impressions are not a million impacted lives.
+
+I would count impact when someone ships an asset, earns from owned work, deploys a useful system, teaches another person, or produces a verified social outcome.
+
+The scalable model is not one founder attempting to serve one million people directly:
+
+> **10,000 builders × 100 people enabled = 1,000,000 lives**
+
+This turns the audience into multipliers. The product does not merely transfer information; it transfers agency.
+
+## What the next generation should learn
+
+The curriculum should move through five identities:
+
+1. **Creator** — discover asymmetric strengths and create with judgment.
+2. **Builder** — select consequential problems and ship useful artifacts.
+3. **Owner** — turn work into systems, IP, distribution, and recurring economics.
+4. **Steward** — govern agents, incentives, rights, and impact.
+5. **Teacher** — transfer the system so capability multiplies beyond the founder.
+
+The outcome of every level is a shipped artifact—not course consumption.
+
+## The operating sequence
+
+**Now:** reconcile FrankX with the canonical GenCreator, Arcanea, and Agentic Income surfaces. Use the existing diagnostic and establish the baseline from entry to activation and week-four return.
+
+**Next:** strengthen the diagnostic with advantage and problem validation. Track self-serve packets as one-time revenue, OS Circle as recurring revenue, Studio as service revenue, and Arcanea plans as pre-launch.
+
+**Later:** scale recurring payment only where cohorts prove voluntary return and repeated value. Add licenses, marketplaces, or new memberships one proven job at a time.
+
+The goal is not more brands or more monthly plans. It is a portfolio in which every current promise is true, every experiment is labeled, and every recurring model begins with value that actually recurs.
+
+See the current roles, acquisition paths, activation events, fulfillment systems, and proof metrics in the live [business architecture](/business-plan).

--- a/data/portfolio.ts
+++ b/data/portfolio.ts
@@ -1,0 +1,224 @@
+export type PortfolioAccent = 'emerald' | 'cyan' | 'sky' | 'violet' | 'amber'
+
+export interface PortfolioBrand {
+  id: 'frankx' | 'gencreator' | 'agentic-income' | 'starlight' | 'arcanea'
+  name: string
+  domain: string
+  href: string
+  role: string
+  buyer: string
+  recurringProblem: string
+  acquisitionPath: string
+  activation: string
+  currentValue: string
+  recurringExperiment: string
+  fulfillmentSystem: string
+  proofMetric: string
+  ctaLabel: string
+  accent: PortfolioAccent
+}
+
+export interface PortfolioProgram {
+  name: string
+  decision: 'Keep distinct' | 'Embed' | 'Incubate'
+  parent: string
+  rule: string
+  domain?: string
+  href?: string
+}
+
+export interface RevenueEvent {
+  event: string
+  model: string
+  standard: string
+}
+
+/**
+ * Verified, customer-facing portfolio registry for /business-plan.
+ *
+ * It deliberately excludes defensive, inactive, legal, partner, and client
+ * domains. Those decisions belong in the private portfolio registry. Paid
+ * status mirrors the canonical brand page and distinguishes live, pre-launch,
+ * waitlist, and service-led offers.
+ */
+export const portfolioBrands: PortfolioBrand[] = [
+  {
+    id: 'frankx',
+    name: 'FrankX',
+    domain: 'frankx.ai',
+    href: '/?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+    role: 'Authority and demand',
+    buyer: 'Creators, founders, and AI architects with too many disconnected tools and initiatives.',
+    recurringProblem: 'Important ideas stall because priorities, architecture, and execution do not stay coherent.',
+    acquisitionPath: 'Search, field notes, research, and public tools route readers to the operating brand that matches the job.',
+    activation: 'Name a distinct advantage, validate a costly recurring problem, and choose the next owned asset to ship.',
+    currentValue: 'Public research, guides, tools, books, and architecture notes.',
+    recurringExperiment: 'None by default. FrankX remains the authority layer unless repeat customer behavior proves a separate recurring job.',
+    fulfillmentSystem: 'A documented editorial cadence, one portfolio diagnostic, and tagged routes into each operating brand.',
+    proofMetric: 'Qualified visits that continue into a relevant framework, tool, or product path.',
+    ctaLabel: 'Explore FrankX',
+    accent: 'emerald',
+  },
+  {
+    id: 'gencreator',
+    name: 'GenCreator',
+    domain: 'gencreator.ai',
+    href: 'https://gencreator.ai/products/diagnostic?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+    role: 'Creator intelligence OS',
+    buyer: 'Creators and experts turning knowledge into useful, owned work.',
+    recurringProblem: 'Expertise does not compound when creation, publishing, distribution, and learning remain separate activities.',
+    acquisitionPath: 'The free workspace, Creation Engine, and readiness diagnostic route buyers to the right product door.',
+    activation: 'Generate a seven-day plan, then ship the first reviewable artifact or installable operating packet.',
+    currentValue: 'Free activation and workspace tools, $19–149 self-serve packets, OS Circle at $49/month, and capped Studio review at $297/month.',
+    recurringExperiment: 'OS Circle is the current recurring offer. Treat capped Studio as service revenue—not self-service ARR—and retain each only when cohorts prove repeat value.',
+    fulfillmentSystem: 'Activation packet, creator vault, signal-to-campaign workflow, approval queue, weekly source pulse, and member artifact review.',
+    proofMetric: 'Activation completed, useful artifact shipped, paid conversion by door, and voluntary week-four member return.',
+    ctaLabel: 'Run the readiness diagnostic',
+    accent: 'cyan',
+  },
+  {
+    id: 'agentic-income',
+    name: 'Agentic Income',
+    domain: 'agenticincome.ai',
+    href: 'https://agenticincome.ai/?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+    role: 'Revenue systems business',
+    buyer: 'Builders who want owned, agent-assisted revenue systems instead of isolated income tactics.',
+    recurringProblem: 'Offers, demand, delivery, and retention break when they are built as one-off campaigns.',
+    acquisitionPath: 'High-intent revenue education and tools lead to an ARR diagnostic and a focused system-building path.',
+    activation: 'Select one recurring customer failure, define the repeat value event, and install the first measurable revenue loop.',
+    currentValue: 'A distinct public home for agentic revenue systems and asset-based recurring income.',
+    recurringExperiment: 'Keep the public brand distinct. Share infrastructure with GenCreator only after customer and traffic data support convergence.',
+    fulfillmentSystem: 'Problem-to-offer diagnostic, demand test, delivery workflow, retention review, and monthly economics check.',
+    proofMetric: 'A validated offer or installed revenue loop that customers and builders use again.',
+    ctaLabel: 'Explore Agentic Income',
+    accent: 'sky',
+  },
+  {
+    id: 'starlight',
+    name: 'Starlight Intelligence System',
+    domain: 'starlightintelligence.org',
+    href: '/starlight-intelligence-system?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+    role: 'Open intelligence substrate',
+    buyer: 'Builders and teams that need portable, governed human-agent systems.',
+    recurringProblem: 'Agentic work degrades when memory, evaluation, governance, and ownership are fragmented.',
+    acquisitionPath: 'Open-source documentation, architecture research, and working reference systems lead to adoption.',
+    activation: 'Install the open system and produce a portable intelligence artifact in the builder’s own environment.',
+    currentValue: 'A free, MIT-licensed, markdown-first intelligence substrate with no subscription or vendor lock-in.',
+    recurringExperiment: 'Not a current offer: validate a separate team governance or update service without restricting the open core.',
+    fulfillmentSystem: 'Versioned releases, conformance tests, reference agents, documentation, and public implementation evidence.',
+    proofMetric: 'Successful installs, useful artifacts produced, repeat project use, and verified contributions.',
+    ctaLabel: 'Inspect the open system',
+    accent: 'violet',
+  },
+  {
+    id: 'arcanea',
+    name: 'Arcanea',
+    domain: 'arcanea.ai',
+    href: 'https://arcanea.ai/pricing?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+    role: 'World, culture, and owned IP',
+    buyer: 'Readers, families, worldbuilders, and creative technologists.',
+    recurringProblem: 'Creative work becomes disposable when story, progression, participation, and belonging do not persist.',
+    acquisitionPath: 'Stories, music, art, and worldbuilding releases invite readers into a connected creative universe.',
+    activation: 'Complete a first story, quest, collection, or worldbuilding artifact that carries forward.',
+    currentValue: 'A free open core plus published pre-launch Cloud Sync at $12/month and Studio Bench at $39/month.',
+    recurringExperiment: 'Both paid plans are limited pre-launch/waitlist experiments, not proven ARR. Earn general availability through repeat use and paid conversion.',
+    fulfillmentSystem: 'Local creation, encrypted sync, semantic search, collaboration and bench runs, supported by a release and canon cadence.',
+    proofMetric: 'Activation, waitlist-to-paid conversion, voluntary four-week return, and persistent creation or collaboration.',
+    ctaLabel: 'Review the pre-launch plans',
+    accent: 'amber',
+  },
+]
+
+export const portfolioPrograms: PortfolioProgram[] = [
+  {
+    name: 'Agentic Passive Income',
+    decision: 'Keep distinct',
+    parent: 'Agentic Income network',
+    rule: 'Own the automation stage with inspectable recurring loops, explicit maintenance floors, its own pack, and a focused knowledge base.',
+    domain: 'agenticpassiveincome.com',
+    href: 'https://agenticpassiveincome.com/?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+  },
+  {
+    name: 'Disruptive Passive Income',
+    decision: 'Keep distinct',
+    parent: 'Agentic Income network',
+    rule: 'Own the compounding/wealth stage. Reconcile the legacy crypto surface with the current network promise before sending new paid traffic.',
+    domain: 'disruptivepassiveincome.com',
+    href: 'https://disruptivepassiveincome.com/?utm_source=frankx&utm_medium=business-plan&utm_campaign=portfolio-operating-model',
+  },
+  {
+    name: 'Reality Architect',
+    decision: 'Embed',
+    parent: 'FrankX publications',
+    rule: 'Operate it as a publication and product franchise, not a second software or membership platform.',
+  },
+  {
+    name: 'Music and creator pathways',
+    decision: 'Embed',
+    parent: 'GenCreator',
+    rule: 'Treat each pathway as curriculum, templates, and workflows inside the creator framework.',
+  },
+  {
+    name: 'Anime, clubs, and creative worlds',
+    decision: 'Embed',
+    parent: 'Arcanea',
+    rule: 'Develop them as series, programs, or seasonal experiences that strengthen one persistent world.',
+  },
+  {
+    name: 'AI architecture academies',
+    decision: 'Embed',
+    parent: 'Starlight',
+    rule: 'Ship curriculum against the open substrate; do not duplicate identity, community, or payment systems.',
+  },
+  {
+    name: 'Blue Life and ocean intelligence',
+    decision: 'Incubate',
+    parent: 'Mission portfolio',
+    rule: 'Publish open knowledge first. Add paid intelligence only after a reliable cadence or committed institutional partner exists.',
+  },
+]
+
+export const revenueEvents: RevenueEvent[] = [
+  {
+    event: 'A bounded transformation completes',
+    model: 'One-time product',
+    standard: 'The buyer leaves with a finished asset, decision, or installed capability.',
+  },
+  {
+    event: 'A repeat job keeps producing value',
+    model: 'Subscription',
+    standard: 'Customers return for a specific recurring outcome and retain because the result continues.',
+  },
+  {
+    event: 'Another builder repeatedly deploys the system',
+    model: 'License',
+    standard: 'Rights, updates, support boundaries, and the licensed unit are explicit.',
+  },
+  {
+    event: 'Buyers and builders exchange value',
+    model: 'Marketplace take rate',
+    standard: 'The platform improves discovery, trust, payment, delivery, or reputation.',
+  },
+  {
+    event: 'Owned work is reused or distributed',
+    model: 'Royalty or revenue share',
+    standard: 'Attribution, ownership, reporting, and payout terms survive beyond one campaign.',
+  },
+]
+
+export const operatingLoop = [
+  ['Discover', 'Earn attention through useful research, stories, tools, and proof.'],
+  ['Diagnose', 'Identify the buyer’s recurring problem and the founder’s credible advantage.'],
+  ['Activate', 'Help the person ship a useful asset, decision, or installed capability.'],
+  ['Operate', 'Support one repeat job through a documented workflow and cadence.'],
+  ['Prove', 'Measure return behavior, customer outcome, retention, and economics.'],
+  ['Expand', 'Only then add subscriptions, licenses, marketplaces, or royalties.'],
+] as const
+
+export const recurringValueTests = [
+  ['Primary recurring job', 'One repeat outcome is clear enough that customers return and pay for it.'],
+  ['Fresh value', 'New intelligence, releases, templates, quests, or data strengthen the core job.'],
+  ['Accumulated value', 'History, assets, progress, reputation, or benchmarks become more useful over time.'],
+  ['Operational value', 'Agents or workflows perform recurring work.'],
+  ['Network value', 'Collaboration, distribution, exchange, or access improves with participation.'],
+] as const


### PR DESCRIPTION
## Outcome

Publishes the public-safe FrankX portfolio operating model and recurring-value doctrine.

## What changes

- replaces stale high-touch and contradictory pricing on `/business-plan`
- adds a typed customer-facing portfolio registry
- routes GenCreator to its canonical readiness diagnostic
- classifies GenCreator packets, Circle, and Studio as one-time, recurring, and service revenue respectively
- labels Arcanea $12/$39 plans as limited pre-launch
- preserves Agentic Income plus Agentic Passive Income and Disruptive Passive Income
- adds the shared marketing → sales → systemization loop
- rewrites the canonical article and removes the mismatched hero
- excludes defensive, partner, client, legal, and inactive domains

## Verification

- `npx eslint app/business-plan/page.tsx data/portfolio.ts`
- `npm run type-check`
- `node scripts/check-mdx-safety.mjs`
- `npm run content:check`
- `npm run claims:audit:strict`
- `git diff --check`
- runtime render: `/business-plan` and `/blog/frankx-business-plan-canvas` returned 200
- GitHub Actions CI: passed
- Vercel build and deployment: passed

## Hosted preview

- [Business architecture](https://frankx-ai-vercel-website-git-agen-e88dea-starlight-intelligence.vercel.app/business-plan)
- [Vercel deployment](https://vercel.com/starlight-intelligence/frankx-ai-vercel-website/35twLf6zvR2BqCAfD1YEcjki5BnW)

## Review gate

This remains a draft for the final owner visual review. The preview is protected by Vercel authentication, and local Chrome was unavailable in the execution environment.